### PR TITLE
Aardocs

### DIFF
--- a/book/src/encodingdictionaries.md
+++ b/book/src/encodingdictionaries.md
@@ -1,0 +1,86 @@
+# Encoding dictionaries as Merkle trees
+
+In the backend, every value of any of the three types
+- `Integer`
+- `String`
+- `Dictionary`
+is represented by a sequence of field elements of the same length, which is the output length of the cryptographic hash function.  (In the case of the Plonky2 backend with 100 bits of security, all of these types are represented as 4 field elements.)
+
+The encoding of `Integer` and `String` types is explained in [Values](./values.md) -- in brief, a integer is encoded in limbs of suitable size, while a string is encoded by hashing.
+
+The encoding of the `Dictionary` is a recursive process:
+- Encode all keys and values in the `Dictionary`.
+- Put all keys and values into a sparse Merkle tree.
+- The `Dictionary` is encoded as the root of this sparse Merkle tree.
+
+This document explains the construction of the sparse Merkle tree.
+
+## The branching rule
+
+A sparse Merkle tree is implemented as a binary tree.  The insertion path of any key is given by a deterministic rule: given ```key``` and a nonnegative integer ```depth```, the rule determines that ```key``` belongs to either the ```left``` or ```right``` branch at depth ```depth```.
+
+The precise rule is as follows.  In-circuit, compute a Poseidon hash of ```key``` to obtain a 4-tuple of field elements 
+```
+Poseidon(key) = (k_0, k_1, k_2, k_3).
+```
+Write the field elements in binary (in little-endian order):
+```
+k_0 = b_0 b_1 ... b_63
+k_1 = b_64 b_65 ... b_127
+....
+```
+
+At the root, ```key``` goes to the left subtree if ```b_0 = 0```, otherwise the right subtree.  At depth 1, ```key``` goes to the left subtree if ```b_1 = 0```, otherwise the right subtree, and similarly for higher depth.
+
+## The tree structure
+
+A Merkle tree with no entry at all is represented by the hash value
+```root = hash(0).```
+(With the Plonky2 backend, the hash function ```hash``` will output a 4-tuple of field elements.)
+
+A Merkle tree with a single entry ```(key, value)``` is called a "leaf".  It is represented by the hash value
+```root = hash((key, value, 1)).```
+
+A Merkle tree ```tree``` with more than one entry is required to have two subtrees, ```left``` and ```right```.  It is then represented by the hash value
+```root = hash((left_root, right_root, 2)).```
+
+(The role of the constants 1 and 2 is to prevent collisions between leaves and non-leaf Merkle roots.  If the constants were omitted, a large Merkle tree could be dishonestly interpreted as a leaf, leading to security vulnerabilities.)
+
+## Example
+
+Suppose we want to build a Merkle tree from the following `Dictionary` with three key-value pairs:
+```
+{
+    4: "even",
+    5: "odd",
+    6: "even"
+}
+```
+
+The keys are integers, so the are represented in-circuit by themselves.  Let's suppose that in little-endian order, the first three bits of the hashes of the keys are:
+```
+hash(4) = 000...
+hash(5) = 010...
+hash(6) = 001...
+```
+
+The resulting tree looks like:
+```
+                root
+              /      \
+           L_root   R_root = hash(0)
+          /      \
+      LL_root   LR_root = hash((4, "even", 1))
+      /    \
+          LLR_root = hash((5, "odd", 1))
+LLL_root = hash((6, "even", 1)).
+```
+
+The intermediate roots are computed as hashes of their subroots:
+```
+LL_root = hash((LLL_root, LLR_root, 2))
+L_root = hash((LL_root, LR_root, 2))
+root = hash((L_root, R_root, 2)).
+```
+
+The full `Dictionary` is then represented in the backend as `root` (four field elements in the Plonky2 backend).

--- a/book/src/statements.md
+++ b/book/src/statements.md
@@ -27,7 +27,7 @@ SumOf(AnchoredKey, AnchoredKey, AnchoredKey),
 ProductOf(AnchoredKey, AnchoredKey, AnchoredKey),
 MaxOf(AnchoredKey, AnchoredKey, AnchoredKey),
 Branches(AnchoredKey, AnchoredKey, AnchoredKey),
