### PR TITLE
Merkleproof verify circuit

### DIFF
--- a/book/src/merkletree.md
+++ b/book/src/merkletree.md
@@ -137,6 +137,10 @@ Since leaf positions are deterministic based on the key, the same approach is us
 
 For the current use cases, we don't need to prove that the key exists but the value is different on that leaf, so we only use the option 1.
 
+There are 2 cases to have into account when dealing with non-inclusion proofs:
+- case i) the expected leaf does not exist.
+- case ii) the expected leaf does exist in the tree, but it has a different `key`.
+
 
 ## Encoding
 > TODO: how key-values, nodes, merkle-proofs, ... are encoded.

--- a/src/backends/plonky2/basetypes.rs
+++ b/src/backends/plonky2/basetypes.rs
@@ -30,6 +30,7 @@ pub type Proof = Plonky2Proof<F, PoseidonGoldilocksConfig, D>;
 pub const HASH_SIZE: usize = 4;
 pub const VALUE_SIZE: usize = 4;
 
+// TODO mv `EMPTY`-> `EMTPY_VALUE`, and `NULL` -> `EMPTY_HASH`.
 pub const EMPTY: Value = Value([F::ZERO, F::ZERO, F::ZERO, F::ZERO]);
 pub const SELF_ID_HASH: Hash = Hash([F::ONE, F::ZERO, F::ZERO, F::ZERO]);
 pub const NULL: Hash = Hash([F::ZERO, F::ZERO, F::ZERO, F::ZERO]);

--- a/src/backends/plonky2/basetypes.rs
+++ b/src/backends/plonky2/basetypes.rs
@@ -30,10 +30,9 @@ pub type Proof = Plonky2Proof<F, PoseidonGoldilocksConfig, D>;
 pub const HASH_SIZE: usize = 4;
 pub const VALUE_SIZE: usize = 4;
 
-// TODO mv `EMPTY`-> `EMTPY_VALUE`, and `NULL` -> `EMPTY_HASH`.
-pub const EMPTY: Value = Value([F::ZERO, F::ZERO, F::ZERO, F::ZERO]);
+pub const EMPTY_VALUE: Value = Value([F::ZERO, F::ZERO, F::ZERO, F::ZERO]);
 pub const SELF_ID_HASH: Hash = Hash([F::ONE, F::ZERO, F::ZERO, F::ZERO]);
-pub const NULL: Hash = Hash([F::ZERO, F::ZERO, F::ZERO, F::ZERO]);
+pub const EMPTY_HASH: Hash = Hash([F::ZERO, F::ZERO, F::ZERO, F::ZERO]);
 
 #[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq)]
 pub struct Value(pub [F; VALUE_SIZE]);

