### PR TITLE
Add extra front-end types and make MainPodBuilder emit these

### DIFF
--- a/src/examples/custom.rs
+++ b/src/examples/custom.rs
@@ -37,6 +37,7 @@ pub fn eth_friend_batch(params: &Params) -> Result<Arc<CustomPredicateBatch>> {
                 .arg(("attestation_pod", literal("attestation")))
                 .arg(("dst_ori", "dst_key")),
         ],
+        "eth_friend",
     )?;
 
     println!("a.0. eth_friend = {}", builder.predicates.last().unwrap());
@@ -74,6 +75,7 @@ pub fn eth_dos_batch(params: &Params) -> Result<Arc<CustomPredicateBatch>> {
                 .arg(("distance_ori", "distance_key"))
                 .arg(0),
         ],
+        "eth_dos_distance_base",
     )?;
     println!(
         "b.0. eth_dos_distance_base = {}",
@@ -119,6 +121,7 @@ pub fn eth_dos_batch(params: &Params) -> Result<Arc<CustomPredicateBatch>> {
                 .arg(("intermed_ori", "intermed_key"))
                 .arg(("dst_ori", "dst_key")),
         ],
+        "eth_dos_distance_ind",
     )?;
 
     println!(
@@ -147,6 +150,7 @@ pub fn eth_dos_batch(params: &Params) -> Result<Arc<CustomPredicateBatch>> {
                 .arg(("dst_ori", "dst_key"))
                 .arg(("distance_ori", "distance_key")),
         ],
+        "eth_dos_distance",
     )?;
 
     println!(

--- a/src/examples/custom.rs
+++ b/src/examples/custom.rs
@@ -27,7 +27,7 @@ pub fn eth_friend_batch(params: &Params) -> Result<Arc<CustomPredicateBatch>> {
             // there is an attestation pod that's a SignedPod
             STB::new(NP::ValueOf)
                 .arg(("attestation_pod", literal(KEY_TYPE)))
-                .arg(Value::from(middleware::Value::from(PodType::MockSigned))), // TODO
+                .arg(middleware::Value::from(PodType::MockSigned)), // TODO
             // the attestation pod is signed by (src_or, src_key)
             STB::new(NP::Equal)
                 .arg(("attestation_pod", literal(KEY_SIGNER)))

--- a/src/examples/custom.rs
+++ b/src/examples/custom.rs
@@ -45,7 +45,7 @@ pub fn eth_friend_batch(params: &Params) -> Result<Arc<CustomPredicateBatch>> {
 
 /// Instantiates an ETHDoS batch
 pub fn eth_dos_batch(params: &Params) -> Result<Arc<CustomPredicateBatch>> {
-    let eth_friend = Predicate::Custom(CustomPredicateRef(eth_friend_batch(params)?, 0));
+    let eth_friend = Predicate::Custom(CustomPredicateRef::new(eth_friend_batch(params)?, 0));
     let mut builder = CustomPredicateBatchBuilder::new("eth_dos_distance_base".into());
 
     // eth_dos_distance_base(src_or, src_key, dst_or, dst_key, distance_or, distance_key) = and<

--- a/src/examples/custom.rs
+++ b/src/examples/custom.rs
@@ -3,11 +3,11 @@ use std::sync::Arc;
 use anyhow::Result;
 
 use crate::{
-    frontend::{literal, CustomPredicateBatchBuilder, StatementTmplBuilder},
-    middleware::{
-        CustomPredicateBatch, CustomPredicateRef, NativePredicate, Params, PodType, Predicate,
-        KEY_SIGNER, KEY_TYPE,
+    frontend::{
+        literal, CustomPredicateBatch, CustomPredicateBatchBuilder, CustomPredicateRef, Predicate,
+        StatementTmplBuilder, Value,
     },
+    middleware::{self, NativePredicate, Params, PodType, KEY_SIGNER, KEY_TYPE},
 };
 
 use NativePredicate as NP;
@@ -27,7 +27,7 @@ pub fn eth_friend_batch(params: &Params) -> Result<Arc<CustomPredicateBatch>> {
             // there is an attestation pod that's a SignedPod
             STB::new(NP::ValueOf)
                 .arg(("attestation_pod", literal(KEY_TYPE)))
-                .arg(PodType::MockSigned), // TODO
+                .arg(Value::from(middleware::Value::from(PodType::MockSigned))), // TODO
             // the attestation pod is signed by (src_or, src_key)
             STB::new(NP::Equal)
                 .arg(("attestation_pod", literal(KEY_SIGNER)))

--- a/src/examples/mod.rs
+++ b/src/examples/mod.rs
@@ -5,11 +5,11 @@ use custom::{eth_dos_batch, eth_friend_batch};
 use std::collections::HashMap;
 
 use crate::backends::plonky2::mock::signedpod::MockSigner;
+use crate::frontend::CustomPredicateRef;
 use crate::frontend::{
     containers::{Dictionary, Set},
     MainPodBuilder, SignedPod, SignedPodBuilder, Statement, Value,
 };
-use crate::middleware::CustomPredicateRef;
 use crate::middleware::{Params, PodType, KEY_SIGNER, KEY_TYPE};
 use crate::op;
 

--- a/src/examples/mod.rs
+++ b/src/examples/mod.rs
@@ -83,11 +83,11 @@ pub fn eth_dos_pod_builder(
     bob_pubkey: &Value,
 ) -> Result<MainPodBuilder> {
     // Will need ETH friend and ETH DoS custom predicate batches.
-    let eth_friend = CustomPredicateRef(eth_friend_batch(params)?, 0);
+    let eth_friend = CustomPredicateRef::new(eth_friend_batch(params)?, 0);
     let eth_dos_batch = eth_dos_batch(params)?;
-    let eth_dos_base = CustomPredicateRef(eth_dos_batch.clone(), 0);
-    let eth_dos_ind = CustomPredicateRef(eth_dos_batch.clone(), 1);
-    let eth_dos = CustomPredicateRef(eth_dos_batch.clone(), 2);
+    let eth_dos_base = CustomPredicateRef::new(eth_dos_batch.clone(), 0);
+    let eth_dos_ind = CustomPredicateRef::new(eth_dos_batch.clone(), 1);
+    let eth_dos = CustomPredicateRef::new(eth_dos_batch.clone(), 2);
 
     // ETHDoS POD builder
     let mut alice_bob_ethdos = MainPodBuilder::new(params);

--- a/src/frontend/custom.rs
+++ b/src/frontend/custom.rs
@@ -1,34 +1,83 @@
 #![allow(unused)]
-use anyhow::Result;
+use anyhow::{anyhow, Result};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::iter::zip;
 use std::sync::Arc;
+use std::{fmt, hash as h, iter};
 
-use crate::middleware::{
-    hash_str, CustomPredicate, CustomPredicateBatch, Hash, HashOrWildcard, NativePredicate, Params,
-    Predicate, StatementTmpl, StatementTmplArg, ToFields, Value, F,
-};
+use crate::middleware::{self, hash_str, HashOrWildcard, NativePredicate, Params, PodId, ToFields};
+use crate::util::hashmap_insert_no_dupe;
 
+use super::{AnchoredKey, Origin, Statement, StatementArg, Value};
+
+#[derive(Clone, Debug, PartialEq, Eq, h::Hash, Serialize, Deserialize, JsonSchema)]
 /// Argument to a statement template
-pub enum HashOrWildcardStr {
-    Hash(Hash), // represents a literal key
+pub enum KeyOrWildcardStr {
+    Key(String), // represents a literal key
     Wildcard(String),
 }
 
-/// helper to build a literal HashOrWildcardStr::Hash from the given str
-pub fn literal(s: &str) -> HashOrWildcardStr {
-    HashOrWildcardStr::Hash(hash_str(s))
+#[derive(Clone, Debug, PartialEq, Eq, h::Hash, Serialize, Deserialize, JsonSchema)]
+pub struct IndexedWildcard(String, usize);
+#[derive(Clone, Debug, PartialEq, Eq, h::Hash, Serialize, Deserialize, JsonSchema)]
+/// Represents a key or resolved wildcard
+pub enum KeyOrWildcard {
+    Key(String),
+    Wildcard(IndexedWildcard),
 }
 
-/// helper to build a HashOrWildcardStr::Wildcard from the given str. For the
+impl KeyOrWildcard {
+    /// Matches a key or wildcard against a value, returning a pair
+    /// representing a wildcard binding (if any) or an error if no
+    /// match is possible.
+    pub fn match_against(&self, v: &Value) -> Result<Option<(usize, Value)>> {
+        match self {
+            KeyOrWildcard::Key(k) if Value::from(k.as_str()) == *v => Ok(None),
+            KeyOrWildcard::Wildcard(i) => Ok(Some((i.1, v.clone()))),
+            _ => Err(anyhow!(
+                "Failed to match key or wildcard {} against value {}.",
+                self,
+                v
+            )),
+        }
+    }
+}
+
+impl From<KeyOrWildcard> for middleware::HashOrWildcard {
+    fn from(v: KeyOrWildcard) -> Self {
+        match v {
+            KeyOrWildcard::Key(k) => middleware::HashOrWildcard::Hash(hash_str(&k)),
+            KeyOrWildcard::Wildcard(n) => middleware::HashOrWildcard::Wildcard(n.1),
+        }
+    }
+}
+impl fmt::Display for KeyOrWildcard {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Key(k) => write!(f, "{}", k),
+            Self::Wildcard(n) => write!(f, "*{}", n.0),
+        }
+    }
+}
+
+/// helper to build a literal KeyOrWildcardStr::Key from the given str
+pub fn literal(s: &str) -> KeyOrWildcardStr {
+    KeyOrWildcardStr::Key(s.to_string())
+}
+
+/// helper to build a KeyOrWildcardStr::Wildcard from the given str. For the
 /// moment this method does not need to be public.
-fn wildcard(s: &str) -> HashOrWildcardStr {
-    HashOrWildcardStr::Wildcard(s.to_string())
+fn wildcard(s: &str) -> KeyOrWildcardStr {
+    KeyOrWildcardStr::Wildcard(s.to_string())
 }
 
 /// Builder Argument for the StatementTmplBuilder
 pub enum BuilderArg {
     Literal(Value),
     /// Key: (origin, key), where origin & key can be both Hash or Wildcard
-    Key(HashOrWildcardStr, HashOrWildcardStr),
+    Key(KeyOrWildcardStr, KeyOrWildcardStr),
 }
 
 /// When defining a `BuilderArg`, it can be done from 3 different inputs:
@@ -37,11 +86,11 @@ pub enum BuilderArg {
 /// iii. Value: this is to define a literal value, ie. 0
 ///
 /// case i.
-impl From<(&str, HashOrWildcardStr)> for BuilderArg {
-    fn from((origin, lit): (&str, HashOrWildcardStr)) -> Self {
+impl From<(&str, KeyOrWildcardStr)> for BuilderArg {
+    fn from((origin, lit): (&str, KeyOrWildcardStr)) -> Self {
         // ensure that `lit` is of HashOrWildcardStr::Hash type
         match lit {
-            HashOrWildcardStr::Hash(_) => (),
+            KeyOrWildcardStr::Key(_) => (),
             _ => panic!("not supported"),
         };
         Self::Key(wildcard(origin), lit)
@@ -63,6 +112,225 @@ where
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", content = "value")]
+pub enum Predicate {
+    Native(NativePredicate),
+    BatchSelf(usize),
+    Custom(CustomPredicateRef),
+}
+
+impl From<NativePredicate> for Predicate {
+    fn from(v: NativePredicate) -> Self {
+        Self::Native(v)
+    }
+}
+
+impl From<Predicate> for middleware::Predicate {
+    fn from(v: Predicate) -> Self {
+        match v {
+            Predicate::Native(p) => p.into(),
+            Predicate::BatchSelf(i) => middleware::Predicate::BatchSelf(i),
+            Predicate::Custom(CustomPredicateRef(pb, i)) => {
+                let cpb: middleware::CustomPredicateBatch = Arc::unwrap_or_clone(pb).into();
+                middleware::Predicate::Custom(middleware::CustomPredicateRef(Arc::new(cpb), i))
+            }
+        }
+    }
+}
+
+impl fmt::Display for Predicate {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Native(p) => write!(f, "{:?}", p),
+            Self::BatchSelf(i) => write!(f, "self.{}", i),
+            Self::Custom(CustomPredicateRef(pb, i)) => write!(f, "{}.{}", pb.name, i),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct CustomPredicateRef(pub Arc<CustomPredicateBatch>, pub usize);
+
+impl From<CustomPredicateRef> for middleware::CustomPredicateRef {
+    fn from(v: CustomPredicateRef) -> Self {
+        let cpb: middleware::CustomPredicateBatch = Arc::unwrap_or_clone(v.0).into();
+        middleware::CustomPredicateRef(Arc::new(cpb), v.1)
+    }
+}
+
+impl CustomPredicateRef {
+    pub fn arg_len(&self) -> usize {
+        self.0.predicates[self.1].args_len
+    }
+    pub fn match_against(&self, statements: &[Statement]) -> Result<HashMap<usize, Value>> {
+        let mut bindings = HashMap::new();
+        // Single out custom predicate, replacing batch-self
+        // references with custom predicate references.
+        let custom_predicate = {
+            let cp = &Arc::unwrap_or_clone(self.0.clone()).predicates[self.1];
+            CustomPredicate {
+                conjunction: cp.conjunction,
+                statements: cp
+                    .statements
+                    .iter()
+                    .map(|StatementTmpl(p, args)| {
+                        StatementTmpl(
+                            match p {
+                                Predicate::BatchSelf(i) => {
+                                    Predicate::Custom(CustomPredicateRef(self.0.clone(), *i))
+                                }
+                                _ => p.clone(),
+                            },
+                            args.to_vec(),
+                        )
+                    })
+                    .collect(),
+                args_len: cp.args_len,
+            }
+        };
+        match custom_predicate.conjunction {
+                    true if custom_predicate.statements.len() == statements.len() => {
+                        // Match op args against statement templates
+                    let match_bindings = iter::zip(custom_predicate.statements, statements).map(
+                        |(s_tmpl, s)| s_tmpl.match_against(s)
+                    ).collect::<Result<Vec<_>>>()
+                        .map(|v| v.concat())?;
+                    // Add bindings to binding table, throwing if there is an inconsistency.
+                    match_bindings.into_iter().try_for_each(|kv| hashmap_insert_no_dupe(&mut bindings, kv))?;
+                    Ok(bindings)
+                    },
+                    false if statements.len() == 1 => {
+                        // Match op arg against each statement template
+                        custom_predicate.statements.iter().map(
+                            |s_tmpl| {
+                                let mut bindings = bindings.clone();
+                                s_tmpl.match_against(&statements[0])?.into_iter().try_for_each(|kv| hashmap_insert_no_dupe(&mut bindings, kv))?;
+                                Ok::<_, anyhow::Error>(bindings)
+                            }
+                        ).find(|m| m.is_ok()).unwrap_or(Err(anyhow!("Statement {} does not match disjunctive custom predicate {}.", &statements[0], custom_predicate)))
+                    },
+                    _ =>                     Err(anyhow!("Custom predicate statement template list {:?} does not match op argument list {:?}.", custom_predicate.statements, statements))
+                }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct CustomPredicateBatch {
+    pub name: String,
+    pub predicates: Vec<CustomPredicate>,
+}
+
+impl From<CustomPredicateBatch> for middleware::CustomPredicateBatch {
+    fn from(v: CustomPredicateBatch) -> Self {
+        middleware::CustomPredicateBatch {
+            name: v.name,
+            predicates: v.predicates.into_iter().map(|p| p.into()).collect(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct CustomPredicate {
+    /// NOTE: fields are not public (outside of crate) to enforce the struct instantiation through
+    /// the `::and/or` methods, which performs checks on the values.
+
+    /// true for "and", false for "or"
+    pub(crate) conjunction: bool,
+    pub(crate) statements: Vec<StatementTmpl>,
+    pub(crate) args_len: usize,
+    // TODO: Add private args length?
+    // TODO: Add args type information?
+}
+
+impl CustomPredicate {
+    pub fn and(params: &Params, statements: Vec<StatementTmpl>, args_len: usize) -> Result<Self> {
+        Self::new(params, true, statements, args_len)
+    }
+    pub fn or(params: &Params, statements: Vec<StatementTmpl>, args_len: usize) -> Result<Self> {
+        Self::new(params, false, statements, args_len)
+    }
+    pub fn new(
+        params: &Params,
+        conjunction: bool,
+        statements: Vec<StatementTmpl>,
+        args_len: usize,
+    ) -> Result<Self> {
+        if statements.len() > params.max_custom_predicate_arity {
+            return Err(anyhow!("Custom predicate depends on too many statements"));
+        }
+
+        Ok(Self {
+            conjunction,
+            statements,
+            args_len,
+        })
+    }
+}
+
+impl From<CustomPredicate> for middleware::CustomPredicate {
+    fn from(v: CustomPredicate) -> Self {
+        middleware::CustomPredicate {
+            conjunction: v.conjunction,
+            statements: v.statements.into_iter().map(|s| s.into()).collect(),
+            args_len: v.args_len,
+        }
+    }
+}
+impl fmt::Display for CustomPredicate {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "{}<", if self.conjunction { "and" } else { "or" })?;
+        for st in &self.statements {
+            write!(f, "  {}", st.0)?;
+            for (i, arg) in st.1.iter().enumerate() {
+                if i != 0 {
+                    write!(f, ", ")?;
+                }
+                write!(f, "{}", arg)?;
+            }
+            writeln!(f, "),")?;
+        }
+        write!(f, ">(")?;
+        for i in 0..self.args_len {
+            if i != 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "*{}", i)?;
+        }
+        writeln!(f, ")")?;
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, h::Hash, Serialize, Deserialize, JsonSchema)]
+pub enum StatementTmplArg {
+    None,
+    Literal(Value),
+    Key(KeyOrWildcard, KeyOrWildcard),
+}
+
+impl From<StatementTmplArg> for middleware::StatementTmplArg {
+    fn from(v: StatementTmplArg) -> Self {
+        match v {
+            StatementTmplArg::None => middleware::StatementTmplArg::None,
+            StatementTmplArg::Literal(v) => middleware::StatementTmplArg::Literal((&v).into()),
+            StatementTmplArg::Key(pod_id, key) => {
+                middleware::StatementTmplArg::Key(pod_id.into(), key.into())
+            }
+        }
+    }
+}
+
+impl fmt::Display for StatementTmplArg {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Literal(v) => write!(f, "{}", v),
+            Self::Key(pod_id, key) => write!(f, "({}, {})", pod_id, key),
+        }
+    }
+}
+
 pub struct StatementTmplBuilder {
     predicate: Predicate,
     args: Vec<BuilderArg>,
@@ -79,6 +347,75 @@ impl StatementTmplBuilder {
     pub fn arg(mut self, a: impl Into<BuilderArg>) -> Self {
         self.args.push(a.into());
         self
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct StatementTmpl(pub Predicate, pub Vec<StatementTmplArg>);
+
+impl StatementTmpl {
+    pub fn pred(&self) -> &Predicate {
+        &self.0
+    }
+    pub fn args(&self) -> &[StatementTmplArg] {
+        &self.1
+    }
+    /// Matches a statement template against a statement, returning
+    /// the variable bindings as an association list. Returns an error
+    /// if there is type or argument mismatch.
+    pub fn match_against(&self, s: &Statement) -> Result<Vec<(usize, Value)>> {
+        type P = Predicate;
+        if matches!(self, Self(P::BatchSelf(_), _)) {
+            Err(anyhow!(
+                "Cannot check self-referencing statement templates."
+            ))
+        } else if self.pred() != &s.predicate {
+            Err(anyhow!("Type mismatch between {:?} and {}.", self, s))
+        } else {
+            zip(self.args(), s.args.clone())
+                .map(|(t_arg, s_arg)| t_arg.match_against(&s_arg))
+                .collect::<Result<Vec<_>>>()
+                .map(|v| v.concat())
+        }
+    }
+}
+
+impl From<StatementTmpl> for middleware::StatementTmpl {
+    fn from(v: StatementTmpl) -> Self {
+        middleware::StatementTmpl(v.0.into(), v.1.into_iter().map(|a| a.into()).collect())
+    }
+}
+
+impl StatementTmplArg {
+    /// Matches a statement template argument against a statement
+    /// argument, returning a wildcard correspondence in the case of
+    /// one or more wildcard matches, nothing in the case of a
+    /// literal/hash match, and an error otherwise.
+    pub fn match_against(&self, s_arg: &StatementArg) -> Result<Vec<(usize, Value)>> {
+        match (self, s_arg) {
+            //    (Self::None, StatementArg::None) => Ok(vec![]),
+            (Self::Literal(v), StatementArg::Literal(w)) if v == w => Ok(vec![]),
+            (
+                Self::Key(tmpl_o, tmpl_k),
+                StatementArg::Key(AnchoredKey {
+                    origin:
+                        Origin {
+                            pod_id: PodId(o),
+                            pod_class: _,
+                        },
+                    key: k,
+                }),
+            ) => {
+                let o_corr = tmpl_o.match_against(&(middleware::Value::from(*o)).into())?;
+                let k_corr = tmpl_k.match_against(&(*k.as_str()).into())?;
+                Ok([o_corr, k_corr].into_iter().flatten().collect())
+            }
+            _ => Err(anyhow!(
+                "Failed to match statement template argument {:?} against statement argument {:?}.",
+                self,
+                s_arg
+            )),
+        }
     }
 }
 
@@ -132,7 +469,7 @@ impl CustomPredicateBatchBuilder {
                     .args
                     .iter()
                     .map(|a| match a {
-                        BuilderArg::Literal(v) => StatementTmplArg::Literal(*v),
+                        BuilderArg::Literal(v) => StatementTmplArg::Literal(v.clone()),
                         BuilderArg::Key(pod_id, key) => StatementTmplArg::Key(
                             resolve_wildcard(args, priv_args, pod_id),
                             resolve_wildcard(args, priv_args, key),
@@ -155,14 +492,14 @@ impl CustomPredicateBatchBuilder {
     }
 }
 
-fn resolve_wildcard(args: &[&str], priv_args: &[&str], v: &HashOrWildcardStr) -> HashOrWildcard {
+fn resolve_wildcard(args: &[&str], priv_args: &[&str], v: &KeyOrWildcardStr) -> KeyOrWildcard {
     match v {
-        HashOrWildcardStr::Hash(h) => HashOrWildcard::Hash(*h),
-        HashOrWildcardStr::Wildcard(s) => HashOrWildcard::Wildcard(
+        KeyOrWildcardStr::Key(k) => KeyOrWildcard::Key(k.clone()),
+        KeyOrWildcardStr::Wildcard(s) => KeyOrWildcard::Wildcard(
             args.iter()
                 .chain(priv_args.iter())
                 .enumerate()
-                .find_map(|(i, name)| (&s == name).then_some(i))
+                .find_map(|(i, name)| (&s == name).then_some(IndexedWildcard(s.clone(), i)))
                 .unwrap(),
         ),
     }
@@ -173,7 +510,8 @@ mod tests {
     use super::*;
     use crate::{
         examples::custom::{eth_dos_batch, eth_friend_batch},
-        middleware::{CustomPredicateRef, Params, PodType},
+        middleware,
+        //   middleware::{CustomPredicateRef, Params, PodType},
     };
 
     #[test]
@@ -191,7 +529,9 @@ mod tests {
         let eth_friend = Predicate::Custom(CustomPredicateRef(eth_friend, 0));
 
         let eth_dos_batch = eth_dos_batch(&params)?;
-        let fields = eth_dos_batch.to_fields(&params);
+        let eth_dos_batch_mw: middleware::CustomPredicateBatch =
+            Arc::unwrap_or_clone(eth_dos_batch).into();
+        let fields = eth_dos_batch_mw.to_fields(&params);
         println!("Batch b, serialized: {:?}", fields);
 
         Ok(())

--- a/src/frontend/custom.rs
+++ b/src/frontend/custom.rs
@@ -447,11 +447,7 @@ impl StatementTmplArg {
             (
                 Self::Key(tmpl_o, tmpl_k),
                 StatementArg::Key(AnchoredKey {
-                    origin:
-                        Origin {
-                            pod_id: PodId(o),
-                            pod_class: _,
-                        },
+                    origin: Origin { pod_id: PodId(o) },
                     key: k,
                 }),
             ) => {

--- a/src/frontend/serialization.rs
+++ b/src/frontend/serialization.rs
@@ -12,6 +12,7 @@ use crate::middleware::PodId;
 use super::{MainPod, SignedPod, Value};
 
 #[derive(Serialize, Deserialize, JsonSchema)]
+#[schemars(title = "SignedPod")]
 pub struct SignedPodHelper {
     entries: HashMap<String, Value>,
     proof: String,
@@ -54,6 +55,7 @@ impl From<SignedPod> for SignedPodHelper {
 }
 
 #[derive(Serialize, Deserialize, JsonSchema)]
+#[schemars(title = "MainPod")]
 pub struct MainPodHelper {
     public_statements: Vec<Statement>,
     proof: String,
@@ -301,8 +303,13 @@ mod tests {
     #[test]
     fn test_schema() {
         let generator = SchemaSettings::draft07().into_generator();
-        let schema = generator.into_root_schema_for::<MainPodHelper>();
+        let mainpod_schema = generator.clone().into_root_schema_for::<MainPodHelper>();
+        let signedpod_schema = generator.into_root_schema_for::<SignedPodHelper>();
 
-        println!("{}", serde_json::to_string(&schema).unwrap());
+        println!("{}", serde_json::to_string_pretty(&mainpod_schema).unwrap());
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&signedpod_schema).unwrap()
+        );
     }
 }

--- a/src/frontend/serialization.rs
+++ b/src/frontend/serialization.rs
@@ -151,6 +151,9 @@ pub fn transform_value_schema(schema: &mut Schema) {
 
 #[cfg(test)]
 mod tests {
+    use schemars::generate::SchemaSettings;
+    use serde_json::json;
+
     use crate::{
         backends::plonky2::mock::{mainpod::MockProver, signedpod::MockSigner},
         examples::{zu_kyc_pod_builder, zu_kyc_sign_pod_builders},
@@ -293,5 +296,13 @@ mod tests {
             kyc_pod.pod.verify().is_ok(),
             deserialized.pod.verify().is_ok()
         );
+    }
+
+    #[test]
+    fn test_schema() {
+        let generator = SchemaSettings::draft07().into_generator();
+        let schema = generator.into_root_schema_for::<MainPodHelper>();
+
+        println!("{}", serde_json::to_string(&schema).unwrap());
     }
 }

--- a/src/frontend/serialization.rs
+++ b/src/frontend/serialization.rs
@@ -154,7 +154,6 @@ pub fn transform_value_schema(schema: &mut Schema) {
 #[cfg(test)]
 mod tests {
     use schemars::generate::SchemaSettings;
-    use serde_json::json;
 
     use crate::{
         backends::plonky2::mock::{mainpod::MockProver, signedpod::MockSigner},

--- a/src/frontend/statement.rs
+++ b/src/frontend/statement.rs
@@ -1,5 +1,6 @@
 use super::{AnchoredKey, SignedPod, Value};
-use crate::middleware::{self, NativePredicate, Predicate};
+use crate::frontend::Predicate;
+use crate::middleware::{self, NativePredicate};
 use anyhow::{anyhow, Result};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -97,7 +98,7 @@ impl TryFrom<Statement> for middleware::Statement {
                 _ => Err(anyhow!("Ill-formed statement: {}", s))?,
             },
             Predicate::Custom(cpr) => MS::Custom(
-                cpr.clone(),
+                cpr.clone().into(),
                 s.args
                     .iter()
                     .map(|arg| match arg {

--- a/src/middleware/statement.rs
+++ b/src/middleware/statement.rs
@@ -5,9 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::{fmt, iter};
 use strum_macros::FromRepr;
 
-use super::{
-    AnchoredKey, CustomPredicateRef, Params, Predicate, ToFields, Value, F, HASH_SIZE, VALUE_SIZE,
-};
+use super::{AnchoredKey, CustomPredicateRef, Params, Predicate, ToFields, Value, F, VALUE_SIZE};
 
 pub const KEY_SIGNER: &str = "_signer";
 pub const KEY_TYPE: &str = "_type";


### PR DESCRIPTION
Closes #161 

In order to allow for serialization of front-end versions of Custom Statements, it's necessary to include the definition of the matching Custom Deduction. This PR adds front-end types for custom predicate definitions, including statement templates.

Unfortunately this leads to some duplication of code already implemented in the middleware, for example for wildcard matching. This is needed in the front-end for `MainPodBuilder`, but the compiler also needs a version of the same thing for `Operation::check`. It's not a _huge_ amount of code, but there is some risk that we change how the middleware works without changing how the front-end works, or vice versa. If we're intending to do a larger tidy-up of the code later then maybe we can decide what to do about this then.