-Leaf(AnchoredKey, AnchoredKey),
+Leaf(AnchoredKey, AnchoredKey, AnchoredKey),
 GoesLeft(AnchoredKey, AnchoredKey),
 GoesRight(AnchoredKey, AnchoredKey),
 Contains(AnchoredKey, AnchoredKey)

--- a/book/src/statements.md
+++ b/book/src/statements.md
@@ -1,1 +1,127 @@
 # Statements
+
+A _statement_ is any sort of claim about the values of entries: for example, that two values are equal, or that one entry is contained in another.
+
+Statements come in two types: _built-in_ and _custom_.  There is a short list of built-in statements (see below). [^builtin]
+In addition, users can freely define custom statements.
+
+From the user (front-end) perspective, a statement represents a claim about the values of some number of entries -- the statement can only be proved if the claim is true.
+
+From the circuit (back-end) perspective, a statement can be proved either:
+- by direct in-circuit verification, or
+- by an operation (aka deduction rule).
+
+## Built-in statements
+
+The POD system has several builtin statements. These statements are associated to a reserved set of statement IDs.
+
+```
+ValueOf(AnchoredKey, ScalarOrVec),
+Equal(AnchoredKey, AnchoredKey),
+NotEqual(AnchoredKey, AnchoredKey),
+IsGreater(AnchoredKey, AnchoredKey),
+IsLess(AnchoredKey, AnchoredKey),
+IsGreaterOrEqual(AnchoredKey, AnchoredKey),
+IsLessOrEqual(AnchoredKey, AnchoredKey),
+SumOf(AnchoredKey, AnchoredKey, AnchoredKey),
+ProductOf(AnchoredKey, AnchoredKey, AnchoredKey),
+MaxOf(AnchoredKey, AnchoredKey, AnchoredKey),
+Branches(AnchoredKey, AnchoredKey, AnchoredKey),
+Leaf(AnchoredKey, AnchoredKey),
+GoesLeft(AnchoredKey, AnchoredKey),
+GoesRight(AnchoredKey, AnchoredKey),
+Contains(AnchoredKey, AnchoredKey)
+DoesNotContain(AnchoredKey, AnchoredKey)
+```
+
+
+In the future, we may also reserve statement IDs for "precompiles" such as:
+```
+poseidon_hash_of(A.hash, B.preimage) // perhaps a hash_of predicate can be parametrized by an enum representing the hash scheme; rather than having a bunch of specific things like SHA256_hash_of and poseidon_hash_of etc.
+```
+
+```
+ecdsa_priv_to_pub_of(A.pubkey, B.privkey)
+```
+
+### Built-in statements for entries of any type
+
+A ```ValueOf``` statement asserts that an entry has a certain value.
+```
+ValueOf(A.name, "Arthur") 
+```
+
+An ```IsEqual``` statement asserts that two entries have the same value.  (Technical note: The circuit only proves equality of field elements; no type checking is performed.  For strings or Merkle roots, collision-resistance of the hash gives a cryptographic guarantee of equality.)
+```
+IsEqual(A.name, B.name)
+```
+
+An ```IsUnequal``` statement asserts that two entries have different values.
+```
+IsUnequal   (for arbitary types)
+```
+
+##### Built-in Statements for Numerical Types
+An ```IsGreater(x, y)``` statement asserts that ```x``` is an entry of type ```Integer```, ```y``` is an entry or constant of type ```Integer```, and ```x > y```.
+```
+is_greater    (for numerical types only)
+is_greater(A.price, 100)
+is_greater(A.price, B.balance)
+```
+
+The statements ```IsLess```, ```IsGreaterOrEqual```, ```IsLessOrEqual``` are defined analogously.
+
+```SumOf(x, y, z)``` asserts that ```x```, ```y```, ```z``` are entries of type ```Integer```, and [^fillsum]
+
+```ProductOf``` and ```MaxOf``` are defined analogously.
+
+The two items below may be added in the future:
+```
+poseidon_hash_of(A.hash, B.preimage) // perhaps a hash_of predicate can be parametrized by an enum representing the hash scheme; rather than having a bunch of specific things like SHA256_hash_of and poseidon_hash_of etc.
+```
+
+```
+ecdsa_priv_to_pub_of(A.pubkey, B.privkey)
+```
+
+##### Primitive Built-in Statements for Merkle Roots
+
+Every Merkle root either:
+- is a special type of Merkle tree called a "leaf", which just has a single element, or
+- has two branches, left and right -- each of which is itself a Merkle tree.  Such a tree is called a "non-leaf" Merkle tree.
+
+There are six built-in statements involving Merkle roots:
+```
+Branches(node, left, right, depth)
+```
+means that ```node``` is a non-leaf Merkle node at depth ```depth```, and ```left``` and ```right``` are its branches.
+```
+Leaf(node, item)
+```
+means that ```node``` is a leaf Merkle node, whose single item is ```item```.
+
+```
+GoesLeft(node, item, depth)
+```
+means that ```node``` is a non-leaf Merkle node at depth ```depth```, and if ```item``` is contained under ```node```, it must be in the left branch.
+
+```
+GoesRight(node, item, depth)
+```
+means that ```tree``` is a non-leaf Merkle node at depth ```depth```, and if ```item``` is contained under ```node```, it must be in the right branch.
+
+
+```
+Contains(tree, item)
+```
+means that ```item``` is contained in the Merkle tree ```tree```.
+
+```
+DoesNotContain(tree, item)
+```
+means that ```item``` is not contained in the Merkle tree ```tree```.
+
+
+[^builtin]: <font color="red">TODO</font> List of built-in statements is not yet complete.
+
+[^fillsum]: <font color="red">TODO</font> Does sum mean x+y = z or x = y+z?

