### PR TITLE
Progress on the MainPod circuit

### DIFF
--- a/src/backends/plonky2/common.rs
+++ b/src/backends/plonky2/common.rs
@@ -1,9 +1,9 @@
 //! Common functionality to build Pod circuits with plonky2
 
-use crate::middleware::STATEMENT_ARG_F_LEN;
 use crate::middleware::{
     Operation, Params, Statement, StatementArg, ToFields, Value, F, HASH_SIZE, VALUE_SIZE,
 };
+use crate::middleware::{OPERATION_ARG_F_LEN, STATEMENT_ARG_F_LEN};
 use anyhow::Result;
 use plonky2::field::extension::Extendable;
 use plonky2::field::types::{Field, PrimeField64};
@@ -20,7 +20,7 @@ pub struct ValueTarget {
 
 #[derive(Clone)]
 pub struct StatementTarget {
-    pub code: [Target; HASH_SIZE + 2],
+    pub code: [Target; Params::predicate_size()],
     pub args: Vec<[Target; STATEMENT_ARG_F_LEN]>,
 }
 
@@ -56,8 +56,8 @@ impl StatementTarget {
 // TODO: Implement Operation::to_field to determine the size of each element
 #[derive(Clone)]
 pub struct OperationTarget {
-    pub code: [Target; 6],                        // TODO: Figure out the length
-    pub args: Vec<[Target; STATEMENT_ARG_F_LEN]>, // TODO: Figure out the length
+    pub code: [Target; Params::operation_type_size()],
+    pub args: Vec<[Target; OPERATION_ARG_F_LEN]>,
 }
 
 impl OperationTarget {

--- a/src/backends/plonky2/common.rs
+++ b/src/backends/plonky2/common.rs
@@ -1,8 +1,8 @@
 //! Common functionality to build Pod circuits with plonky2
 
-use crate::middleware::{
-    Operation, Params, Statement, StatementArg, ToFields, Value, F, HASH_SIZE, VALUE_SIZE,
-};
+use crate::backends::plonky2::mock_main::Statement;
+use crate::backends::plonky2::mock_main::{Operation, OperationArg};
+use crate::middleware::{Params, StatementArg, ToFields, Value, F, HASH_SIZE, VALUE_SIZE};
 use crate::middleware::{OPERATION_ARG_F_LEN, STATEMENT_ARG_F_LEN};
 use anyhow::Result;
 use plonky2::field::extension::Extendable;
@@ -68,7 +68,15 @@ impl OperationTarget {
         op: &Operation,
     ) -> Result<()> {
         pw.set_target_arr(&self.code, &op.code().to_fields(params))?;
-        // TODO: Arguments
+        for (i, arg) in op
+            .args()
+            .iter()
+            .chain(iter::repeat(&OperationArg::None))
+            .take(params.max_operation_args)
+            .enumerate()
+        {
+            pw.set_target_arr(&self.args[i], &arg.to_fields(params))?;
+        }
         Ok(())
     }
 }

--- a/src/backends/plonky2/common.rs
+++ b/src/backends/plonky2/common.rs
@@ -1,12 +1,17 @@
 //! Common functionality to build Pod circuits with plonky2
 
 use crate::middleware::STATEMENT_ARG_F_LEN;
-use crate::middleware::{Params, Value, HASH_SIZE, VALUE_SIZE};
+use crate::middleware::{
+    Operation, Params, Statement, StatementArg, ToFields, Value, F, HASH_SIZE, VALUE_SIZE,
+};
+use anyhow::Result;
 use plonky2::field::extension::Extendable;
-use plonky2::field::types::PrimeField64;
+use plonky2::field::types::{Field, PrimeField64};
 use plonky2::hash::hash_types::RichField;
 use plonky2::iop::target::{BoolTarget, Target};
+use plonky2::iop::witness::{PartialWitness, WitnessWrite};
 use plonky2::plonk::circuit_builder::CircuitBuilder;
+use std::iter;
 
 #[derive(Copy, Clone)]
 pub struct ValueTarget {
@@ -27,6 +32,25 @@ impl StatementTarget {
             .cloned()
             .collect()
     }
+
+    pub fn set_targets(
+        &self,
+        pw: &mut PartialWitness<F>,
+        params: &Params,
+        st: &Statement,
+    ) -> Result<()> {
+        pw.set_target_arr(&self.code, &st.code().to_fields(params))?;
+        for (i, arg) in st
+            .args()
+            .iter()
+            .chain(iter::repeat(&StatementArg::None))
+            .take(params.max_statement_args)
+            .enumerate()
+        {
+            pw.set_target_arr(&self.args[i], &arg.to_fields(params))?;
+        }
+        Ok(())
+    }
 }
 
 // TODO: Implement Operation::to_field to determine the size of each element
@@ -34,6 +58,19 @@ impl StatementTarget {
 pub struct OperationTarget {
     pub code: [Target; 6],                        // TODO: Figure out the length
     pub args: Vec<[Target; STATEMENT_ARG_F_LEN]>, // TODO: Figure out the length
+}
+
+impl OperationTarget {
+    pub fn set_targets(
+        &self,
+        pw: &mut PartialWitness<F>,
+        params: &Params,
+        op: &Operation,
+    ) -> Result<()> {
+        pw.set_target_arr(&self.code, &op.code().to_fields(params))?;
+        // TODO: Arguments
+        Ok(())
+    }
 }
 
 pub trait CircuitBuilderPod<F: RichField + Extendable<D>, const D: usize> {
@@ -70,15 +107,20 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilderPod<F, D>
 
     fn add_virtual_statement(&mut self, params: &Params) -> StatementTarget {
         StatementTarget {
-            code: self.add_virtual_target_arr::<6>(),
+            code: self.add_virtual_target_arr(),
             args: (0..params.max_statement_args)
-                .map(|_| self.add_virtual_target_arr::<STATEMENT_ARG_F_LEN>())
+                .map(|_| self.add_virtual_target_arr())
                 .collect(),
         }
     }
 
     fn add_virtual_operation(&mut self, params: &Params) -> OperationTarget {
-        todo!()
+        OperationTarget {
+            code: self.add_virtual_target_arr(),
+            args: (0..params.max_operation_args)
+                .map(|_| self.add_virtual_target_arr())
+                .collect(),
+        }
     }
 
     fn select_value(&mut self, b: BoolTarget, x: ValueTarget, y: ValueTarget) -> ValueTarget {

--- a/src/backends/plonky2/common.rs
+++ b/src/backends/plonky2/common.rs
@@ -20,13 +20,13 @@ pub struct ValueTarget {
 
 #[derive(Clone)]
 pub struct StatementTarget {
-    pub code: [Target; Params::predicate_size()],
+    pub predicate: [Target; Params::predicate_size()],
     pub args: Vec<[Target; STATEMENT_ARG_F_LEN]>,
 }
 
 impl StatementTarget {
     pub fn to_flattened(&self) -> Vec<Target> {
-        self.code
+        self.predicate
             .iter()
             .chain(self.args.iter().flatten())
             .cloned()
@@ -39,7 +39,7 @@ impl StatementTarget {
         params: &Params,
         st: &Statement,
     ) -> Result<()> {
-        pw.set_target_arr(&self.code, &st.code().to_fields(params))?;
+        pw.set_target_arr(&self.predicate, &st.predicate().to_fields(params))?;
         for (i, arg) in st
             .args()
             .iter()
@@ -56,7 +56,7 @@ impl StatementTarget {
 // TODO: Implement Operation::to_field to determine the size of each element
 #[derive(Clone)]
 pub struct OperationTarget {
-    pub code: [Target; Params::operation_type_size()],
+    pub op_type: [Target; Params::operation_type_size()],
     pub args: Vec<[Target; OPERATION_ARG_F_LEN]>,
 }
 
@@ -67,7 +67,7 @@ impl OperationTarget {
         params: &Params,
         op: &Operation,
     ) -> Result<()> {
-        pw.set_target_arr(&self.code, &op.code().to_fields(params))?;
+        pw.set_target_arr(&self.op_type, &op.op_type().to_fields(params))?;
         for (i, arg) in op
             .args()
             .iter()
@@ -115,7 +115,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilderPod<F, D>
 
     fn add_virtual_statement(&mut self, params: &Params) -> StatementTarget {
         StatementTarget {
-            code: self.add_virtual_target_arr(),
+            predicate: self.add_virtual_target_arr(),
             args: (0..params.max_statement_args)
                 .map(|_| self.add_virtual_target_arr())
                 .collect(),
@@ -124,7 +124,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilderPod<F, D>
 
     fn add_virtual_operation(&mut self, params: &Params) -> OperationTarget {
         OperationTarget {
-            code: self.add_virtual_target_arr(),
+            op_type: self.add_virtual_target_arr(),
             args: (0..params.max_operation_args)
                 .map(|_| self.add_virtual_target_arr())
                 .collect(),

--- a/src/backends/plonky2/main.rs
+++ b/src/backends/plonky2/main.rs
@@ -145,8 +145,8 @@ impl OperationVerifyGate {
         // `OperationVerifyTarget` so that we can set during witness generation.
 
         // For now only support native operations
-        builder.connect(op.code[0], one);
-        let native_op = op.code[1];
+        builder.connect(op.op_type[0], one);
+        let native_op = op.op_type[1];
 
         let mut op_flags = Vec::new();
         let op_none = builder.constant(F::from_canonical_u64(NativeOperation::None as u64));
@@ -214,14 +214,14 @@ impl OperationVerifyGate {
         _op: &OperationTarget,
     ) -> BoolTarget {
         let value_of_st = &Statement::ValueOf(AnchoredKey(SELF, EMPTY_HASH), EMPTY_VALUE);
-        let expected_code =
+        let expected_predicate =
             builder.constants(&Predicate::Native(NativePredicate::ValueOf).to_fields(&self.params));
-        let code_ok = builder.is_equal_slice(&st.code, &expected_code);
+        let predicate_ok = builder.is_equal_slice(&st.predicate, &expected_predicate);
         let expected_arg_prefix = builder.constants(
             &StatementArg::Key(AnchoredKey(SELF, EMPTY_HASH)).to_fields(&self.params)[..VALUE_SIZE],
         );
         let arg_prefix_ok = builder.is_equal_slice(&st.args[0][..VALUE_SIZE], &expected_arg_prefix);
-        builder.and(code_ok, arg_prefix_ok)
+        builder.and(predicate_ok, arg_prefix_ok)
     }
 }
 
@@ -277,7 +277,7 @@ impl MainPodVerifyGate {
         // 2. Calculate the Pod Id from the public statements
         let pub_statements_flattened = pub_statements
             .iter()
-            .map(|s| s.code.iter().chain(s.args.iter().flatten()))
+            .map(|s| s.predicate.iter().chain(s.args.iter().flatten()))
             .flatten()
             .cloned()
             .collect();

--- a/src/backends/plonky2/mock_main/mod.rs
+++ b/src/backends/plonky2/mock_main/mod.rs
@@ -260,7 +260,7 @@ impl MockMainPod {
                 .map(|mid_arg| Self::find_op_arg(statements, mid_arg))
                 .collect::<Result<Vec<_>>>()?;
             Self::pad_operation_args(params, &mut args);
-            operations.push(Operation(op.predicate(), args));
+            operations.push(Operation(op.op_type(), args));
         }
         Ok(operations)
     }

--- a/src/backends/plonky2/mock_main/operation.rs
+++ b/src/backends/plonky2/mock_main/operation.rs
@@ -1,6 +1,7 @@
 use super::Statement;
-use crate::middleware::{self, OperationType};
+use crate::middleware::{self, OperationType, Params, ToFields, F};
 use anyhow::Result;
+use plonky2::field::types::{Field, PrimeField64};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -8,6 +9,16 @@ use std::fmt;
 pub enum OperationArg {
     None,
     Index(usize),
+}
+
+impl ToFields for OperationArg {
+    fn to_fields(&self, _params: &Params) -> Vec<F> {
+        let f = match self {
+            Self::None => F::ZERO,
+            Self::Index(i) => F::from_canonical_usize(*i),
+        };
+        vec![f]
+    }
 }
 
 impl OperationArg {
@@ -20,6 +31,12 @@ impl OperationArg {
 pub struct Operation(pub OperationType, pub Vec<OperationArg>);
 
 impl Operation {
+    pub fn code(&self) -> OperationType {
+        self.0.clone()
+    }
+    pub fn args(&self) -> &[OperationArg] {
+        &self.1
+    }
     pub fn deref(&self, statements: &[Statement]) -> Result<crate::middleware::Operation> {
         let deref_args = self
             .1

--- a/src/backends/plonky2/mock_main/operation.rs
+++ b/src/backends/plonky2/mock_main/operation.rs
@@ -31,7 +31,7 @@ impl OperationArg {
 pub struct Operation(pub OperationType, pub Vec<OperationArg>);
 
 impl Operation {
-    pub fn code(&self) -> OperationType {
+    pub fn op_type(&self) -> OperationType {
         self.0.clone()
     }
     pub fn args(&self) -> &[OperationArg] {

--- a/src/backends/plonky2/mock_main/statement.rs
+++ b/src/backends/plonky2/mock_main/statement.rs
@@ -13,7 +13,7 @@ impl Statement {
     pub fn is_none(&self) -> bool {
         self.0 == Predicate::Native(NativePredicate::None)
     }
-    pub fn code(&self) -> Predicate {
+    pub fn predicate(&self) -> Predicate {
         self.0.clone()
     }
     /// Argument method. Trailing Nones are filtered out.
@@ -99,7 +99,7 @@ impl TryFrom<Statement> for middleware::Statement {
 
 impl From<middleware::Statement> for Statement {
     fn from(s: middleware::Statement) -> Self {
-        match s.code() {
+        match s.predicate() {
             middleware::Predicate::Native(c) => Statement(
                 middleware::Predicate::Native(c),
                 s.args().into_iter().collect(),

--- a/src/backends/plonky2/mock_main/statement.rs
+++ b/src/backends/plonky2/mock_main/statement.rs
@@ -13,6 +13,9 @@ impl Statement {
     pub fn is_none(&self) -> bool {
         self.0 == Predicate::Native(NativePredicate::None)
     }
+    pub fn code(&self) -> Predicate {
+        self.0.clone()
+    }
     /// Argument method. Trailing Nones are filtered out.
     pub fn args(&self) -> Vec<StatementArg> {
         let maybe_last_arg_index = (0..self.1.len()).rev().find(|i| !self.1[*i].is_none());

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -1091,6 +1091,7 @@ pub mod tests {
             max_operation_args: 5,
             max_custom_predicate_arity: 5,
             max_custom_batch_size: 5,
+            ..Default::default()
         };
 
         let mut alice = MockSigner { pk: "Alice".into() };

--- a/src/middleware/custom.rs
+++ b/src/middleware/custom.rs
@@ -49,9 +49,9 @@ impl fmt::Display for HashOrWildcard {
 }
 
 impl ToFields for HashOrWildcard {
-    fn to_fields(&self, _params: &Params) -> Vec<F> {
+    fn to_fields(&self, params: &Params) -> Vec<F> {
         match self {
-            HashOrWildcard::Hash(h) => h.to_fields(_params),
+            HashOrWildcard::Hash(h) => h.to_fields(params),
             HashOrWildcard::Wildcard(w) => (0..HASH_SIZE - 1)
                 .chain(iter::once(*w))
                 .map(|x| F::from_canonical_u64(x as u64))
@@ -91,7 +91,7 @@ impl StatementTmplArg {
 }
 
 impl ToFields for StatementTmplArg {
-    fn to_fields(&self, _params: &Params) -> Vec<F> {
+    fn to_fields(&self, params: &Params) -> Vec<F> {
         // None => (0, ...)
         // Literal(value) => (1, [value], 0, 0, 0, 0)
         // Key(hash_or_wildcard1, hash_or_wildcard2)
@@ -107,15 +107,15 @@ impl ToFields for StatementTmplArg {
             }
             StatementTmplArg::Literal(v) => {
                 let fields: Vec<F> = iter::once(F::from_canonical_u64(1))
-                    .chain(v.to_fields(_params))
+                    .chain(v.to_fields(params))
                     .chain(iter::repeat_with(|| F::from_canonical_u64(0)).take(HASH_SIZE))
                     .collect();
                 fields
             }
             StatementTmplArg::Key(hw1, hw2) => {
                 let fields: Vec<F> = iter::once(F::from_canonical_u64(2))
-                    .chain(hw1.to_fields(_params))
-                    .chain(hw2.to_fields(_params))
+                    .chain(hw1.to_fields(params))
+                    .chain(hw2.to_fields(params))
                     .collect();
                 fields
             }
@@ -318,8 +318,8 @@ impl ToFields for CustomPredicateBatch {
 }
 
 impl CustomPredicateBatch {
-    pub fn hash(&self, _params: &Params) -> Hash {
-        let input = self.to_fields(_params);
+    pub fn hash(&self, params: &Params) -> Hash {
+        let input = self.to_fields(params);
 
         hash_fields(&input)
     }
@@ -399,7 +399,7 @@ impl From<NativePredicate> for Predicate {
 }
 
 impl ToFields for Predicate {
-    fn to_fields(&self, _params: &Params) -> Vec<F> {
+    fn to_fields(&self, params: &Params) -> Vec<F> {
         // serialize:
         // NativePredicate(id) as (0, id, 0, 0, 0, 0) -- id: usize
         // BatchSelf(i) as (1, i, 0, 0, 0, 0) -- i: usize
@@ -410,13 +410,13 @@ impl ToFields for Predicate {
         // in every case: pad to (hash_size + 2) field elements
         let mut fields: Vec<F> = match self {
             Self::Native(p) => iter::once(F::from_canonical_u64(1))
-                .chain(p.to_fields(_params))
+                .chain(p.to_fields(params))
                 .collect(),
             Self::BatchSelf(i) => iter::once(F::from_canonical_u64(2))
                 .chain(iter::once(F::from_canonical_usize(*i)))
                 .collect(),
             Self::Custom(CustomPredicateRef(pb, i)) => iter::once(F::from_canonical_u64(3))
-                .chain(pb.hash(_params).0)
+                .chain(pb.hash(params).0)
                 .chain(iter::once(F::from_canonical_usize(*i)))
                 .collect(),
         };

--- a/src/middleware/custom.rs
+++ b/src/middleware/custom.rs
@@ -5,6 +5,7 @@ use std::{fmt, hash as h, iter, iter::zip};
 use anyhow::{anyhow, Result};
 use plonky2::field::types::Field;
 use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 use super::{
     hash_fields, AnchoredKey, Hash, NativePredicate, Params, PodId, Statement, StatementArg,
@@ -12,7 +13,6 @@ use super::{
 };
 use crate::backends::plonky2::basetypes::HASH_SIZE;
 use crate::util::hashmap_insert_no_dupe;
-use serde::{Deserialize, Serialize};
 
 // BEGIN Custom 1b
 
@@ -165,7 +165,7 @@ impl StatementTmpl {
             Err(anyhow!(
                 "Cannot check self-referencing statement templates."
             ))
-        } else if self.pred() != &s.code() {
+        } else if self.pred() != &s.predicate() {
             Err(anyhow!("Type mismatch between {:?} and {}.", self, s))
         } else {
             zip(self.args(), s.args())

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -93,6 +93,8 @@ pub struct Params {
     // in a custom predicate
     pub max_custom_predicate_arity: usize,
     pub max_custom_batch_size: usize,
+    // maximum depth for merkle tree gates
+    pub max_depth_mt_gate: usize,
 }
 
 impl Default for Params {
@@ -107,6 +109,7 @@ impl Default for Params {
             max_operation_args: 5,
             max_custom_predicate_arity: 5,
             max_custom_batch_size: 5,
+            max_depth_mt_gate: 32,
         }
     }
 }

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -119,15 +119,27 @@ impl Params {
         self.max_statements - self.max_public_statements
     }
 
-    pub fn statement_tmpl_arg_size() -> usize {
+    pub const fn statement_tmpl_arg_size() -> usize {
         2 * HASH_SIZE + 1
     }
 
-    pub fn predicate_size() -> usize {
+    pub const fn predicate_size() -> usize {
         HASH_SIZE + 2
     }
 
-    pub fn statement_tmpl_size(&self) -> usize {
+    pub const fn operation_type_size() -> usize {
+        HASH_SIZE + 2
+    }
+
+    pub fn statement_size(&self) -> usize {
+        Self::predicate_size() + STATEMENT_ARG_F_LEN * self.max_statement_args
+    }
+
+    pub fn operation_size(&self) -> usize {
+        Self::operation_type_size() + OPERATION_ARG_F_LEN * self.max_operation_args
+    }
+
+    pub const fn statement_tmpl_size(&self) -> usize {
         Self::predicate_size() + self.max_statement_args * Self::statement_tmpl_arg_size()
     }
 

--- a/src/middleware/operation.rs
+++ b/src/middleware/operation.rs
@@ -3,13 +3,19 @@ use log::error;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-use super::{CustomPredicateRef, NativePredicate, Statement, StatementArg};
+use super::{CustomPredicateRef, NativePredicate, Statement, StatementArg, ToFields, F};
 use crate::middleware::{AnchoredKey, Params, Predicate, Value, SELF};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum OperationType {
     Native(NativeOperation),
     Custom(CustomPredicateRef),
+}
+
+impl ToFields for OperationType {
+    fn to_fields(&self, params: &Params) -> Vec<F> {
+        todo!()
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -398,6 +404,12 @@ impl Operation {
                 output_statement
             )),
         }
+    }
+}
+
+impl ToFields for Operation {
+    fn to_fields(&self, params: &Params) -> Vec<F> {
+        todo!()
     }
 }
 

--- a/src/middleware/operation.rs
+++ b/src/middleware/operation.rs
@@ -115,7 +115,7 @@ pub enum Operation {
 }
 
 impl Operation {
-    pub fn predicate(&self) -> OperationType {
+    pub fn op_type(&self) -> OperationType {
         type OT = OperationType;
         use NativeOperation::*;
         match self {
@@ -202,7 +202,7 @@ impl Operation {
     /// The outer Result is error handling
     pub fn output_statement(&self) -> Result<Option<Statement>> {
         use Statement::*;
-        let pred: Option<Predicate> = self.predicate().output_predicate();
+        let pred: Option<Predicate> = self.op_type().output_predicate();
 
         let st_args: Option<Vec<StatementArg>> = match self {
             Self::None => Some(vec![]),
@@ -434,7 +434,7 @@ impl ToFields for Operation {
 impl fmt::Display for Operation {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f, "middleware::Operation:")?;
-        writeln!(f, "  {:?} ", self.predicate())?;
+        writeln!(f, "  {:?} ", self.op_type())?;
         for arg in self.args().iter() {
             writeln!(f, "    {}", arg)?;
         }

--- a/src/middleware/statement.rs
+++ b/src/middleware/statement.rs
@@ -12,6 +12,7 @@ use super::{
 pub const KEY_SIGNER: &str = "_signer";
 pub const KEY_TYPE: &str = "_type";
 pub const STATEMENT_ARG_F_LEN: usize = 8;
+pub const OPERATION_ARG_F_LEN: usize = 1;
 
 #[derive(Clone, Copy, Debug, FromRepr, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
 pub enum NativePredicate {
@@ -189,10 +190,7 @@ impl ToFields for Statement {
     fn to_fields(&self, params: &Params) -> Vec<F> {
         let mut fields = self.code().to_fields(params);
         fields.extend(self.args().iter().flat_map(|arg| arg.to_fields(params)));
-        fields.resize_with(
-            2 + HASH_SIZE + STATEMENT_ARG_F_LEN * params.max_statement_args,
-            || F::ZERO,
-        );
+        fields.resize_with(params.statement_size(), || F::ZERO);
         fields
     }
 }

--- a/src/middleware/statement.rs
+++ b/src/middleware/statement.rs
@@ -56,7 +56,7 @@ impl Statement {
     pub fn is_none(&self) -> bool {
         self == &Self::None
     }
-    pub fn code(&self) -> Predicate {
+    pub fn predicate(&self) -> Predicate {
         use Predicate::*;
         match self {
             Self::None => Native(NativePredicate::None),
@@ -188,7 +188,7 @@ impl Statement {
 
 impl ToFields for Statement {
     fn to_fields(&self, params: &Params) -> Vec<F> {
-        let mut fields = self.code().to_fields(params);
+        let mut fields = self.predicate().to_fields(params);
         fields.extend(self.args().iter().flat_map(|arg| arg.to_fields(params)));
         fields.resize_with(params.statement_size(), || F::ZERO);
         fields
@@ -197,7 +197,7 @@ impl ToFields for Statement {
 
 impl fmt::Display for Statement {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?} ", self.code())?;
+        write!(f, "{:?} ", self.predicate())?;
         for (i, arg) in self.args().iter().enumerate() {
             if i != 0 {
                 write!(f, " ")?;

--- a/src/middleware/statement.rs
+++ b/src/middleware/statement.rs
@@ -5,7 +5,9 @@ use serde::{Deserialize, Serialize};
 use std::{fmt, iter};
 use strum_macros::FromRepr;
 
-use super::{AnchoredKey, CustomPredicateRef, Params, Predicate, ToFields, Value, F, VALUE_SIZE};
+use super::{
+    AnchoredKey, CustomPredicateRef, Params, Predicate, ToFields, Value, F, HASH_SIZE, VALUE_SIZE,
+};
 
 pub const KEY_SIGNER: &str = "_signer";
 pub const KEY_TYPE: &str = "_type";
@@ -184,9 +186,13 @@ impl Statement {
 }
 
 impl ToFields for Statement {
-    fn to_fields(&self, _params: &Params) -> Vec<F> {
-        let mut fields = self.code().to_fields(_params);
-        fields.extend(self.args().iter().flat_map(|arg| arg.to_fields(_params)));
+    fn to_fields(&self, params: &Params) -> Vec<F> {
+        let mut fields = self.code().to_fields(params);
+        fields.extend(self.args().iter().flat_map(|arg| arg.to_fields(params)));
+        fields.resize_with(
+            2 + HASH_SIZE + STATEMENT_ARG_F_LEN * params.max_statement_args,
+            || F::ZERO,
+        );
         fields
     }
 }


### PR DESCRIPTION
I've implemented the necessary `ToFields` for `Operation` for the MainPod circuit.
I've fixed a few things, implemented the witness assignment for Statements and Operations and added two tests:
- SignedPod verification circuit test
- Operation verification circuit test, only for the None operation for now, but it should be easy to follow the pattern to add a test for each operation.

I've also did a small refactor on the MerkleTree circuit to follow the same naming conventions as the MainPod circuit gates.  I've also moved the max depth from a generic constant to a dynamic parameter in Params.