### PR TITLE
add circuit to verify signatures (SignatureVerifyGadget)

### DIFF
--- a/src/backends/plonky2/circuits/mainpod.rs
+++ b/src/backends/plonky2/circuits/mainpod.rs
@@ -21,7 +21,7 @@ use crate::backends::plonky2::circuits::common::{
 };
 use crate::backends::plonky2::primitives::merkletree::MerkleTree;
 use crate::backends::plonky2::primitives::merkletree::{
-    MerkleProofExistenceGate, MerkleProofExistenceTarget,
+    MerkleProofExistenceGadget, MerkleProofExistenceTarget,
 };
 use crate::middleware::{
     hash_str, AnchoredKey, NativeOperation, NativePredicate, Params, PodType, Statement,
@@ -34,18 +34,18 @@ use super::common::Flattenable;
 // SignedPod verification
 //
 
-struct SignedPodVerifyGate {
+struct SignedPodVerifyGadget {
     params: Params,
 }
 
-impl SignedPodVerifyGate {
+impl SignedPodVerifyGadget {
     fn eval(&self, builder: &mut CircuitBuilder<F, D>) -> Result<SignedPodVerifyTarget> {
         // 2. Verify id
         let id = builder.add_virtual_hash();
         let mut mt_proofs = Vec::new();
         for _ in 0..self.params.max_signed_pod_values {
-            let mt_proof = MerkleProofExistenceGate {
-                max_depth: self.params.max_depth_mt_gate,
+            let mt_proof = MerkleProofExistenceGadget {
+                max_depth: self.params.max_depth_mt_gadget,
             }
             .eval(builder)?;
             builder.connect_hashes(id, mt_proof.root);
@@ -100,7 +100,7 @@ impl SignedPodVerifyTarget {
 
     fn set_targets(&self, pw: &mut PartialWitness<F>, input: &SignedPodVerifyInput) -> Result<()> {
         assert!(input.kvs.len() <= self.params.max_signed_pod_values);
-        let tree = MerkleTree::new(self.params.max_depth_mt_gate, &input.kvs)?;
+        let tree = MerkleTree::new(self.params.max_depth_mt_gadget, &input.kvs)?;
 
         // First handle the type entry, then the rest of the entries, and finally pad with
         // repetitions of the type entry (which always exists)
@@ -125,11 +125,11 @@ impl SignedPodVerifyTarget {
 // MainPod verification
 //
 
-struct OperationVerifyGate {
+struct OperationVerifyGadget {
     params: Params,
 }
 
-impl OperationVerifyGate {
+impl OperationVerifyGadget {
     fn eval(
         &self,
         builder: &mut CircuitBuilder<F, D>,
@@ -359,17 +359,17 @@ impl OperationVerifyTarget {
     }
 }
 
-struct MainPodVerifyGate {
+struct MainPodVerifyGadget {
     params: Params,
 }
 
-impl MainPodVerifyGate {
+impl MainPodVerifyGadget {
     fn eval(&self, builder: &mut CircuitBuilder<F, D>) -> Result<MainPodVerifyTarget> {
         let params = &self.params;
         // 1. Verify all input signed pods
         let mut signed_pods = Vec::new();
         for _ in 0..params.max_input_signed_pods {
-            let signed_pod = SignedPodVerifyGate {
+            let signed_pod = SignedPodVerifyGadget {
                 params: params.clone(),
             }
             .eval(builder)?;
@@ -421,7 +421,7 @@ impl MainPodVerifyGate {
         let mut op_verifications = Vec::new();
         for (i, (st, op)) in input_statements.iter().zip(operations.iter()).enumerate() {
             let prev_statements = &statements[..input_statements_offset + i - 1];
-            let op_verification = OperationVerifyGate {
+            let op_verification = OperationVerifyGadget {
                 params: params.clone(),
             }
             .eval(builder, st, op, prev_statements)?;
@@ -478,7 +478,7 @@ pub struct MainPodVerifyCircuit {
 
 impl MainPodVerifyCircuit {
     pub fn eval(&self, builder: &mut CircuitBuilder<F, D>) -> Result<MainPodVerifyTarget> {
-        let main_pod = MainPodVerifyGate {
+        let main_pod = MainPodVerifyGadget {
             params: self.params.clone(),
         }
         .eval(builder)?;
@@ -502,7 +502,7 @@ mod tests {
         let config = CircuitConfig::standard_recursion_config();
         let mut builder = CircuitBuilder::<F, D>::new(config);
 
-        let signed_pod_verify = SignedPodVerifyGate { params }.eval(&mut builder)?;
+        let signed_pod_verify = SignedPodVerifyGadget { params }.eval(&mut builder)?;
 
         let mut pw = PartialWitness::<F>::new();
         let kvs = [
@@ -540,7 +540,7 @@ mod tests {
             .map(|_| builder.add_virtual_statement(&params))
             .collect();
 
-        let operation_verify = OperationVerifyGate {
+        let operation_verify = OperationVerifyGadget {
             params: params.clone(),
         }
         .eval(

--- a/src/backends/plonky2/primitives/merkletree.rs
+++ b/src/backends/plonky2/primitives/merkletree.rs
@@ -9,7 +9,6 @@ use std::iter::IntoIterator;
 use crate::backends::counter;
 use crate::backends::plonky2::basetypes::{hash_fields, Hash, Value, EMPTY_HASH, F};
 
-// mod merkletree_circuit;
 pub use super::merkletree_circuit::*;
 
 /// Implements the MerkleTree specified at

--- a/src/backends/plonky2/primitives/merkletree_circuit.rs
+++ b/src/backends/plonky2/primitives/merkletree_circuit.rs
@@ -27,11 +27,11 @@ use crate::backends::plonky2::basetypes::{Hash, Value, D, EMPTY_HASH, EMPTY_VALU
 use crate::backends::plonky2::circuits::common::{CircuitBuilderPod, ValueTarget};
 use crate::backends::plonky2::primitives::merkletree::MerkleProof;
 
-/// `MerkleProofGate` allows to verify both proofs of existence and proofs
+/// `MerkleProofGadget` allows to verify both proofs of existence and proofs
 /// non-existence with the same circuit.
-/// If only proofs of existence are needed, use `MerkleProofExistenceGate`,
+/// If only proofs of existence are needed, use `MerkleProofExistenceGadget`,
 /// which requires less amount of constraints.
-pub struct MerkleProofGate {
+pub struct MerkleProofGadget {
     pub max_depth: usize,
 }
 
@@ -47,7 +47,7 @@ pub struct MerkleProofTarget {
     pub other_value: ValueTarget,
 }
 
-impl MerkleProofGate {
+impl MerkleProofGadget {
     /// creates the targets and defines the logic of the circuit
     pub fn eval(&self, builder: &mut CircuitBuilder<F, D>) -> Result<MerkleProofTarget> {
         // create the targets
@@ -179,7 +179,7 @@ impl MerkleProofTarget {
 
 /// `MerkleProofExistenceCircuit` allows to verify proofs of existence only. If
 /// proofs of non-existence are needed, use `MerkleProofCircuit`.
-pub struct MerkleProofExistenceGate {
+pub struct MerkleProofExistenceGadget {
     pub max_depth: usize,
 }
 
@@ -191,7 +191,7 @@ pub struct MerkleProofExistenceTarget {
     pub siblings: Vec<HashOutTarget>,
 }
 
-impl MerkleProofExistenceGate {
+impl MerkleProofExistenceGadget {
     /// creates the targets and defines the logic of the circuit
     pub fn eval(&self, builder: &mut CircuitBuilder<F, D>) -> Result<MerkleProofExistenceTarget> {
         // create the targets
@@ -486,7 +486,7 @@ pub mod tests {
         let mut builder = CircuitBuilder::<F, D>::new(config);
         let mut pw = PartialWitness::<F>::new();
 
-        let targets = MerkleProofGate { max_depth }.eval(&mut builder)?;
+        let targets = MerkleProofGadget { max_depth }.eval(&mut builder)?;
         targets.set_targets(&mut pw, existence, tree.root(), proof, key, value)?;
 
         // generate & verify proof
@@ -525,7 +525,7 @@ pub mod tests {
         let mut builder = CircuitBuilder::<F, D>::new(config);
         let mut pw = PartialWitness::<F>::new();
 
-        let targets = MerkleProofExistenceGate { max_depth }.eval(&mut builder)?;
+        let targets = MerkleProofExistenceGadget { max_depth }.eval(&mut builder)?;
         targets.set_targets(&mut pw, tree.root(), proof, key, value)?;
 
         // generate & verify proof
@@ -592,7 +592,7 @@ pub mod tests {
         let mut builder = CircuitBuilder::<F, D>::new(config);
         let mut pw = PartialWitness::<F>::new();
 
-        let targets = MerkleProofGate { max_depth }.eval(&mut builder)?;
+        let targets = MerkleProofGadget { max_depth }.eval(&mut builder)?;
         targets.set_targets(&mut pw, proof.existence, tree.root(), proof, key, value)?;
 
         // generate & verify proof
@@ -633,7 +633,7 @@ pub mod tests {
         let mut builder = CircuitBuilder::<F, D>::new(config);
         let mut pw = PartialWitness::<F>::new();
 
-        let targets = MerkleProofGate { max_depth }.eval(&mut builder)?;
+        let targets = MerkleProofGadget { max_depth }.eval(&mut builder)?;
         targets.set_targets(&mut pw, true, tree2.root(), proof, key, value)?;
 
         // generate proof, expecting it to fail (since we're using the wrong

--- a/src/backends/plonky2/primitives/mod.rs
+++ b/src/backends/plonky2/primitives/mod.rs
@@ -1,3 +1,4 @@
 pub mod merkletree;
 mod merkletree_circuit;
 pub mod signature;
+mod signature_circuit;

--- a/src/backends/plonky2/primitives/signature.rs
+++ b/src/backends/plonky2/primitives/signature.rs
@@ -22,6 +22,8 @@ use plonky2::{
 
 use crate::backends::plonky2::basetypes::{Proof, Value, C, D, F, VALUE_SIZE};
 
+pub use super::signature_circuit::*;
+
 lazy_static! {
     /// Signature prover parameters
     pub static ref PP: ProverParams = Signature::prover_params().unwrap();

--- a/src/backends/plonky2/primitives/signature.rs
+++ b/src/backends/plonky2/primitives/signature.rs
@@ -23,7 +23,9 @@ use plonky2::{
 use crate::backends::plonky2::basetypes::{Proof, Value, C, D, F, VALUE_SIZE};
 
 lazy_static! {
+    /// Signature prover parameters
     pub static ref PP: ProverParams = Signature::prover_params().unwrap();
+    /// Signature verifier parameters
     pub static ref VP: VerifierParams = Signature::verifier_params().unwrap();
 }
 

--- a/src/backends/plonky2/primitives/signature_circuit.rs
+++ b/src/backends/plonky2/primitives/signature_circuit.rs
@@ -29,7 +29,7 @@ lazy_static! {
 }
 
 pub struct SignatureVerifyGadget {}
-pub struct SignatureTarget {
+pub struct SignatureVerifyTarget {
     // verifier_data of the SignatureInternalCircuit
     verifier_data_targ: VerifierCircuitTarget,
     selector: BoolTarget,
@@ -53,7 +53,7 @@ impl SignatureVerifyGadget {
 
 impl SignatureVerifyGadget {
     /// creates the targets and defines the logic of the circuit
-    pub fn eval(&self, builder: &mut CircuitBuilder<F, D>) -> Result<SignatureTarget> {
+    pub fn eval(&self, builder: &mut CircuitBuilder<F, D>) -> Result<SignatureVerifyTarget> {
         let selector = builder.add_virtual_bool_target_safe();
 
         let common_data = super::signature::VP.0.common.clone();
@@ -81,7 +81,7 @@ impl SignatureVerifyGadget {
             &common_data,
         );
 
-        Ok(SignatureTarget {
+        Ok(SignatureVerifyTarget {
             selector,
             proof: proof_targ,
             pk: pk_targ,
@@ -91,7 +91,7 @@ impl SignatureVerifyGadget {
     }
 }
 
-impl SignatureTarget {
+impl SignatureVerifyTarget {
     /// assigns the given values to the targets
     pub fn set_targets(
         &self,

--- a/src/backends/plonky2/primitives/signature_circuit.rs
+++ b/src/backends/plonky2/primitives/signature_circuit.rs
@@ -24,11 +24,11 @@ use crate::backends::plonky2::circuits::common::{CircuitBuilderPod, ValueTarget}
 use crate::backends::plonky2::primitives::signature::{PublicKey, Signature};
 
 lazy_static! {
-    // SignatureGate VerifierCircuitData
-    pub static ref S_VD: VerifierCircuitData<F,C,D> = SignatureGate::verifier_data().unwrap();
+    /// SignatureVerifyGadget VerifierCircuitData
+    pub static ref S_VD: VerifierCircuitData<F,C,D> = SignatureVerifyGadget::verifier_data().unwrap();
 }
 
-pub struct SignatureGate {}
+pub struct SignatureVerifyGadget {}
 pub struct SignatureTarget {
     // verifier_data of the SignatureInternalCircuit
     verifier_data_targ: VerifierCircuitTarget,
@@ -37,19 +37,19 @@ pub struct SignatureTarget {
     proof: ProofWithPublicInputsTarget<D>,
 }
 
-impl SignatureGate {
+impl SignatureVerifyGadget {
     pub fn verifier_data() -> Result<VerifierCircuitData<F, C, D>> {
         // notice that we use the 'zk' config
         let config = CircuitConfig::standard_recursion_zk_config();
         let mut builder = CircuitBuilder::<F, D>::new(config);
-        let circuit = SignatureGate {}.eval(&mut builder)?;
+        let circuit = SignatureVerifyGadget {}.eval(&mut builder)?;
 
         let circuit_data = builder.build::<C>();
         Ok(circuit_data.verifier_data())
     }
 }
 
-impl SignatureGate {
+impl SignatureVerifyGadget {
     /// creates the targets and defines the logic of the circuit
     pub fn eval(&self, builder: &mut CircuitBuilder<F, D>) -> Result<SignatureTarget> {
         let selector = builder.add_virtual_bool_target_safe();
@@ -63,9 +63,10 @@ impl SignatureGate {
 
         let proof_targ = builder.add_virtual_proof_with_pis(&common_data);
         builder.verify_proof::<C>(&proof_targ, &verifier_data_targ, &common_data);
-        // NOTE: we would use the `conditional_verify...` method, but since we're using the
-        // `standard_recursion_zk_config` (with zk), internally it fails to generate the
-        // `dummy_circuit`. So for the moment we use `verify_proof` (not-conditional).
+        // NOTE: we would use the `conditional_verify_proof_or_dummy` method,
+        // but since we're using the `standard_recursion_zk_config` (with zk),
+        // internally it fails to generate the `dummy_circuit`. So for the
+        // moment we use `verify_proof` (not-conditional).
         // builder.conditionally_verify_proof_or_dummy::<C>(
         //     selector,
         //     &proof_targ,
@@ -138,7 +139,7 @@ pub mod tests {
         let mut builder = CircuitBuilder::<F, D>::new(config);
         let mut pw = PartialWitness::<F>::new();
 
-        let targets = SignatureGate {}.eval(&mut builder)?;
+        let targets = SignatureVerifyGadget {}.eval(&mut builder)?;
         targets.set_targets(&mut pw, true, pk, msg, sig)?;
 
         // generate & verify proof

--- a/src/backends/plonky2/primitives/signature_circuit.rs
+++ b/src/backends/plonky2/primitives/signature_circuit.rs
@@ -1,0 +1,157 @@
+#![allow(unused)]
+use anyhow::Result;
+use lazy_static::lazy_static;
+use plonky2::{
+    field::types::Field,
+    hash::{
+        hash_types::{HashOut, HashOutTarget},
+        poseidon::PoseidonHash,
+    },
+    iop::{
+        target::{BoolTarget, Target},
+        witness::{PartialWitness, WitnessWrite},
+    },
+    plonk::circuit_builder::CircuitBuilder,
+    plonk::circuit_data::{
+        CircuitConfig, CircuitData, ProverCircuitData, VerifierCircuitData, VerifierCircuitTarget,
+    },
+    plonk::config::Hasher,
+    plonk::proof::{ProofWithPublicInputs, ProofWithPublicInputsTarget},
+};
+
+use crate::backends::plonky2::basetypes::{Hash, Value, C, D, EMPTY_HASH, EMPTY_VALUE, F};
+use crate::backends::plonky2::circuits::common::{CircuitBuilderPod, ValueTarget};
+use crate::backends::plonky2::primitives::signature::{PublicKey, Signature};
+
+lazy_static! {
+    // SignatureGate VerifierCircuitData
+    pub static ref S_VD: VerifierCircuitData<F,C,D> = SignatureGate::verifier_data().unwrap();
+}
+
+pub struct SignatureGate {}
+pub struct SignatureTarget {
+    // verifier_data of the SignatureInternalCircuit
+    verifier_data_targ: VerifierCircuitTarget,
+    selector: BoolTarget,
+    pk: ValueTarget,
+    proof: ProofWithPublicInputsTarget<D>,
+}
+
+impl SignatureGate {
+    pub fn verifier_data() -> Result<VerifierCircuitData<F, C, D>> {
+        // notice that we use the 'zk' config
+        let config = CircuitConfig::standard_recursion_zk_config();
+        let mut builder = CircuitBuilder::<F, D>::new(config);
+        let circuit = SignatureGate {}.eval(&mut builder)?;
+
+        let circuit_data = builder.build::<C>();
+        Ok(circuit_data.verifier_data())
+    }
+}
+
+impl SignatureGate {
+    /// creates the targets and defines the logic of the circuit
+    pub fn eval(&self, builder: &mut CircuitBuilder<F, D>) -> Result<SignatureTarget> {
+        let selector = builder.add_virtual_bool_target_safe();
+
+        let common_data = super::signature::VP.0.common.clone();
+
+        let pk_targ = builder.add_virtual_value();
+
+        let verifier_data_targ =
+            builder.add_virtual_verifier_data(common_data.config.fri_config.cap_height);
+
+        let proof_targ = builder.add_virtual_proof_with_pis(&common_data);
+        builder.verify_proof::<C>(&proof_targ, &verifier_data_targ, &common_data);
+        // NOTE: we would use the `conditional_verify...` method, but since we're using the
+        // `standard_recursion_zk_config` (with zk), internally it fails to generate the
+        // `dummy_circuit`. So for the moment we use `verify_proof` (not-conditional).
+        // builder.conditionally_verify_proof_or_dummy::<C>(
+        //     selector,
+        //     &proof_targ,
+        //     &verifier_data_targ,
+        //     &common_data,
+        // )?;
+
+        Ok(SignatureTarget {
+            selector,
+            proof: proof_targ,
+            pk: pk_targ,
+            verifier_data_targ,
+        })
+    }
+}
+
+impl SignatureTarget {
+    /// assigns the given values to the targets
+    pub fn set_targets(
+        &self,
+        pw: &mut PartialWitness<F>,
+        selector: bool,
+        pk: PublicKey,
+        msg: Value,
+        signature: Signature,
+    ) -> Result<()> {
+        pw.set_bool_target(self.selector, selector)?;
+        pw.set_target_arr(&self.pk.elements, &pk.0 .0)?;
+
+        // note that this hash is checked again in-circuit at the `SignatureInternalCircuit`
+        let s = Value(PoseidonHash::hash_no_pad(&[pk.0 .0, msg.0].concat()).elements);
+        let public_inputs: Vec<F> = [pk.0 .0, msg.0, s.0].concat();
+
+        pw.set_proof_with_pis_target(
+            &self.proof,
+            &ProofWithPublicInputs {
+                proof: signature.0,
+                public_inputs,
+            },
+        )?;
+
+        pw.set_verifier_data_target(
+            &self.verifier_data_targ,
+            &super::signature::VP.0.verifier_only,
+        )?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use crate::backends::plonky2::basetypes::Hash;
+    use crate::backends::plonky2::primitives::signature::SecretKey;
+
+    use super::*;
+
+    // Note: this test must be run with the `--release` flag.
+    #[test]
+    fn test_signature_gate() -> Result<()> {
+        // generate a valid signature
+        let sk = SecretKey::new();
+        let pk = sk.public_key();
+        let msg = Value::from(42);
+        let sig = sk.sign(msg)?;
+        sig.verify(&pk, msg)?;
+
+        // circuit
+        let config = CircuitConfig::standard_recursion_zk_config();
+        let mut builder = CircuitBuilder::<F, D>::new(config);
+        let mut pw = PartialWitness::<F>::new();
+
+        let targets = SignatureGate {}.eval(&mut builder)?;
+        targets.set_targets(&mut pw, true, pk, msg, sig)?;
+
+        // generate & verify proof
+        let data = builder.build::<C>();
+        let proof = data.prove(pw)?;
+        data.verify(proof.clone())?;
+
+        // verify the proof with the lazy_static loaded verifier_data (S_VD)
+        S_VD.verify(ProofWithPublicInputs {
+            proof: proof.proof.clone(),
+            public_inputs: vec![],
+        })?;
+
+        Ok(())
+    }
+}

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -105,8 +105,8 @@ pub struct Params {
     // in a custom predicate
     pub max_custom_predicate_arity: usize,
     pub max_custom_batch_size: usize,
-    // maximum depth for merkle tree gates
-    pub max_depth_mt_gate: usize,
+    // maximum depth for merkle tree gadget
+    pub max_depth_mt_gadget: usize,
 }
 
 impl Default for Params {
@@ -121,7 +121,7 @@ impl Default for Params {
             max_operation_args: 5,
             max_custom_predicate_arity: 5,
             max_custom_batch_size: 5,
-            max_depth_mt_gate: 32,
+            max_depth_mt_gadget: 32,
         }
     }
 }


### PR DESCRIPTION
This PR implements the `SignatureVerifyGadget`, the circuit that verifies the `Signature`; where since the signatures currently are proof-based signatures, the `SignatureVerifyGadget` internally is doing a 1-level recursive proof verification.