--- a/book/src/values.md
+++ b/book/src/values.md
@@ -2,9 +2,9 @@
 From the frontend perspective, POD values may be one of three[^type] types:
 - `Integer`
 - `String`
-- `MerkleTree`
+- `Dictionary`
 
-From the backend perspective, however, these types will all be encoded as a fixed number of field elements, the number being chosen so as to accommodate the `Integer` type as well as hashes to represent the `String` and `MerkleTree` types with the appropriate level of security.
+From the backend perspective, however, these types will all be encoded as a fixed number of field elements, the number being chosen so as to accommodate the `Integer` type as well as hashes to represent the `String` and `Dictionary` types with the appropriate level of security.
 
 In the case of the Plonky2 backend with 100 bits of security, all of these types are represented as 4 field elements, the output of the Poseidon hash function used there being
 
@@ -22,8 +22,27 @@ where $\iota:\mathbb{N}\rightarrow\texttt{GoldilocksField}$ is the canonical pro
 ## `String`
 In the frontend, this type corresponds to the usual `String`. In the backend, the string will be mapped to a sequence of field elements[^String] and hashed with the hash function employed there, thus being represented by its hash.
 
-## `MerkleTree`
-In the front end, this type encapsulates a sparse Merkle tree. In the backend, this will be represented by the root hash of the tree, which will be of the type of the output of the hash function employed.
+## `Dictionary`
+In the front end, a `Dictionary` is simply an unordered set of key-value pairs, in which all keys are distinct.  Every key and every value is a string, integer, or dictionary.
+
+A `Dictionary` is supposed to act like a Python dictionary or a JSON object.
+
+An example of a `Dictionary`:
+```
+{
+    "name": "Aard",
+    "ID": 123,
+    "attributes": {
+        height: 7,
+        strength: 12,
+        friendly: "no"
+    }
+}
+```
+
+A `Dictionary` cannot involve circular references: a `Dictionary` cannot appear in itself -- or any subobject of itself -- as a key or value.
+
+In the back end, a dictionary will be represented as a Merkle root, which will be of the type of the output of the hash function employed.  The conversion from dictionary to Merkle root is a recursive process, explained in the [Encoding Dictionaries](encodingdictionaries.md) page.
 
 [^type]: <font color="red">TODO</font> In POD 1, there is the `cryptographic` type, which has the same type of the output of the hash function employed there. It is useful for representing arbitrary hashes. Do we want to expand our type list to include a similar type, which would correspond to the `HashOut` type in the case of Plonky2? This would not have a uniform representation in the frontend if we continue to be backend agnostic unless we fix the number of bits to e.g. 256, in which case we would actually need one more field element in the case of Plonky2.
 [^i64]: <font color="red">TODO</font> Replace this with `i64` once operational details have been worked out.


### PR DESCRIPTION
Some updates to docs:

Replace "MerkleTree" with "Dictionary" as a front-end type
New doc to clarify how a dictionary is converted to a Merkle tree
Draft doc on Statements.  The doc is incomplete: the Merkle tree statements need to take depth as an entry, and I haven't thought through the best design for this.