### PR TITLE
Aard cleanpod

### DIFF
--- a/src/backends/plonky2/mock_main/mod.rs
+++ b/src/backends/plonky2/mock_main/mod.rs
@@ -489,7 +489,7 @@ pub mod tests {
     fn test_mock_main_zu_kyc() -> Result<()> {
         let params = middleware::Params::default();
 
-        let (gov_id_builder, pay_stub_builder, sanction_list_builder) =
+        let (mut gov_id_builder, mut pay_stub_builder, mut sanction_list_builder) =
             zu_kyc_sign_pod_builders(&params);
         let mut signer = MockSigner {
             pk: "ZooGov".into(),

--- a/src/backends/plonky2/mock_signed.rs
+++ b/src/backends/plonky2/mock_signed.rs
@@ -35,6 +35,10 @@ impl PodSigner for MockSigner {
             signature,
         }))
     }
+
+    fn fe_pubkey(&self) -> String {
+        self.pk.clone()
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/examples.rs
+++ b/src/examples.rs
@@ -306,7 +306,7 @@ pub fn great_boy_pod_full_flow() -> Result<MainPodBuilder> {
     let bob = "Bob";
     let mut bob_good_boys = Vec::new();
 
-    let good_boy = good_boy_sign_pod_builder(&params, &bob, 36);
+    let mut good_boy = good_boy_sign_pod_builder(&params, &bob, 36);
     bob_good_boys.push(good_boy.sign(&mut giggles_signer).unwrap());
     bob_good_boys.push(good_boy.sign(&mut macrosoft_signer).unwrap());
 
@@ -315,14 +315,14 @@ pub fn great_boy_pod_full_flow() -> Result<MainPodBuilder> {
     let charlie = "Charlie";
     let mut charlie_good_boys = Vec::new();
 
-    let good_boy = good_boy_sign_pod_builder(&params, &charlie, 27);
+    let mut good_boy = good_boy_sign_pod_builder(&params, &charlie, 27);
     charlie_good_boys.push(good_boy.sign(&mut macrosoft_signer).unwrap());
     charlie_good_boys.push(good_boy.sign(&mut faebook_signer).unwrap());
 
     // Bob and Charlie send Alice a Friend POD
 
     let mut alice_friend_pods = Vec::new();
-    let friend = friend_sign_pod_builder(&params, &alice);
+    let mut friend = friend_sign_pod_builder(&params, &alice);
     alice_friend_pods.push(friend.sign(&mut bob_signer).unwrap());
     alice_friend_pods.push(friend.sign(&mut charlie_signer).unwrap());
 
@@ -378,7 +378,7 @@ pub fn tickets_pod_builder(
 
 pub fn tickets_pod_full_flow() -> Result<MainPodBuilder> {
     let params = Params::default();
-    let builder = tickets_sign_pod_builder(&params);
+    let mut builder = tickets_sign_pod_builder(&params);
     let signed_pod = builder.sign(&mut MockSigner { pk: "test".into() }).unwrap();
     Ok(tickets_pod_builder(
         &params,

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -134,8 +134,10 @@ impl SignedPodBuilder {
             kvs.insert(k_hash, v_hash);
         }
         let pod = signer.sign(&self.params, &kvs)?;
-        self.kvs.insert(KEY_SIGNER.into(), Value::String(signer.fe_pubkey()));
-        self.kvs.insert(KEY_TYPE.into(), Value::Int(PodType::MockSigned as i64));
+        self.kvs
+            .insert(KEY_SIGNER.into(), Value::String(signer.fe_pubkey()));
+        self.kvs
+            .insert(KEY_TYPE.into(), Value::Int(PodType::MockSigned as i64));
         Ok(SignedPod {
             pod,
             key_value_map: self.kvs.clone(),
@@ -159,13 +161,7 @@ impl fmt::Display for SignedPod {
         // deterministic based on the keys values not on the order of the keys when added into the
         // tree.
         for (k, v) in self.key_value_map.iter().sorted_by_key(|kv| kv.0) {
-            writeln!(
-                f,
-                "  - {} = {}: {}",
-                hash_str(&k),
-                k,
-                v
-            )?;
+            writeln!(f, "  - {} = {}: {}", hash_str(&k), k, v)?;
         }
         Ok(())
     }

--- a/src/frontend/statement.rs
+++ b/src/frontend/statement.rs
@@ -25,12 +25,7 @@ pub struct Statement(pub Predicate, pub Vec<StatementArg>);
 impl From<(&SignedPod, &str)> for Statement {
     fn from((pod, key): (&SignedPod, &str)) -> Self {
         // TODO: Actual value, TryFrom.
-        let value_hash = pod.kvs().get(&hash_str(key)).cloned().unwrap();
-        let value = pod
-            .value_hash_map
-            .get(&value_hash.into())
-            .cloned()
-            .unwrap_or(Value::Raw(value_hash));
+        let value = pod.key_value_map.get(key).cloned().unwrap();
         Statement(
             Predicate::Native(NativePredicate::ValueOf),
             vec![

--- a/src/frontend/statement.rs
+++ b/src/frontend/statement.rs
@@ -25,7 +25,7 @@ pub struct Statement(pub Predicate, pub Vec<StatementArg>);
 impl From<(&SignedPod, &str)> for Statement {
     fn from((pod, key): (&SignedPod, &str)) -> Self {
         // TODO: Actual value, TryFrom.
-        let value = pod.key_value_map.get(key).cloned().unwrap();
+        let value: Value = pod.key_value_map.get(key).cloned().unwrap();
         Statement(
             Predicate::Native(NativePredicate::ValueOf),
             vec![

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -173,6 +173,7 @@ dyn_clone::clone_trait_object!(Pod);
 
 pub trait PodSigner {
     fn sign(&mut self, params: &Params, kvs: &HashMap<Hash, Value>) -> Result<Box<dyn Pod>>;
+    fn fe_pubkey(&self) -> String;
 }
 
 /// This is a filler type that fulfills the Pod trait and always verifies.  It's empty.  This


### PR DESCRIPTION
Clean up frontend SignedPod format.  Just have frontend key-value pairs, no hashes (because the hashes can be computed from them anyway).  MainPod still to be done, this is just the SignedPod for now.