### PR TITLE
limit the number of StatementTmpl in CustomPredicate:

### DIFF
--- a/src/backends/plonky2/mock_main/mod.rs
+++ b/src/backends/plonky2/mock_main/mod.rs
@@ -435,7 +435,7 @@ impl Pod for MockMainPod {
                 self.operations[i]
                     .deref(&self.statements[..input_statement_offset + i])
                     .unwrap()
-                    .check(&s.clone().try_into().unwrap())
+                    .check(&self.params, &s.clone().try_into().unwrap())
             })
             .collect::<Result<Vec<_>>>()
             .unwrap();

--- a/src/frontend/operation.rs
+++ b/src/frontend/operation.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use super::{AnchoredKey, SignedPod, Statement, StatementArg, Value};
-use crate::middleware::{hash_str, NativeOperation, NativePredicate, OperationType, Predicate};
+use crate::middleware::{hash_str, NativePredicate, OperationType, Predicate};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum OperationArg {

--- a/src/middleware/custom.rs
+++ b/src/middleware/custom.rs
@@ -396,6 +396,8 @@ mod tests {
 
     #[test]
     fn is_double_test() -> Result<()> {
+        let params = Params::default();
+
         /*
         is_double(S1, S2) :-
         p:value_of(Constant, 2),
@@ -403,9 +405,9 @@ mod tests {
          */
         let cust_pred_batch = Arc::new(CustomPredicateBatch {
             name: "is_double".to_string(),
-            predicates: vec![CustomPredicate {
-                conjunction: true,
-                statements: vec![
+            predicates: vec![CustomPredicate::and(
+                &params,
+                vec![
                     st(
                         P::Native(NP::ValueOf),
                         vec![
@@ -422,8 +424,8 @@ mod tests {
                         ],
                     ),
                 ],
-                args_len: 4,
-            }],
+                4,
+            )?],
         });
 
         let custom_statement = Statement::Custom(
@@ -446,7 +448,6 @@ mod tests {
             ],
         );
 
-        let params = Params::default();
         assert!(custom_deduction.check(&params, &custom_statement)?);
 
         Ok(())
@@ -456,9 +457,9 @@ mod tests {
     fn ethdos_test() -> Result<()> {
         let params = Params::default();
 
-        let eth_friend_cp = CustomPredicate {
-            conjunction: true,
-            statements: vec![
+        let eth_friend_cp = CustomPredicate::and(
+            &params,
+            vec![
                 st(
                     P::Native(NP::ValueOf),
                     vec![
@@ -481,17 +482,17 @@ mod tests {
                     ],
                 ),
             ],
-            args_len: 4,
-        };
+            4,
+        )?;
 
         let eth_friend_batch = Arc::new(CustomPredicateBatch {
             name: "eth_friend".to_string(),
             predicates: vec![eth_friend_cp],
         });
 
-        let eth_dos_base = CustomPredicate {
-            conjunction: true,
-            statements: vec![
+        let eth_dos_base = CustomPredicate::and(
+            &params,
+            vec![
                 st(
                     P::Native(NP::Equal),
                     vec![
@@ -507,12 +508,12 @@ mod tests {
                     ],
                 ),
             ],
-            args_len: 6,
-        };
+            6,
+        )?;
 
-        let eth_dos_ind = CustomPredicate {
-            conjunction: true,
-            statements: vec![
+        let eth_dos_ind = CustomPredicate::and(
+            &params,
+            vec![
                 st(
                     P::BatchSelf(2),
                     vec![
@@ -544,12 +545,12 @@ mod tests {
                     ],
                 ),
             ],
-            args_len: 6,
-        };
+            6,
+        )?;
 
-        let eth_dos_distance_either = CustomPredicate {
-            conjunction: false,
-            statements: vec![
+        let eth_dos_distance_either = CustomPredicate::or(
+            &params,
+            vec![
                 st(
                     P::BatchSelf(0),
                     vec![
@@ -567,8 +568,8 @@ mod tests {
                     ],
                 ),
             ],
-            args_len: 6,
-        };
+            6,
+        )?;
 
         let eth_dos_distance_batch = Arc::new(CustomPredicateBatch {
             name: "ETHDoS_distance".to_string(),

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -92,6 +92,22 @@ pub struct Params {
     pub max_custom_batch_size: usize,
 }
 
+impl Default for Params {
+    fn default() -> Self {
+        Self {
+            max_input_signed_pods: 3,
+            max_input_main_pods: 3,
+            max_statements: 20,
+            max_signed_pod_values: 8,
+            max_public_statements: 10,
+            max_statement_args: 5,
+            max_operation_args: 5,
+            max_custom_predicate_arity: 5,
+            max_custom_batch_size: 5,
+        }
+    }
+}
+
 impl Params {
     pub fn max_priv_statements(&self) -> usize {
         self.max_statements - self.max_public_statements
@@ -131,22 +147,6 @@ impl Params {
             self.custom_predicate_batch_size_field_elts()
         );
         println!("");
-    }
-}
-
-impl Default for Params {
-    fn default() -> Self {
-        Self {
-            max_input_signed_pods: 3,
-            max_input_main_pods: 3,
-            max_statements: 20,
-            max_signed_pod_values: 8,
-            max_public_statements: 10,
-            max_statement_args: 5,
-            max_operation_args: 5,
-            max_custom_predicate_arity: 5,
-            max_custom_batch_size: 5,
-        }
     }
 }
 


### PR DESCRIPTION
- add constructor method for CustomPredicate
- make size checks at the CustomPredicate creation, so that once instantiated we can assume that contains valid data

This resolves #79