--- a/src/backends/plonky2/mock_signed.rs
+++ b/src/backends/plonky2/mock_signed.rs
@@ -110,7 +110,7 @@ pub mod tests {
     use super::*;
     use crate::constants::MAX_DEPTH;
     use crate::frontend;
-    use crate::middleware::{self, F, NULL};
+    use crate::middleware::{self, EMPTY_HASH, F};
 
     #[test]
     fn test_mock_signed_0() -> Result<()> {
@@ -137,7 +137,7 @@ pub mod tests {
         assert!(!bad_pod.verify());
 
         let mut bad_pod = pod.clone();
-        let bad_kv = (hash_str(KEY_SIGNER).into(), Value(PodId(NULL).0 .0));
+        let bad_kv = (hash_str(KEY_SIGNER).into(), Value(PodId(EMPTY_HASH).0 .0));
         let bad_kvs_mt = &bad_pod
             .kvs()
             .into_iter()

--- a/src/backends/plonky2/primitives/merkletree.rs
+++ b/src/backends/plonky2/primitives/merkletree.rs
@@ -9,6 +9,9 @@ use std::iter::IntoIterator;
 use crate::backends::counter;
 use crate::backends::plonky2::basetypes::{hash_fields, Hash, Value, F, NULL};
 
+// mod merkletree_circuit;
+pub use super::merkletree_circuit::*;
+
 /// Implements the MerkleTree specified at
 /// https://0xparc.github.io/pod2/merkletree.html
 #[derive(Clone, Debug)]
@@ -520,7 +523,7 @@ impl Leaf {
 // max-depth? ie, what happens when two keys share the same path for more bits
 // than the max_depth?
 /// returns the path of the given key
-fn keypath(max_depth: usize, k: Value) -> Result<Vec<bool>> {
+pub(crate) fn keypath(max_depth: usize, k: Value) -> Result<Vec<bool>> {
     let bytes = k.to_bytes();
     if max_depth > 8 * bytes.len() {
         // note that our current keys are of Value type, which are 4 Goldilocks

--- a/src/backends/plonky2/primitives/merkletree.rs
+++ b/src/backends/plonky2/primitives/merkletree.rs
@@ -212,10 +212,10 @@ pub struct MerkleProof {
     // note: currently we don't use the `_existence` field, we would use if we merge the methods
     // `verify` and `verify_nonexistence` into a single one
     #[allow(unused)]
-    existence: bool,
-    siblings: Vec<Hash>,
+    pub(crate) existence: bool,
+    pub(crate) siblings: Vec<Hash>,
     // other_leaf is used for non-existence proofs
-    other_leaf: Option<(Value, Value)>,
+    pub(crate) other_leaf: Option<(Value, Value)>,
 }
 
 impl fmt::Display for MerkleProof {

--- a/src/backends/plonky2/primitives/merkletree.rs
+++ b/src/backends/plonky2/primitives/merkletree.rs
@@ -7,7 +7,7 @@ use std::fmt;
 use std::iter::IntoIterator;
 
 use crate::backends::counter;
-use crate::backends::plonky2::basetypes::{hash_fields, Hash, Value, F, NULL};
+use crate::backends::plonky2::basetypes::{hash_fields, Hash, Value, EMPTY_HASH, F};
 
 // mod merkletree_circuit;
 pub use super::merkletree_circuit::*;
@@ -182,7 +182,7 @@ impl MerkleTree {
 pub fn kv_hash(key: &Value, value: Option<Value>) -> Hash {
     value
         .map(|v| hash_fields(&[key.0.to_vec(), v.0.to_vec(), vec![GoldilocksField(1)]].concat()))
-        .unwrap_or(NULL)
+        .unwrap_or(EMPTY_HASH)
 }
 
 impl<'a> IntoIterator for &'a MerkleTree {
@@ -305,14 +305,14 @@ impl Node {
     }
     fn compute_hash(&mut self) -> Hash {
         match self {
-            Self::None => NULL,
+            Self::None => EMPTY_HASH,
             Self::Leaf(l) => l.compute_hash(),
             Self::Intermediate(n) => n.compute_hash(),
         }
     }
     fn hash(&self) -> Hash {
         match self {
-            Self::None => NULL,
+            Self::None => EMPTY_HASH,
             Self::Leaf(l) => l.hash(),
             Self::Intermediate(n) => n.hash(),
         }
@@ -475,8 +475,8 @@ impl Intermediate {
     }
     fn compute_hash(&mut self) -> Hash {
         if self.left.clone().is_empty() && self.right.clone().is_empty() {
-            self.hash = Some(NULL);
-            return NULL;
+            self.hash = Some(EMPTY_HASH);
+            return EMPTY_HASH;
         }
         let l_hash = self.left.compute_hash();
         let r_hash = self.right.compute_hash();

--- a/src/backends/plonky2/primitives/merkletree.rs
+++ b/src/backends/plonky2/primitives/merkletree.rs
@@ -182,7 +182,7 @@ impl MerkleTree {
 pub fn kv_hash(key: &Value, value: Option<Value>) -> Hash {
     value
         .map(|v| hash_fields(&[key.0.to_vec(), v.0.to_vec(), vec![GoldilocksField(1)]].concat()))
-        .unwrap_or(Hash([GoldilocksField(0); 4]))
+        .unwrap_or(NULL)
 }
 
 impl<'a> IntoIterator for &'a MerkleTree {

--- a/src/backends/plonky2/primitives/merkletree_circuit.rs
+++ b/src/backends/plonky2/primitives/merkletree_circuit.rs
@@ -24,7 +24,7 @@ use std::iter::IntoIterator;
 
 use crate::backends::counter;
 use crate::backends::plonky2::basetypes::{
-    hash_fields, Hash, Value, D, F, HASH_SIZE, NULL, VALUE_SIZE,
+    hash_fields, Hash, Value, D, EMPTY, F, HASH_SIZE, NULL, VALUE_SIZE,
 };
 use crate::backends::plonky2::primitives::merkletree::MerkleProof;
 
@@ -34,6 +34,10 @@ pub struct MerkleProofCircuit<const MAX_DEPTH: usize> {
     value: Vec<Target>,
     existence: BoolTarget,
     siblings: Vec<HashOutTarget>,
+    // siblings_selectors: Vec<BoolTarget>,
+    case_ii_selector: BoolTarget, // for case ii)
+    other_key: Vec<Target>,
+    other_value: Vec<Target>,
 }
 
 impl<const MAX_DEPTH: usize> MerkleProofCircuit<MAX_DEPTH> {
@@ -48,8 +52,76 @@ impl<const MAX_DEPTH: usize> MerkleProofCircuit<MAX_DEPTH> {
         // siblings are padded
         let siblings = builder.add_virtual_hashes(MAX_DEPTH);
 
-        let h = Self::compute_root_from_leaf(builder, &key, &value, &siblings)?;
-        builder.connect_hashes(h, root);
+        let case_ii_selector = builder.add_virtual_bool_target_safe();
+        let other_key = builder.add_virtual_targets(VALUE_SIZE);
+        let other_value = builder.add_virtual_targets(VALUE_SIZE);
+
+        // We have 3 cases for when computing the Leaf's hash:
+        // - existence: leaf contains the given key & value
+        // - non-existence:
+        //      - case i) expected leaf does not exist
+        //      - case ii) expected leaf does exist but it has a different key
+        //
+        // The following table expresses the options with their in-circuit
+        // selectors:
+        // | existence   | case_ii   | leaf_hash                    |
+        // | ----------- | --------- | ---------------------------- |
+        // | 1           | 0         | H(key, value, 1)             |
+        // | 0           | 0         | EMPTY_HASH                   |
+        // | 0           | 1         | H(other_key, other_value, 1) |
+        // | 1           | 1         | invalid combination          |
+
+        // First, ensure that both existence & case_ii are not true at the same
+        // time:
+        // 1. sum = existence + case_ii_selector
+        let sum = builder.add(existence.target, case_ii_selector.target);
+        // 2. sum * (sum-1) == 0
+        builder.assert_bool(BoolTarget::new_unsafe(sum));
+
+        // define the case_i_selector as true when both existence and
+        // case_ii_selector are false:
+        //     case_i_selector = (1 - existence) * (1- case_ii_selector)
+        let one = builder.one();
+        let existence_inv = builder.sub(one, existence.target);
+        let case_ii_inv = builder.sub(one, case_ii_selector.target);
+        let case_i_selector = BoolTarget::new_unsafe(builder.mul(existence_inv, case_ii_inv));
+
+        // use (key,value) or (other_key, other_value) depending if it's a proof
+        // of existence or of non-existence, ie:
+        // k = key * existence + other_key * (1-existence)
+        // v = value * existence + other_value * (1-existence)
+        let k: Vec<Target> = (0..4)
+            .map(|j| builder.select(existence, key[j], other_key[j]))
+            .collect();
+        let v: Vec<Target> = (0..4)
+            .map(|j| builder.select(existence, value[j], other_value[j]))
+            .collect();
+
+        // get leaf's hash for the selected k & v
+        let h = Self::kv_hash_target(builder, &k, &v);
+
+        // if we're in the case i), use leaf_hash=EMPTY_HASH, else use the
+        // previously computed hash h.
+        let empty_hash = builder.constant_hash(HashOut::from(NULL.0));
+        let leaf_hash = HashOutTarget::from_vec(
+            (0..4)
+                .map(|j| builder.select(case_i_selector, empty_hash.elements[j], h.elements[j]))
+                .collect(),
+        );
+
+        // get key's path
+        let path = Self::keypath_target(builder, &key);
+
+        // compute the root for the given siblings and the computed leaf_hash
+        // (this is for the three cases (existence, non-existence case i, and
+        // non-existence case ii)
+        let computed_root = Self::compute_root_from_leaf(
+            builder, &path, &leaf_hash, &siblings,
+            // &siblings_selectors,
+        )?;
+        // ensure that the computed root matches the given root (which is a
+        // public input)
+        builder.connect_hashes(computed_root, root);
 
         Ok(Self {
             existence,
@@ -57,6 +129,9 @@ impl<const MAX_DEPTH: usize> MerkleProofCircuit<MAX_DEPTH> {
             siblings,
             key,
             value,
+            case_ii_selector,
+            other_key,
+            other_value,
         })
     }
 
@@ -64,6 +139,7 @@ impl<const MAX_DEPTH: usize> MerkleProofCircuit<MAX_DEPTH> {
     fn set_targets(
         &self,
         pw: &mut PartialWitness<F>,
+        existence: bool,
         root: Hash,
         proof: MerkleProof,
         key: Value,
@@ -72,7 +148,7 @@ impl<const MAX_DEPTH: usize> MerkleProofCircuit<MAX_DEPTH> {
         pw.set_hash_target(self.root, HashOut::from_vec(root.0.to_vec()))?;
         pw.set_target_arr(&self.key, &key.0.to_vec())?;
         pw.set_target_arr(&self.value, &value.0.to_vec())?;
-        pw.set_bool_target(self.existence, proof.existence)?;
+        pw.set_bool_target(self.existence, existence)?;
 
         // pad siblings with zeros to length MAX_DEPTH
         let mut siblings = proof.siblings.clone();
@@ -83,13 +159,25 @@ impl<const MAX_DEPTH: usize> MerkleProofCircuit<MAX_DEPTH> {
             pw.set_hash_target(self.siblings[i], HashOut::from_vec(sibling.0.to_vec()));
         }
 
+        if !existence && proof.other_leaf.is_some() {
+            // non-existence case ii) expected leaf does exist but it has a different key
+            pw.set_bool_target(self.case_ii_selector, true)?;
+            pw.set_target_arr(&self.other_key, &proof.other_leaf.unwrap().0 .0.to_vec())?;
+            pw.set_target_arr(&self.other_value, &proof.other_leaf.unwrap().1 .0.to_vec())?;
+        } else {
+            // existence & non-existence case i) expected leaf does not exist
+            pw.set_bool_target(self.case_ii_selector, false)?;
+            pw.set_target_arr(&self.other_key, &EMPTY.0.to_vec())?;
+            pw.set_target_arr(&self.other_value, &EMPTY.0.to_vec())?;
+        }
+
         Ok(())
     }
 
     fn compute_root_from_leaf(
         builder: &mut CircuitBuilder<F, D>,
-        key: &Vec<Target>,
-        value: &Vec<Target>,
+        path: &Vec<BoolTarget>,
+        leaf_hash: &HashOutTarget,
         siblings: &Vec<HashOutTarget>,
     ) -> Result<HashOutTarget> {
         assert!(siblings.len() <= MAX_DEPTH);
@@ -116,11 +204,7 @@ impl<const MAX_DEPTH: usize> MerkleProofCircuit<MAX_DEPTH> {
             .rev()
             .collect::<Vec<_>>();
 
-        // get key's path
-        let path = Self::keypath_target(builder, key);
-        // get leaf's hash
-        let mut h = Self::kv_hash_target(builder, key, value);
-
+        let mut h = leaf_hash.clone();
         let one: Target = builder.one(); // constant in-circuit
         for (i, (sibling, selector)) in std::iter::zip(siblings, &sibling_selectors)
             .enumerate()
@@ -128,46 +212,23 @@ impl<const MAX_DEPTH: usize> MerkleProofCircuit<MAX_DEPTH> {
         {
             // to compute the hash, we want to do the following 3 steps:
             //     Let s := path[i], then
-            //     input_1 = sibling * s + h * (1-s)
-            //     input_2 = sibling * (1-s) + h * s
+            //     input_1 = sibling * s + h * (1-s) = select(s, sibling, h)
+            //     input_2 = sibling * (1-s) + h * s = select(s, h, sibling)
             //     new_h = hash([input_1, input_2])
-
-            // TODO group multiple muls in a single gate
-            let bit: Target = path[i].target;
-            let bit_inv: Target = builder.sub(one, bit);
-
-            let input_1_sibling: Vec<Target> = sibling
-                .elements
-                .iter()
-                .map(|e| builder.mul(*e, bit))
-                .collect();
-            let input_1_h: Vec<Target> = h
-                .elements
-                .iter()
-                .map(|e| builder.mul(*e, bit_inv))
-                .collect();
+            // TODO explore if to group multiple muls in a single gate
+            let bit: BoolTarget = path[i];
             let input_1: Vec<Target> = (0..4)
-                .map(|j| builder.add(input_1_sibling[j], input_1_h[j]))
+                .map(|j| builder.select(bit, sibling.elements[j], h.elements[j]))
                 .collect();
-
-            let input_2_sibling: Vec<Target> = sibling
-                .elements
-                .iter()
-                .map(|e| builder.mul(*e, bit_inv))
-                .collect();
-            let input_2_h: Vec<Target> = h.elements.iter().map(|e| builder.mul(*e, bit)).collect();
             let input_2: Vec<Target> = (0..4)
-                .map(|j| builder.add(input_2_sibling[j], input_2_h[j]))
+                .map(|j| builder.select(bit, h.elements[j], sibling.elements[j]))
                 .collect();
 
             let new_h = builder.hash_n_to_hash_no_pad::<PoseidonHash>([input_1, input_2].concat());
 
-            // Let s := sibling_selectors[i], then h = new_h * s + h * (1-s)
-            let s: Target = selector.target;
-            let s_inv: Target = builder.sub(one, s);
-            let new_h_s: Vec<Target> = new_h.elements.iter().map(|e| builder.mul(*e, s)).collect();
-            let h_s: Vec<Target> = h.elements.iter().map(|e| builder.mul(*e, s_inv)).collect();
-            let h_targ = (0..4).map(|j| builder.add(new_h_s[j], h_s[j])).collect();
+            let h_targ: Vec<Target> = (0..4)
+                .map(|j| builder.select(*selector, new_h.elements[j], h.elements[j]))
+                .collect();
             h = HashOutTarget::from_vec(h_targ);
         }
         Ok(h)
@@ -305,35 +366,57 @@ pub mod tests {
     }
 
     #[test]
-    fn test_merkleproof_verify() -> Result<()> {
-        test_merkleproof_verify_opt::<10>()?;
-        test_merkleproof_verify_opt::<16>()?;
-        test_merkleproof_verify_opt::<32>()?;
-        test_merkleproof_verify_opt::<40>()?;
-        test_merkleproof_verify_opt::<64>()?;
-        test_merkleproof_verify_opt::<128>()?;
-        test_merkleproof_verify_opt::<130>()?;
-        test_merkleproof_verify_opt::<250>()?;
-        test_merkleproof_verify_opt::<256>()?;
+    fn test_merkleproof_verify_existence() -> Result<()> {
+        test_merkleproof_verify_opt::<10>(true)?;
+        test_merkleproof_verify_opt::<16>(true)?;
+        test_merkleproof_verify_opt::<32>(true)?;
+        test_merkleproof_verify_opt::<40>(true)?;
+        test_merkleproof_verify_opt::<64>(true)?;
+        test_merkleproof_verify_opt::<128>(true)?;
+        test_merkleproof_verify_opt::<130>(true)?;
+        test_merkleproof_verify_opt::<250>(true)?;
+        test_merkleproof_verify_opt::<256>(true)?;
+        Ok(())
+    }
+    #[test]
+    fn test_merkleproof_verify_nonexistence() -> Result<()> {
+        test_merkleproof_verify_opt::<10>(false)?;
+        test_merkleproof_verify_opt::<16>(false)?;
+        test_merkleproof_verify_opt::<32>(false)?;
+        test_merkleproof_verify_opt::<40>(false)?;
+        test_merkleproof_verify_opt::<64>(false)?;
+        test_merkleproof_verify_opt::<128>(false)?;
+        test_merkleproof_verify_opt::<130>(false)?;
+        test_merkleproof_verify_opt::<250>(false)?;
+        test_merkleproof_verify_opt::<256>(false)?;
         Ok(())
     }
 
-    fn test_merkleproof_verify_opt<const MD: usize>() -> Result<()> {
+    // test logic to be reused both by the existence & nonexistence tests
+    fn test_merkleproof_verify_opt<const MD: usize>(existence: bool) -> Result<()> {
         let mut kvs: HashMap<Value, Value> = HashMap::new();
-        for i in 0..8 {
-            kvs.insert(
-                Value::from(hash_value(&Value::from(i))),
-                Value::from(1000 + i),
-            );
+        for i in 0..10 {
+            kvs.insert(Value::from(hash_value(&Value::from(i))), Value::from(i));
         }
 
         let tree = MerkleTree::new(MD, &kvs)?;
 
-        let key = Value::from(hash_value(&Value::from(5)));
-        let (value, proof) = tree.prove(&key)?;
-        assert_eq!(value, Value::from(1005));
+        let (key, value, proof) = if existence {
+            let key = Value::from(hash_value(&Value::from(5)));
+            let (value, proof) = tree.prove(&key)?;
+            assert_eq!(value, Value::from(5));
+            (key, value, proof)
+        } else {
+            let key = Value::from(hash_value(&Value::from(200)));
+            (key, EMPTY, tree.prove_nonexistence(&key)?)
+        };
+        assert_eq!(proof.existence, existence);
 
-        MerkleTree::verify(MD, tree.root(), &proof, &key, &value)?;
+        if existence {
+            MerkleTree::verify(MD, tree.root(), &proof, &key, &value)?;
+        } else {
+            MerkleTree::verify_nonexistence(MD, tree.root(), &proof, &key)?;
+        }
 
         // circuit
         let config = CircuitConfig::standard_recursion_config();
@@ -341,7 +424,74 @@ pub mod tests {
         let mut pw = PartialWitness::<F>::new();
 
         let targets = MerkleProofCircuit::<MD>::add_targets(&mut builder)?;
-        targets.set_targets(&mut pw, tree.root(), proof, key, value)?;
+        targets.set_targets(&mut pw, existence, tree.root(), proof, key, value)?;
+
+        // generate & verify proof
+        let data = builder.build::<C>();
+        let proof = data.prove(pw)?;
+        data.verify(proof)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_merkletree_edgecases() -> Result<()> {
+        // fill the tree as in https://0xparc.github.io/pod2/merkletree.html#example-3
+        //
+        //     root
+        //     /  \
+        //    ()  ()
+        //   / \  /
+        //   0 2 ()
+        //        \
+        //        ()
+        //        /\
+        //       5  13
+
+        let mut kvs = HashMap::new();
+        kvs.insert(Value::from(0), Value::from(1000));
+        kvs.insert(Value::from(2), Value::from(1002));
+        kvs.insert(Value::from(5), Value::from(1005));
+        kvs.insert(Value::from(13), Value::from(1013));
+
+        const MD: usize = 5;
+        let tree = MerkleTree::new(MD, &kvs)?;
+        // existence
+        test_merkletree_edgecase_opt::<MD>(&tree, Value::from(5))?;
+        // non-existence case i) expected leaf does not exist
+        test_merkletree_edgecase_opt::<MD>(&tree, Value::from(1))?;
+        // non-existence case ii) expected leaf does exist but it has a different 'key'
+        test_merkletree_edgecase_opt::<MD>(&tree, Value::from(21))?;
+
+        Ok(())
+    }
+
+    fn test_merkletree_edgecase_opt<const MD: usize>(tree: &MerkleTree, key: Value) -> Result<()> {
+        let contains = tree.contains(&key)?;
+        // generate merkleproof
+        let (value, proof) = if contains {
+            tree.prove(&key)?
+        } else {
+            let proof = tree.prove_nonexistence(&key)?;
+            (EMPTY, proof)
+        };
+
+        assert_eq!(proof.existence, contains);
+
+        // verify the proof (non circuit)
+        if proof.existence {
+            MerkleTree::verify(MD, tree.root(), &proof, &key, &value)?;
+        } else {
+            MerkleTree::verify_nonexistence(MD, tree.root(), &proof, &key)?;
+        }
+
+        // circuit
+        let config = CircuitConfig::standard_recursion_config();
+        let mut builder = CircuitBuilder::<F, D>::new(config);
+        let mut pw = PartialWitness::<F>::new();
+
+        let targets = MerkleProofCircuit::<MD>::add_targets(&mut builder)?;
+        targets.set_targets(&mut pw, proof.existence, tree.root(), proof, key, value)?;
 
         // generate & verify proof
         let data = builder.build::<C>();

--- a/src/backends/plonky2/primitives/merkletree_circuit.rs
+++ b/src/backends/plonky2/primitives/merkletree_circuit.rs
@@ -1,0 +1,126 @@
+#![allow(unused)]
+//! Circuits compatible with the merkletree.rs implementation.
+use anyhow::{anyhow, Result};
+use plonky2::{
+    field::{goldilocks_field::GoldilocksField, types::Field, types::Sample},
+    hash::{
+        hash_types::{HashOut, HashOutTarget},
+        poseidon::PoseidonHash,
+    },
+    iop::{
+        target::{BoolTarget, Target},
+        witness::{PartialWitness, WitnessWrite},
+    },
+    plonk::{
+        circuit_builder::CircuitBuilder,
+        circuit_data::{CircuitConfig, ProverCircuitData, VerifierCircuitData},
+        config::Hasher,
+        proof::ProofWithPublicInputs,
+    },
+};
+use std::collections::HashMap;
+use std::fmt;
+use std::iter::IntoIterator;
+
+use crate::backends::counter;
+use crate::backends::plonky2::basetypes::{
+    hash_fields, Hash, Value, D, F, HASH_SIZE, NULL, VALUE_SIZE,
+};
+
+// TODO TMP
+const MAX_DEPTH: usize = 256;
+
+pub struct MerkleProofCircuit {
+    existence_targ: BoolTarget,
+    siblings_targ: Vec<HashOutTarget>,
+    leaf: (Vec<Target>, Vec<Target>),
+    other_leaf: (Vec<Target>, Vec<Target>),
+}
+impl MerkleProofCircuit {
+    /// creates the targets and defines the logic of the circuit
+    fn add_targets(builder: &mut CircuitBuilder<F, D>) -> Result<Self> {
+        // create the targets
+        let existence_targ = builder.add_virtual_bool_target_safe();
+        let siblings_targ = builder.add_virtual_targets(HASH_SIZE * MAX_DEPTH);
+        let key = builder.add_virtual_targets(VALUE_SIZE);
+        let value = builder.add_virtual_targets(VALUE_SIZE);
+        let other_key = builder.add_virtual_targets(VALUE_SIZE);
+        let other_value = builder.add_virtual_targets(VALUE_SIZE);
+
+        // get key's path
+        let path: Vec<BoolTarget> = key
+            .iter()
+            .flat_map(|e| builder.split_le(*e, MAX_DEPTH / 4))
+            .collect();
+        todo!();
+    }
+
+    /// assigns the given values to the targets
+    fn set_targets(
+        &self,
+        pw: &mut PartialWitness<F>,
+        existence: bool,
+        siblings: Vec<Hash>,
+        other_leaf: (Value, Value),
+        s: Value,
+    ) -> Result<()> {
+        todo!();
+    }
+}
+
+// Note: this logic is in its own method for easy of reusability but specially
+// to be able to test it isolated
+fn keypath_target(builder: &mut CircuitBuilder<F, D>, key: &Vec<Target>) -> Vec<BoolTarget> {
+    assert_eq!(key.len(), VALUE_SIZE);
+    key.iter()
+        .flat_map(|e| builder.split_le(*e, F::BITS))
+        .collect()
+}
+
+#[cfg(test)]
+pub mod tests {
+    use itertools::Itertools;
+    use std::cmp::Ordering;
+
+    use super::*;
+    use crate::backends::plonky2::basetypes::hash_value;
+    use crate::backends::plonky2::basetypes::C;
+    use crate::backends::plonky2::primitives::merkletree::*;
+
+    #[test]
+    fn test_keypath() -> Result<()> {
+        for i in 0..100 {
+            let key = Value::from(hash_value(&Value::from(100 + i)));
+            let path = keypath(MAX_DEPTH, key)?;
+            test_keypath_opt(key, path)?;
+        }
+        Ok(())
+    }
+    fn test_keypath_opt(key: Value, expected_path: Vec<bool>) -> Result<()> {
+        let config = CircuitConfig::standard_recursion_config();
+        let mut builder = CircuitBuilder::<F, D>::new(config);
+
+        // small circuit logic to check
+        // expected_path_targ==keypath_target(key_targ)
+        let expected_path_targ: Vec<BoolTarget> = (0..MAX_DEPTH)
+            .map(|_| builder.add_virtual_bool_target_safe())
+            .collect();
+        let key_targ = builder.add_virtual_targets(VALUE_SIZE);
+        let computed_path_targ = keypath_target(&mut builder, &key_targ);
+        for i in 0..MAX_DEPTH {
+            builder.connect(computed_path_targ[i].target, expected_path_targ[i].target);
+        }
+
+        // assign the input values to the targets
+        let mut pw = PartialWitness::<F>::new();
+        pw.set_target_arr(&key_targ, &key.0.to_vec())?;
+        for i in 0..MAX_DEPTH {
+            pw.set_bool_target(expected_path_targ[i], expected_path[i])?;
+        }
+
+        // generate & verify proof
+        let data = builder.build::<C>();
+        let proof = data.prove(pw)?;
+        data.verify(proof)
+    }
+}

--- a/src/backends/plonky2/primitives/merkletree_circuit.rs
+++ b/src/backends/plonky2/primitives/merkletree_circuit.rs
@@ -26,46 +26,167 @@ use crate::backends::counter;
 use crate::backends::plonky2::basetypes::{
     hash_fields, Hash, Value, D, F, HASH_SIZE, NULL, VALUE_SIZE,
 };
+use crate::backends::plonky2::primitives::merkletree::MerkleProof;
 
-// TODO TMP
+// TODO TMP, this might end up being a parameter of the proof struct
 const MAX_DEPTH: usize = 256;
 
+// TODO: think if maybe define a ValueTarget type, which to instantiate it
+// already performs the checks of length.
+
 pub struct MerkleProofCircuit {
-    existence_targ: BoolTarget,
-    siblings_targ: Vec<HashOutTarget>,
-    leaf: (Vec<Target>, Vec<Target>),
-    other_leaf: (Vec<Target>, Vec<Target>),
+    root: HashOutTarget,
+    key: Vec<Target>,
+    value: Vec<Target>,
+    existence: BoolTarget,
+    siblings: Vec<HashOutTarget>,
+    siblings_selectors: Vec<BoolTarget>,
+    // other_key: Vec<Target>,
+    // other_value: Vec<Target>,
 }
+
 impl MerkleProofCircuit {
     /// creates the targets and defines the logic of the circuit
     fn add_targets(builder: &mut CircuitBuilder<F, D>) -> Result<Self> {
         // create the targets
-        let existence_targ = builder.add_virtual_bool_target_safe();
-        let siblings_targ = builder.add_virtual_targets(HASH_SIZE * MAX_DEPTH);
+        let root = builder.add_virtual_hash();
         let key = builder.add_virtual_targets(VALUE_SIZE);
         let value = builder.add_virtual_targets(VALUE_SIZE);
-        let other_key = builder.add_virtual_targets(VALUE_SIZE);
-        let other_value = builder.add_virtual_targets(VALUE_SIZE);
-
-        // get key's path
-        let path: Vec<BoolTarget> = key
-            .iter()
-            .flat_map(|e| builder.split_le(*e, MAX_DEPTH / 4))
+        // from proof struct:
+        let existence = builder.add_virtual_bool_target_safe();
+        // siblings are padded
+        let siblings = builder.add_virtual_hashes(MAX_DEPTH);
+        let siblings_selectors = (0..MAX_DEPTH)
+            .map(|_| builder.add_virtual_bool_target_safe())
             .collect();
-        todo!();
+
+        // let other_key = builder.add_virtual_targets(VALUE_SIZE);
+        // let other_value = builder.add_virtual_targets(VALUE_SIZE);
+
+        // WIP: only covers proof of existence for the moment
+        let h = compute_root_from_leaf(builder, &key, &value, &siblings, &siblings_selectors)?;
+        builder.connect_hashes(h, root);
+
+        Ok(Self {
+            existence,
+            root,
+            siblings,
+            key,
+            value,
+            // other_key,
+            // other_value,
+            siblings_selectors,
+        })
     }
 
     /// assigns the given values to the targets
     fn set_targets(
         &self,
         pw: &mut PartialWitness<F>,
-        existence: bool,
-        siblings: Vec<Hash>,
-        other_leaf: (Value, Value),
-        s: Value,
+        root: Hash,
+        proof: MerkleProof,
+        key: Value,
+        value: Value,
     ) -> Result<()> {
-        todo!();
+        pw.set_hash_target(self.root, HashOut::from_vec(root.0.to_vec()))?;
+        pw.set_target_arr(&self.key, &key.0.to_vec())?;
+        pw.set_target_arr(&self.value, &value.0.to_vec())?;
+        pw.set_bool_target(self.existence, proof.existence)?;
+
+        // pad siblings
+        let mut siblings = proof.siblings.clone();
+        siblings.resize(MAX_DEPTH, NULL);
+        assert_eq!(self.siblings.len(), siblings.len());
+
+        for (i, sibling) in siblings.iter().enumerate() {
+            pw.set_hash_target(self.siblings[i], HashOut::from_vec(sibling.0.to_vec()));
+        }
+        // The given `siblings` can have length <= MAX_DEPTH, the
+        // `siblings_selectors` are used to indicate when the `siblings` exist
+        // or if it is padded.
+        // `siblings_selectors` are set to `1` when the given siblings exist,
+        // and to `0` when the given siblings don't exist.
+        for i in 0..proof.siblings.len() {
+            pw.set_bool_target(self.siblings_selectors[i], true)?;
+        }
+        for i in proof.siblings.len()..MAX_DEPTH {
+            pw.set_bool_target(self.siblings_selectors[i], false)?;
+        }
+
+        // non-existence proof values:
+        // pw.set_target_arr(&self.other_key, &proof.other_leaf.0 .0.to_vec())?;
+        // pw.set_target_arr(&self.other_value, &proof.other_leaf.1 .0.to_vec())?;
+
+        Ok(())
     }
+}
+
+fn compute_root_from_leaf(
+    builder: &mut CircuitBuilder<F, D>,
+    key: &Vec<Target>,
+    value: &Vec<Target>,
+    siblings: &Vec<HashOutTarget>,
+    siblings_selectors: &Vec<BoolTarget>,
+) -> Result<HashOutTarget> {
+    assert!(siblings.len() / HASH_SIZE < MAX_DEPTH);
+    assert_eq!(siblings_selectors.len(), MAX_DEPTH);
+
+    // get key's path
+    let path: Vec<BoolTarget> = key
+        .iter()
+        .flat_map(|e| builder.split_le(*e, MAX_DEPTH / 4))
+        .collect();
+
+    let mut h = kv_hash_target(builder, key, value);
+
+    let one: Target = builder.one(); // constant in-circuit
+    for (i, sibling) in siblings.iter().enumerate().rev() {
+        // to compute the hash, we want to do the following 3 steps:
+        //     Let s := path[i], then
+        //     input_1 = sibling * s + h * (1-s)
+        //     input_2 = sibling * (1-s) + h * s
+        //     new_h = hash([input_1, input_2])
+
+        // TODO group multiple muls in a single gate
+        let bit: Target = path[i].target;
+        let bit_inv: Target = builder.sub(one, bit);
+
+        let input_1_sibling: Vec<Target> = sibling
+            .elements
+            .iter()
+            .map(|e| builder.mul(*e, bit))
+            .collect();
+        let input_1_h: Vec<Target> = h
+            .elements
+            .iter()
+            .map(|e| builder.mul(*e, bit_inv))
+            .collect();
+        let input_1: Vec<Target> = (0..4)
+            .map(|j| builder.add(input_1_sibling[j], input_1_h[j]))
+            .collect();
+
+        let input_2_sibling: Vec<Target> = sibling
+            .elements
+            .iter()
+            .map(|e| builder.mul(*e, bit_inv))
+            .collect();
+        let input_2_h: Vec<Target> = h.elements.iter().map(|e| builder.mul(*e, bit)).collect();
+        let input_2: Vec<Target> = (0..4)
+            .map(|j| builder.add(input_2_sibling[j], input_2_h[j]))
+            .collect();
+
+        let new_h = builder.hash_n_to_hash_no_pad::<PoseidonHash>([input_1, input_2].concat());
+
+        // Let s := siblings_selectors[i], then
+        // h = new_h * s + h * (1-s)
+        let s: Target = siblings_selectors[i].target;
+        let s_inv: Target = builder.sub(one, s);
+        let new_h_s: Vec<Target> = new_h.elements.iter().map(|e| builder.mul(*e, s)).collect();
+        let h_s: Vec<Target> = h.elements.iter().map(|e| builder.mul(*e, s_inv)).collect();
+        let h_targ = (0..4).map(|j| builder.add(new_h_s[j], h_s[j])).collect();
+        h = HashOutTarget::from_vec(h_targ);
+    }
+    Ok(h)
 }
 
 // Note: this logic is in its own method for easy of reusability but specially
@@ -75,6 +196,15 @@ fn keypath_target(builder: &mut CircuitBuilder<F, D>, key: &Vec<Target>) -> Vec<
     key.iter()
         .flat_map(|e| builder.split_le(*e, F::BITS))
         .collect()
+}
+
+fn kv_hash_target(
+    builder: &mut CircuitBuilder<F, D>,
+    key: &Vec<Target>,
+    value: &Vec<Target>,
+) -> HashOutTarget {
+    let inputs: Vec<Target> = [key.clone(), value.clone(), vec![builder.one()]].concat();
+    builder.hash_n_to_hash_no_pad::<PoseidonHash>(inputs)
 }
 
 #[cfg(test)]
@@ -89,38 +219,102 @@ pub mod tests {
 
     #[test]
     fn test_keypath() -> Result<()> {
-        for i in 0..100 {
-            let key = Value::from(hash_value(&Value::from(100 + i)));
-            let path = keypath(MAX_DEPTH, key)?;
-            test_keypath_opt(key, path)?;
+        for i in 0..10 {
+            let config = CircuitConfig::standard_recursion_config();
+            let mut builder = CircuitBuilder::<F, D>::new(config);
+            let mut pw = PartialWitness::<F>::new();
+
+            let key = Value::from(hash_value(&Value::from(i)));
+            let expected_path = keypath(MAX_DEPTH, key)?;
+
+            // small circuit logic to check
+            // expected_path_targ==keypath_target(key_targ)
+            let expected_path_targ: Vec<BoolTarget> = (0..MAX_DEPTH)
+                .map(|_| builder.add_virtual_bool_target_safe())
+                .collect();
+            let key_targ = builder.add_virtual_targets(VALUE_SIZE);
+            let computed_path_targ = keypath_target(&mut builder, &key_targ);
+            for i in 0..MAX_DEPTH {
+                builder.connect(computed_path_targ[i].target, expected_path_targ[i].target);
+            }
+
+            // assign the input values to the targets
+            pw.set_target_arr(&key_targ, &key.0.to_vec())?;
+            for i in 0..MAX_DEPTH {
+                pw.set_bool_target(expected_path_targ[i], expected_path[i])?;
+            }
+
+            // generate & verify proof
+            let data = builder.build::<C>();
+            let proof = data.prove(pw)?;
+            data.verify(proof)?;
         }
         Ok(())
     }
-    fn test_keypath_opt(key: Value, expected_path: Vec<bool>) -> Result<()> {
+
+    #[test]
+    fn test_kv_hash() -> Result<()> {
+        for i in 0..10 {
+            let key = Value::from(hash_value(&Value::from(i)));
+            let value = Value::from(1000 + i);
+            let h = kv_hash(&key, Some(value));
+
+            // circuit
+            let config = CircuitConfig::standard_recursion_config();
+            let mut builder = CircuitBuilder::<F, D>::new(config);
+            let mut pw = PartialWitness::<F>::new();
+
+            let h_targ = builder.add_virtual_hash();
+            let key_targ = builder.add_virtual_targets(VALUE_SIZE);
+            let value_targ = builder.add_virtual_targets(VALUE_SIZE);
+
+            let computed_h = kv_hash_target(&mut builder, &key_targ, &value_targ);
+            builder.connect_hashes(computed_h, h_targ);
+
+            // assign the input values to the targets
+            pw.set_target_arr(&key_targ, &key.0.to_vec())?;
+            pw.set_target_arr(&value_targ, &value.0.to_vec())?;
+            pw.set_hash_target(h_targ, HashOut::from_vec(h.0.to_vec()))?;
+
+            // generate & verify proof
+            let data = builder.build::<C>();
+            let proof = data.prove(pw)?;
+            data.verify(proof)?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_merkleproof_verify() -> Result<()> {
+        let mut kvs: HashMap<Value, Value> = HashMap::new();
+        for i in 0..8 {
+            kvs.insert(
+                Value::from(hash_value(&Value::from(i))),
+                Value::from(1000 + i),
+            );
+        }
+
+        let tree = MerkleTree::new(32, &kvs)?;
+
+        let key = Value::from(hash_value(&Value::from(5)));
+        let (value, proof) = tree.prove(&key)?;
+        assert_eq!(value, Value::from(1005));
+
+        MerkleTree::verify(32, tree.root(), &proof, &key, &value)?;
+
+        // circuit
         let config = CircuitConfig::standard_recursion_config();
         let mut builder = CircuitBuilder::<F, D>::new(config);
-
-        // small circuit logic to check
-        // expected_path_targ==keypath_target(key_targ)
-        let expected_path_targ: Vec<BoolTarget> = (0..MAX_DEPTH)
-            .map(|_| builder.add_virtual_bool_target_safe())
-            .collect();
-        let key_targ = builder.add_virtual_targets(VALUE_SIZE);
-        let computed_path_targ = keypath_target(&mut builder, &key_targ);
-        for i in 0..MAX_DEPTH {
-            builder.connect(computed_path_targ[i].target, expected_path_targ[i].target);
-        }
-
-        // assign the input values to the targets
         let mut pw = PartialWitness::<F>::new();
-        pw.set_target_arr(&key_targ, &key.0.to_vec())?;
-        for i in 0..MAX_DEPTH {
-            pw.set_bool_target(expected_path_targ[i], expected_path[i])?;
-        }
+
+        let targets = MerkleProofCircuit::add_targets(&mut builder)?;
+        targets.set_targets(&mut pw, tree.root(), proof, key, value)?;
 
         // generate & verify proof
         let data = builder.build::<C>();
         let proof = data.prove(pw)?;
-        data.verify(proof)
+        data.verify(proof)?;
+
+        Ok(())
     }
 }

--- a/src/backends/plonky2/primitives/mod.rs
+++ b/src/backends/plonky2/primitives/mod.rs
@@ -1,2 +1,3 @@
 pub mod merkletree;
+mod merkletree_circuit;
 pub mod signature;

--- a/src/middleware/basetypes.rs
+++ b/src/middleware/basetypes.rs
@@ -35,6 +35,6 @@
 /// then the Value, Hash and F types would come from the plonky3 backend.
 #[cfg(feature = "backend_plonky2")]
 pub use crate::backends::plonky2::basetypes::{
-    hash_fields, hash_str, hash_value, Hash, Value, EMPTY, F, HASH_SIZE, NULL, SELF_ID_HASH,
-    VALUE_SIZE,
+    hash_fields, hash_str, hash_value, Hash, Value, EMPTY_HASH, EMPTY_VALUE, F, HASH_SIZE,
+    SELF_ID_HASH, VALUE_SIZE,
 };

--- a/src/middleware/containers.rs
+++ b/src/middleware/containers.rs
@@ -8,7 +8,7 @@ use crate::constants::MAX_DEPTH;
 #[cfg(feature = "backend_plonky2")]
 use crate::backends::plonky2::primitives::merkletree::{Iter as TreeIter, MerkleProof, MerkleTree};
 
-use super::basetypes::{hash_value, Hash, Value, EMPTY};
+use super::basetypes::{hash_value, Hash, Value, EMPTY_VALUE};
 
 /// Dictionary: the user original keys and values are hashed to be used in the leaf.
 ///    leaf.key=hash(original_key)
@@ -78,7 +78,7 @@ impl Set {
             .iter()
             .map(|e| {
                 let h = hash_value(e);
-                (Value::from(h), EMPTY)
+                (Value::from(h), EMPTY_VALUE)
             })
             .collect();
         Ok(Self {
@@ -99,7 +99,7 @@ impl Set {
         self.mt.prove_nonexistence(value)
     }
     pub fn verify(root: Hash, proof: &MerkleProof, value: &Value) -> Result<()> {
-        MerkleTree::verify(MAX_DEPTH, root, proof, value, &EMPTY)
+        MerkleTree::verify(MAX_DEPTH, root, proof, value, &EMPTY_VALUE)
     }
     pub fn verify_nonexistence(root: Hash, proof: &MerkleProof, value: &Value) -> Result<()> {
         MerkleTree::verify_nonexistence(MAX_DEPTH, root, proof, value)

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -23,7 +23,7 @@ impl fmt::Display for PodId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if *self == SELF {
             write!(f, "self")
-        } else if self.0 == NULL {
+        } else if self.0 == EMPTY_HASH {
             write!(f, "null")
         } else {
             write!(f, "{}", self.0)
@@ -185,7 +185,7 @@ impl Pod for NonePod {
         true
     }
     fn id(&self) -> PodId {
-        PodId(NULL)
+        PodId(EMPTY_HASH)
     }
     fn pub_statements(&self) -> Vec<Statement> {
         Vec::new()


### PR DESCRIPTION
This PR implements the plonky2 circuit that verifies the merkleproof of existance and merkleproof of non-existence described at #124 and in [docs/merkletree](https://0xparc.github.io/pod2/merkletree.html#proofs-of-inclusion-and-non-inclusion).

This PR resolves #124 and unblocks starting to work on #133.