### PR TITLE
feat: add new bool frontend type

### DIFF
--- a/src/backends/mock_main.rs
+++ b/src/backends/mock_main.rs
@@ -505,7 +505,7 @@ impl Pod for MockMainPod {
 pub mod tests {
     use super::*;
     use crate::backends::mock_signed::MockSigner;
-    use crate::examples::{great_boy_pod_full_flow, zu_kyc_pod_builder, zu_kyc_sign_pod_builders};
+    use crate::examples::{great_boy_pod_full_flow, tickets_pod_full_flow, zu_kyc_pod_builder, zu_kyc_sign_pod_builders};
     use crate::middleware;
 
     #[test]
@@ -549,5 +549,16 @@ pub mod tests {
         println!("{}", pod);
 
         assert_eq!(pod.verify(), true);
+    }
+
+    #[test]
+    fn test_mock_main_tickets() {
+        let tickets_builder = tickets_pod_full_flow();
+        let mut prover = MockProver {};
+        let proof_pod = tickets_builder.prove(&mut prover).unwrap();
+        let pod = proof_pod.pod.into_any().downcast::<MockMainPod>().unwrap();
+
+        println!("{}", pod);
+        assert_eq!(pod.verify(), true); 
     }
 }

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -30,6 +30,7 @@ pub struct Origin(pub PodClass, pub PodId);
 pub enum Value {
     String(String),
     Int(i64),
+    Bool(bool),
     Dictionary(Dictionary),
     Set(Set),
     Array(Array),
@@ -47,11 +48,18 @@ impl From<i64> for Value {
     }
 }
 
+impl From<bool> for Value {
+    fn from(b: bool) -> Self {
+        Value::Bool(b)
+    }
+}
+
 impl From<&Value> for middleware::Value {
     fn from(v: &Value) -> Self {
         match v {
             Value::String(s) => middleware::Value(hash_str(s).0),
             Value::Int(v) => middleware::Value::from(*v),
+            Value::Bool(b) => middleware::Value::from(*b as i64),
             Value::Dictionary(d) => middleware::Value(d.commitment().0),
             Value::Set(s) => middleware::Value(s.commitment().0),
             Value::Array(a) => middleware::Value(a.commitment().0),
@@ -64,6 +72,7 @@ impl fmt::Display for Value {
         match self {
             Value::String(s) => write!(f, "\"{}\"", s),
             Value::Int(v) => write!(f, "{}", v),
+            Value::Bool(b) => write!(f, "{}", b),
             Value::Dictionary(d) => write!(f, "dict:{}", d.commitment()),
             Value::Set(s) => write!(f, "set:{}", s.commitment()),
             Value::Array(a) => write!(f, "arr:{}", a.commitment()),
@@ -221,6 +230,12 @@ impl From<&str> for OperationArg {
 impl From<i64> for OperationArg {
     fn from(v: i64) -> Self {
         Self::Literal(Value::from(v))
+    }
+}
+
+impl From<bool> for OperationArg {
+    fn from(b: bool) -> Self {
+        Self::Literal(Value::from(b))
     }
 }
 
@@ -578,8 +593,9 @@ pub mod build_utils {
 #[cfg(test)]
 pub mod tests {
     use super::*;
+    use crate::backends::mock_main::MockProver;
     use crate::backends::mock_signed::MockSigner;
-    use crate::examples::{great_boy_pod_full_flow, zu_kyc_pod_builder, zu_kyc_sign_pod_builders};
+    use crate::examples::{great_boy_pod_full_flow, tickets_pod_full_flow, zu_kyc_pod_builder, zu_kyc_sign_pod_builders};
 
     #[test]
     fn test_front_zu_kyc() -> Result<()> {
@@ -614,6 +630,14 @@ pub mod tests {
         println!("{}", great_boy);
 
         // TODO: prove kyc with MockProver and print it
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_front_tickets() -> Result<()> {
+        let builder = tickets_pod_full_flow();
+        println!("{}", builder);
 
         Ok(())
     }


### PR DESCRIPTION
- after brief discussion with aard, we decided adding at least some of the POD1 types to POD2 would make sense
- starting with a `bool` atomic type to POD2 since it is a valid JSON type
- added a brief test with a 'ticket' signed pod and a main pod that proves some things about the ticket