### PR TITLE
Signedpod circuit

### DIFF
--- a/src/backends/plonky2/circuits/mainpod.rs
+++ b/src/backends/plonky2/circuits/mainpod.rs
@@ -21,7 +21,7 @@ use crate::backends::plonky2::circuits::common::{
 };
 use crate::backends::plonky2::primitives::merkletree::MerkleTree;
 use crate::backends::plonky2::primitives::merkletree::{
-    MerkleProofExistenceGate, MerkleProofExistenceTarget,
+    MerkleProofExistenceGadget, MerkleProofExistenceTarget,
 };
 use crate::middleware::{
     hash_str, AnchoredKey, NativeOperation, NativePredicate, Params, PodType, Statement,
@@ -34,18 +34,18 @@ use super::common::Flattenable;
 // SignedPod verification
 //
 
-struct SignedPodVerifyGate {
+struct SignedPodVerifyGadget {
     params: Params,
 }
 
-impl SignedPodVerifyGate {
+impl SignedPodVerifyGadget {
     fn eval(&self, builder: &mut CircuitBuilder<F, D>) -> Result<SignedPodVerifyTarget> {
         // 2. Verify id
         let id = builder.add_virtual_hash();
         let mut mt_proofs = Vec::new();
         for _ in 0..self.params.max_signed_pod_values {
-            let mt_proof = MerkleProofExistenceGate {
-                max_depth: self.params.max_depth_mt_gate,
+            let mt_proof = MerkleProofExistenceGadget {
+                max_depth: self.params.max_depth_mt_gadget,
             }
             .eval(builder)?;
             builder.connect_hashes(id, mt_proof.root);
@@ -100,7 +100,7 @@ impl SignedPodVerifyTarget {
 
     fn set_targets(&self, pw: &mut PartialWitness<F>, input: &SignedPodVerifyInput) -> Result<()> {
         assert!(input.kvs.len() <= self.params.max_signed_pod_values);
-        let tree = MerkleTree::new(self.params.max_depth_mt_gate, &input.kvs)?;
+        let tree = MerkleTree::new(self.params.max_depth_mt_gadget, &input.kvs)?;
 
         // First handle the type entry, then the rest of the entries, and finally pad with
         // repetitions of the type entry (which always exists)
@@ -125,11 +125,11 @@ impl SignedPodVerifyTarget {
 // MainPod verification
 //
 
-struct OperationVerifyGate {
+struct OperationVerifyGadget {
     params: Params,
 }
 
-impl OperationVerifyGate {
+impl OperationVerifyGadget {
     fn eval(
         &self,
         builder: &mut CircuitBuilder<F, D>,
@@ -359,17 +359,17 @@ impl OperationVerifyTarget {
     }
 }
 
-struct MainPodVerifyGate {
+struct MainPodVerifyGadget {
     params: Params,
 }
 
-impl MainPodVerifyGate {
+impl MainPodVerifyGadget {
     fn eval(&self, builder: &mut CircuitBuilder<F, D>) -> Result<MainPodVerifyTarget> {
         let params = &self.params;
         // 1. Verify all input signed pods
         let mut signed_pods = Vec::new();
         for _ in 0..params.max_input_signed_pods {
-            let signed_pod = SignedPodVerifyGate {
+            let signed_pod = SignedPodVerifyGadget {
                 params: params.clone(),
             }
             .eval(builder)?;
@@ -421,7 +421,7 @@ impl MainPodVerifyGate {
         let mut op_verifications = Vec::new();
         for (i, (st, op)) in input_statements.iter().zip(operations.iter()).enumerate() {
             let prev_statements = &statements[..input_statements_offset + i - 1];
-            let op_verification = OperationVerifyGate {
+            let op_verification = OperationVerifyGadget {
                 params: params.clone(),
             }
             .eval(builder, st, op, prev_statements)?;
@@ -478,7 +478,7 @@ pub struct MainPodVerifyCircuit {
 
 impl MainPodVerifyCircuit {
     pub fn eval(&self, builder: &mut CircuitBuilder<F, D>) -> Result<MainPodVerifyTarget> {
-        let main_pod = MainPodVerifyGate {
+        let main_pod = MainPodVerifyGadget {
             params: self.params.clone(),
         }
         .eval(builder)?;
@@ -502,7 +502,7 @@ mod tests {
         let config = CircuitConfig::standard_recursion_config();
         let mut builder = CircuitBuilder::<F, D>::new(config);
 
-        let signed_pod_verify = SignedPodVerifyGate { params }.eval(&mut builder)?;
+        let signed_pod_verify = SignedPodVerifyGadget { params }.eval(&mut builder)?;
 
         let mut pw = PartialWitness::<F>::new();
         let kvs = [
@@ -540,7 +540,7 @@ mod tests {
             .map(|_| builder.add_virtual_statement(&params))
             .collect();
 
-        let operation_verify = OperationVerifyGate {
+        let operation_verify = OperationVerifyGadget {
             params: params.clone(),
         }
         .eval(

--- a/src/backends/plonky2/circuits/mainpod.rs
+++ b/src/backends/plonky2/circuits/mainpod.rs
@@ -23,6 +23,7 @@ use crate::backends::plonky2::primitives::merkletree::MerkleTree;
 use crate::backends::plonky2::primitives::merkletree::{
     MerkleProofExistenceGadget, MerkleProofExistenceTarget,
 };
+use crate::backends::plonky2::signedpod::SignedPod;
 use crate::middleware::{
     hash_str, AnchoredKey, NativeOperation, NativePredicate, Params, PodType, Statement,
     StatementArg, ToFields, KEY_TYPE, SELF,
@@ -30,7 +31,7 @@ use crate::middleware::{
 
 use super::{
     common::Flattenable,
-    signedpod::{SignedPodVerifyGadget, SignedPodVerifyInput, SignedPodVerifyTarget},
+    signedpod::{SignedPodVerifyGadget, SignedPodVerifyTarget},
 };
 
 //
@@ -362,7 +363,7 @@ struct MainPodVerifyTarget {
 }
 
 struct MainPodVerifyInput {
-    signed_pods: Vec<SignedPodVerifyInput>,
+    signed_pods: Vec<SignedPod>,
 }
 
 impl MainPodVerifyTarget {
@@ -401,11 +402,14 @@ impl MainPodVerifyCircuit {
 
 #[cfg(test)]
 mod tests {
+    use plonky2::plonk::{circuit_builder::CircuitBuilder, circuit_data::CircuitConfig};
+
     use super::*;
     use crate::backends::plonky2::mock::mainpod;
+    use crate::backends::plonky2::primitives::signature::SecretKey;
+    use crate::backends::plonky2::signedpod::{SignedPod, Signer};
     use crate::backends::plonky2::{basetypes::C, mock::mainpod::OperationArg};
     use crate::middleware::{OperationType, PodId};
-    use plonky2::plonk::{circuit_builder::CircuitBuilder, circuit_data::CircuitConfig};
 
     fn operation_verify(
         st: mainpod::Statement,

--- a/src/backends/plonky2/circuits/mainpod.rs
+++ b/src/backends/plonky2/circuits/mainpod.rs
@@ -28,98 +28,10 @@ use crate::middleware::{
     StatementArg, ToFields, KEY_TYPE, SELF,
 };
 
-use super::common::Flattenable;
-
-//
-// SignedPod verification
-//
-
-struct SignedPodVerifyGadget {
-    params: Params,
-}
-
-impl SignedPodVerifyGadget {
-    fn eval(&self, builder: &mut CircuitBuilder<F, D>) -> Result<SignedPodVerifyTarget> {
-        // 2. Verify id
-        let id = builder.add_virtual_hash();
-        let mut mt_proofs = Vec::new();
-        for _ in 0..self.params.max_signed_pod_values {
-            let mt_proof = MerkleProofExistenceGadget {
-                max_depth: self.params.max_depth_mt_gadget,
-            }
-            .eval(builder)?;
-            builder.connect_hashes(id, mt_proof.root);
-            mt_proofs.push(mt_proof);
-        }
-
-        // 1. Verify type
-        let type_mt_proof = &mt_proofs[0];
-        let key_type = builder.constant_value(hash_str(KEY_TYPE).into());
-        builder.connect_values(type_mt_proof.key, key_type);
-        let value_type = builder.constant_value(Value::from(PodType::MockSigned));
-        builder.connect_values(type_mt_proof.value, value_type);
-
-        // 3. TODO: Verify signature
-
-        Ok(SignedPodVerifyTarget {
-            params: self.params.clone(),
-            id,
-            mt_proofs,
-        })
-    }
-}
-
-struct SignedPodVerifyTarget {
-    params: Params,
-    id: HashOutTarget,
-    // The KEY_TYPE entry must be the first one
-    // The KEY_SIGNER entry must be the second one
-    mt_proofs: Vec<MerkleProofExistenceTarget>,
-}
-
-struct SignedPodVerifyInput {
-    kvs: HashMap<Value, Value>,
-}
-
-impl SignedPodVerifyTarget {
-    fn kvs(&self) -> Vec<(ValueTarget, ValueTarget)> {
-        let mut kvs = Vec::new();
-        for mt_proof in &self.mt_proofs {
-            kvs.push((mt_proof.key, mt_proof.value));
-        }
-        // TODO: when the slot is unused, do we force the kv to be (EMPTY, EMPTY), and then from
-        // it get a ValueOf((id, EMPTY), EMPTY)?  Or should we keep some boolean flags for unused
-        // slots and translate them to Statement::None instead?
-        kvs
-    }
-
-    fn pub_statements(&self) -> Vec<StatementTarget> {
-        // TODO: Here we need to use the self.id in the ValueOf statements
-        todo!()
-    }
-
-    fn set_targets(&self, pw: &mut PartialWitness<F>, input: &SignedPodVerifyInput) -> Result<()> {
-        assert!(input.kvs.len() <= self.params.max_signed_pod_values);
-        let tree = MerkleTree::new(self.params.max_depth_mt_gadget, &input.kvs)?;
-
-        // First handle the type entry, then the rest of the entries, and finally pad with
-        // repetitions of the type entry (which always exists)
-        let mut kvs = input.kvs.clone();
-        let key_type = Value::from(hash_str(KEY_TYPE));
-        let value_type = kvs.remove(&key_type).expect("KEY_TYPE");
-
-        for (i, (k, v)) in iter::once((key_type, value_type))
-            .chain(kvs.into_iter().sorted_by_key(|kv| kv.0))
-            .chain(iter::repeat((key_type, value_type)))
-            .take(self.params.max_signed_pod_values)
-            .enumerate()
-        {
-            let (_, proof) = tree.prove(&k)?;
-            self.mt_proofs[i].set_targets(pw, tree.root(), proof, k, v)?;
-        }
-        Ok(())
-    }
-}
+use super::{
+    common::Flattenable,
+    signedpod::{SignedPodVerifyGadget, SignedPodVerifyInput, SignedPodVerifyTarget},
+};
 
 //
 // MainPod verification
@@ -494,35 +406,6 @@ mod tests {
     use crate::backends::plonky2::{basetypes::C, mock::mainpod::OperationArg};
     use crate::middleware::{OperationType, PodId};
     use plonky2::plonk::{circuit_builder::CircuitBuilder, circuit_data::CircuitConfig};
-
-    #[test]
-    fn test_signed_pod_verify() -> Result<()> {
-        let params = Params::default();
-
-        let config = CircuitConfig::standard_recursion_config();
-        let mut builder = CircuitBuilder::<F, D>::new(config);
-
-        let signed_pod_verify = SignedPodVerifyGadget { params }.eval(&mut builder)?;
-
-        let mut pw = PartialWitness::<F>::new();
-        let kvs = [
-            (
-                Value::from(hash_str(KEY_TYPE)),
-                Value::from(PodType::MockSigned),
-            ),
-            (Value::from(hash_str("foo")), Value::from(42)),
-        ]
-        .into();
-        let input = SignedPodVerifyInput { kvs };
-        signed_pod_verify.set_targets(&mut pw, &input)?;
-
-        // generate & verify proof
-        let data = builder.build::<C>();
-        let proof = data.prove(pw)?;
-        data.verify(proof)?;
-
-        Ok(())
-    }
 
     fn operation_verify(
         st: mainpod::Statement,

--- a/src/backends/plonky2/circuits/mod.rs
+++ b/src/backends/plonky2/circuits/mod.rs
@@ -1,2 +1,3 @@
 pub mod common;
 pub mod mainpod;
+pub mod signedpod;

--- a/src/backends/plonky2/circuits/signedpod.rs
+++ b/src/backends/plonky2/circuits/signedpod.rs
@@ -1,0 +1,161 @@
+use anyhow::Result;
+use itertools::Itertools;
+use plonky2::{
+    field::types::Field,
+    hash::{
+        hash_types::{HashOut, HashOutTarget},
+        poseidon::PoseidonHash,
+    },
+    iop::{
+        target::{BoolTarget, Target},
+        witness::{PartialWitness, WitnessWrite},
+    },
+    plonk::circuit_builder::CircuitBuilder,
+};
+use std::collections::HashMap;
+use std::iter;
+
+use crate::backends::plonky2::basetypes::{Hash, Value, D, EMPTY_HASH, EMPTY_VALUE, F, VALUE_SIZE};
+use crate::backends::plonky2::circuits::common::{
+    CircuitBuilderPod, OperationTarget, StatementTarget, ValueTarget,
+};
+use crate::backends::plonky2::primitives::merkletree::MerkleTree;
+use crate::backends::plonky2::primitives::merkletree::{
+    MerkleProofExistenceGadget, MerkleProofExistenceTarget,
+};
+use crate::middleware::{
+    hash_str, AnchoredKey, NativeOperation, NativePredicate, Params, PodType, Statement,
+    StatementArg, ToFields, KEY_TYPE, SELF,
+};
+
+use super::common::Flattenable;
+
+pub struct SignedPodVerifyGadget {
+    pub params: Params,
+}
+
+impl SignedPodVerifyGadget {
+    pub fn eval(&self, builder: &mut CircuitBuilder<F, D>) -> Result<SignedPodVerifyTarget> {
+        // 2. Verify id
+        let id = builder.add_virtual_hash();
+        let mut mt_proofs = Vec::new();
+        for _ in 0..self.params.max_signed_pod_values {
+            let mt_proof = MerkleProofExistenceGadget {
+                max_depth: self.params.max_depth_mt_gadget,
+            }
+            .eval(builder)?;
+            builder.connect_hashes(id, mt_proof.root);
+            mt_proofs.push(mt_proof);
+        }
+
+        // 1. Verify type
+        let type_mt_proof = &mt_proofs[0];
+        let key_type = builder.constant_value(hash_str(KEY_TYPE).into());
+        builder.connect_values(type_mt_proof.key, key_type);
+        let value_type = builder.constant_value(Value::from(PodType::MockSigned));
+        builder.connect_values(type_mt_proof.value, value_type);
+
+        // 3. TODO: Verify signature
+
+        Ok(SignedPodVerifyTarget {
+            params: self.params.clone(),
+            id,
+            mt_proofs,
+        })
+    }
+}
+
+pub struct SignedPodVerifyTarget {
+    params: Params,
+    id: HashOutTarget,
+    // The KEY_TYPE entry must be the first one
+    // The KEY_SIGNER entry must be the second one
+    mt_proofs: Vec<MerkleProofExistenceTarget>,
+}
+
+pub struct SignedPodVerifyInput {
+    pub kvs: HashMap<Value, Value>,
+}
+
+impl SignedPodVerifyTarget {
+    fn kvs(&self) -> Vec<(ValueTarget, ValueTarget)> {
+        let mut kvs = Vec::new();
+        for mt_proof in &self.mt_proofs {
+            kvs.push((mt_proof.key, mt_proof.value));
+        }
+        // TODO: when the slot is unused, do we force the kv to be (EMPTY, EMPTY), and then from
+        // it get a ValueOf((id, EMPTY), EMPTY)?  Or should we keep some boolean flags for unused
+        // slots and translate them to Statement::None instead?
+        kvs
+    }
+
+    pub fn pub_statements(&self) -> Vec<StatementTarget> {
+        // TODO: Here we need to use the self.id in the ValueOf statements
+        todo!()
+    }
+
+    pub fn set_targets(
+        &self,
+        pw: &mut PartialWitness<F>,
+        input: &SignedPodVerifyInput,
+    ) -> Result<()> {
+        assert!(input.kvs.len() <= self.params.max_signed_pod_values);
+        let tree = MerkleTree::new(self.params.max_depth_mt_gadget, &input.kvs)?;
+
+        // First handle the type entry, then the rest of the entries, and finally pad with
+        // repetitions of the type entry (which always exists)
+        let mut kvs = input.kvs.clone();
+        let key_type = Value::from(hash_str(KEY_TYPE));
+        let value_type = kvs.remove(&key_type).expect("KEY_TYPE");
+
+        // TODO manage unused merkleproof verifications (with selectors)
+        for (i, (k, v)) in iter::once((key_type, value_type))
+            .chain(kvs.into_iter().sorted_by_key(|kv| kv.0))
+            .chain(iter::repeat((key_type, value_type)))
+            .take(self.params.max_signed_pod_values)
+            .enumerate()
+        {
+            let (_, proof) = tree.prove(&k)?;
+            self.mt_proofs[i].set_targets(pw, true, tree.root(), proof, k, v)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backends::plonky2::mock::mainpod;
+    use crate::backends::plonky2::{basetypes::C, mock::mainpod::OperationArg};
+    use crate::middleware::{OperationType, PodId};
+    use plonky2::plonk::{circuit_builder::CircuitBuilder, circuit_data::CircuitConfig};
+
+    #[test]
+    fn test_signed_pod_verify() -> Result<()> {
+        let params = Params::default();
+
+        let config = CircuitConfig::standard_recursion_config();
+        let mut builder = CircuitBuilder::<F, D>::new(config);
+
+        let signed_pod_verify = SignedPodVerifyGadget { params }.eval(&mut builder)?;
+
+        let mut pw = PartialWitness::<F>::new();
+        let kvs = [
+            (
+                Value::from(hash_str(KEY_TYPE)),
+                Value::from(PodType::MockSigned),
+            ),
+            (Value::from(hash_str("foo")), Value::from(42)),
+        ]
+        .into();
+        let input = SignedPodVerifyInput { kvs };
+        signed_pod_verify.set_targets(&mut pw, &input)?;
+
+        // generate & verify proof
+        let data = builder.build::<C>();
+        let proof = data.prove(pw)?;
+        data.verify(proof)?;
+
+        Ok(())
+    }
+}

--- a/src/backends/plonky2/circuits/signedpod.rs
+++ b/src/backends/plonky2/circuits/signedpod.rs
@@ -1,34 +1,18 @@
 use anyhow::Result;
-use itertools::Itertools;
 use plonky2::{
-    field::types::Field,
-    hash::{
-        hash_types::{HashOut, HashOutTarget},
-        poseidon::PoseidonHash,
-    },
-    iop::{
-        target::{BoolTarget, Target},
-        witness::{PartialWitness, WitnessWrite},
-    },
+    hash::hash_types::{HashOut, HashOutTarget},
+    iop::witness::{PartialWitness, WitnessWrite},
     plonk::circuit_builder::CircuitBuilder,
 };
-use std::collections::HashMap;
-use std::iter;
 
-use crate::backends::plonky2::basetypes::{Hash, Value, D, EMPTY_HASH, EMPTY_VALUE, F, VALUE_SIZE};
-use crate::backends::plonky2::circuits::common::{
-    CircuitBuilderPod, OperationTarget, StatementTarget, ValueTarget,
+use crate::backends::plonky2::basetypes::{Value, D, EMPTY_VALUE, F};
+use crate::backends::plonky2::circuits::common::{CircuitBuilderPod, StatementTarget};
+use crate::backends::plonky2::primitives::{
+    merkletree::{MerkleProof, MerkleProofExistenceGadget, MerkleProofExistenceTarget},
+    signature::{PublicKey, SignatureVerifyGadget, SignatureVerifyTarget},
 };
-use crate::backends::plonky2::primitives::merkletree::MerkleTree;
-use crate::backends::plonky2::primitives::merkletree::{
-    MerkleProofExistenceGadget, MerkleProofExistenceTarget,
-};
-use crate::middleware::{
-    hash_str, AnchoredKey, NativeOperation, NativePredicate, Params, PodType, Statement,
-    StatementArg, ToFields, KEY_TYPE, SELF,
-};
-
-use super::common::Flattenable;
+use crate::backends::plonky2::signedpod::SignedPod;
+use crate::middleware::{hash_str, Params, PodType, KEY_SIGNER, KEY_TYPE};
 
 pub struct SignedPodVerifyGadget {
     pub params: Params,
@@ -52,15 +36,23 @@ impl SignedPodVerifyGadget {
         let type_mt_proof = &mt_proofs[0];
         let key_type = builder.constant_value(hash_str(KEY_TYPE).into());
         builder.connect_values(type_mt_proof.key, key_type);
-        let value_type = builder.constant_value(Value::from(PodType::MockSigned));
+        let value_type = builder.constant_value(Value::from(PodType::Signed));
         builder.connect_values(type_mt_proof.value, value_type);
 
-        // 3. TODO: Verify signature
+        // 3. Verify signature
+        let signature = SignatureVerifyGadget {}.eval(builder)?;
+
+        // 4. Verify signer (ie. signature.pk == merkletree.signer_leaf
+        let signer_mt_proof = &mt_proofs[1];
+        let key_signer = builder.constant_value(hash_str(KEY_SIGNER).into());
+        builder.connect_values(signer_mt_proof.key, key_signer);
+        builder.connect_values(signer_mt_proof.value, signature.pk);
 
         Ok(SignedPodVerifyTarget {
             params: self.params.clone(),
             id,
             mt_proofs,
+            signature,
         })
     }
 }
@@ -68,88 +60,146 @@ impl SignedPodVerifyGadget {
 pub struct SignedPodVerifyTarget {
     params: Params,
     id: HashOutTarget,
-    // The KEY_TYPE entry must be the first one
-    // The KEY_SIGNER entry must be the second one
+    // the KEY_TYPE entry must be the first one
+    // the KEY_SIGNER entry must be the second one
     mt_proofs: Vec<MerkleProofExistenceTarget>,
-}
-
-pub struct SignedPodVerifyInput {
-    pub kvs: HashMap<Value, Value>,
+    signature: SignatureVerifyTarget,
 }
 
 impl SignedPodVerifyTarget {
-    fn kvs(&self) -> Vec<(ValueTarget, ValueTarget)> {
-        let mut kvs = Vec::new();
-        for mt_proof in &self.mt_proofs {
-            kvs.push((mt_proof.key, mt_proof.value));
-        }
-        // TODO: when the slot is unused, do we force the kv to be (EMPTY, EMPTY), and then from
-        // it get a ValueOf((id, EMPTY), EMPTY)?  Or should we keep some boolean flags for unused
-        // slots and translate them to Statement::None instead?
-        kvs
-    }
+    // pub fn kvs(&self) -> Vec<(ValueTarget, ValueTarget)> { // UNUSED?
+    //     let mut kvs = Vec::new();
+    //     for mt_proof in &self.mt_proofs {
+    //         kvs.push((mt_proof.key, mt_proof.value));
+    //     }
+    //     // TODO: when the slot is unused, do we force the kv to be (EMPTY, EMPTY), and then from
+    //     // it get a ValueOf((id, EMPTY), EMPTY)?  Or should we keep some boolean flags for unused
+    //     // slots and translate them to Statement::None instead?
+    //     kvs
+    // }
 
     pub fn pub_statements(&self) -> Vec<StatementTarget> {
         // TODO: Here we need to use the self.id in the ValueOf statements
         todo!()
     }
 
-    pub fn set_targets(
-        &self,
-        pw: &mut PartialWitness<F>,
-        input: &SignedPodVerifyInput,
-    ) -> Result<()> {
-        assert!(input.kvs.len() <= self.params.max_signed_pod_values);
-        let tree = MerkleTree::new(self.params.max_depth_mt_gadget, &input.kvs)?;
+    pub fn set_targets(&self, pw: &mut PartialWitness<F>, pod: &SignedPod) -> Result<()> {
+        // set the self.mt_proofs witness with the following order:
+        // - KEY_TYPE leaf proof
+        // - KEY_SIGNER leaf proof
+        // - rest of leaves
+        // - empty leaves (if needed)
+        let key_type_key = Value::from(hash_str(KEY_TYPE));
+        let key_signer_key = Value::from(hash_str(KEY_SIGNER));
+        let (key_type_value, proof) = pod.dict.prove(&key_type_key)?;
+        self.mt_proofs[0].set_targets(
+            pw,
+            true,
+            pod.dict.commitment(),
+            proof,
+            key_type_key,
+            key_type_value,
+        )?;
+        let (key_signer_value, proof) = pod.dict.prove(&key_signer_key)?;
+        self.mt_proofs[1].set_targets(
+            pw,
+            true,
+            pod.dict.commitment(),
+            proof,
+            key_signer_key,
+            key_signer_value,
+        )?;
 
-        // First handle the type entry, then the rest of the entries, and finally pad with
-        // repetitions of the type entry (which always exists)
-        let mut kvs = input.kvs.clone();
-        let key_type = Value::from(hash_str(KEY_TYPE));
-        let value_type = kvs.remove(&key_type).expect("KEY_TYPE");
+        // add the rest of leaves
+        let mut curr = 2; // since we already added key_type and key_signer
+        for (k, v) in pod.dict.iter() {
+            if *k == key_type_key || *k == key_signer_key {
+                // skip the key_type & key_signer leaves, since they have
+                // already been checked
+                continue;
+            }
 
-        // TODO manage unused merkleproof verifications (with selectors)
-        for (i, (k, v)) in iter::once((key_type, value_type))
-            .chain(kvs.into_iter().sorted_by_key(|kv| kv.0))
-            .chain(iter::repeat((key_type, value_type)))
-            .take(self.params.max_signed_pod_values)
-            .enumerate()
-        {
-            let (_, proof) = tree.prove(&k)?;
-            self.mt_proofs[i].set_targets(pw, true, tree.root(), proof, k, v)?;
+            let (obtained_v, proof) = pod.dict.prove(&k)?;
+            assert_eq!(obtained_v, *v); // sanity check
+
+            self.mt_proofs[curr].set_targets(pw, true, pod.dict.commitment(), proof, *k, *v)?;
+            curr += 1;
         }
+        // sanity check
+        assert!(curr <= self.params.max_signed_pod_values);
+
+        // add the empty leaves (if needed)
+        for i in curr..self.params.max_signed_pod_values {
+            let empty_proof = MerkleProof {
+                existence: true,
+                siblings: vec![],
+                other_leaf: None,
+            };
+            self.mt_proofs[i].set_targets(
+                pw,
+                false, // disable verification
+                pod.dict.commitment(),
+                empty_proof,
+                EMPTY_VALUE,
+                EMPTY_VALUE,
+            )?;
+        }
+
+        // get the signer pk
+        // let pk = PublicKey(pod.dict.get(&Value::from(hash_str(KEY_SIGNER)))?);
+        let pk = PublicKey(key_signer_value);
+        // the msg signed is the pod.id
+        let msg = Value::from(pod.id.0);
+
+        // set signature targets values
+        self.signature
+            .set_targets(pw, true, pk, msg, pod.signature.clone())?; // selector=false
+
+        // set the id target value
+        pw.set_hash_target(self.id, HashOut::from_vec(pod.id.0 .0.to_vec()))?;
+
         Ok(())
     }
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::backends::plonky2::mock::mainpod;
-    use crate::backends::plonky2::{basetypes::C, mock::mainpod::OperationArg};
-    use crate::middleware::{OperationType, PodId};
+pub mod tests {
     use plonky2::plonk::{circuit_builder::CircuitBuilder, circuit_data::CircuitConfig};
+
+    use super::*;
+    use crate::backends::plonky2::basetypes::C;
+    use crate::backends::plonky2::primitives::signature::SecretKey;
+    use crate::backends::plonky2::signedpod::{SignedPod, Signer};
+    use crate::middleware::F;
 
     #[test]
     fn test_signed_pod_verify() -> Result<()> {
-        let params = Params::default();
+        let mut params = Params::default();
+        // set max_signed_pod_values to 6, and we insert 3 leaves, so that the
+        // circuit has enough space for the 3 leaves plus the KEY_TYPE and
+        // KEY_SIGNER and one empty leave.
+        params.max_signed_pod_values = 6;
 
+        // prepare a signedpod
+        let mut pod = crate::frontend::SignedPodBuilder::new(&params);
+        pod.insert("idNumber", "4242424242");
+        pod.insert("dateOfBirth", 1169909384);
+        pod.insert("socialSecurityNumber", "G2121210");
+        let sk = SecretKey::new();
+        let mut signer = Signer(sk);
+        let pod = pod.sign(&mut signer).unwrap();
+        let signed_pod = pod.pod.into_any().downcast::<SignedPod>().unwrap();
+
+        // use the pod in the circuit
         let config = CircuitConfig::standard_recursion_config();
         let mut builder = CircuitBuilder::<F, D>::new(config);
+        let mut pw = PartialWitness::<F>::new();
 
+        // build the circuit logic
         let signed_pod_verify = SignedPodVerifyGadget { params }.eval(&mut builder)?;
 
-        let mut pw = PartialWitness::<F>::new();
-        let kvs = [
-            (
-                Value::from(hash_str(KEY_TYPE)),
-                Value::from(PodType::MockSigned),
-            ),
-            (Value::from(hash_str("foo")), Value::from(42)),
-        ]
-        .into();
-        let input = SignedPodVerifyInput { kvs };
-        signed_pod_verify.set_targets(&mut pw, &input)?;
+        // set the signed_pod as target values for the circuit
+        signed_pod_verify.set_targets(&mut pw, &signed_pod)?;
 
         // generate & verify proof
         let data = builder.build::<C>();

--- a/src/backends/plonky2/primitives/merkletree.rs
+++ b/src/backends/plonky2/primitives/merkletree.rs
@@ -9,7 +9,6 @@ use std::iter::IntoIterator;
 use crate::backends::counter;
 use crate::backends::plonky2::basetypes::{hash_fields, Hash, Value, EMPTY_HASH, F};
 
-// mod merkletree_circuit;
 pub use super::merkletree_circuit::*;
 
 /// Implements the MerkleTree specified at

--- a/src/backends/plonky2/primitives/merkletree_circuit.rs
+++ b/src/backends/plonky2/primitives/merkletree_circuit.rs
@@ -27,11 +27,11 @@ use crate::backends::plonky2::basetypes::{Hash, Value, D, EMPTY_HASH, EMPTY_VALU
 use crate::backends::plonky2::circuits::common::{CircuitBuilderPod, ValueTarget};
 use crate::backends::plonky2::primitives::merkletree::MerkleProof;
 
-/// `MerkleProofGate` allows to verify both proofs of existence and proofs
+/// `MerkleProofGadget` allows to verify both proofs of existence and proofs
 /// non-existence with the same circuit.
-/// If only proofs of existence are needed, use `MerkleProofExistenceGate`,
+/// If only proofs of existence are needed, use `MerkleProofExistenceGadget`,
 /// which requires less amount of constraints.
-pub struct MerkleProofGate {
+pub struct MerkleProofGadget {
     pub max_depth: usize,
 }
 
@@ -47,7 +47,7 @@ pub struct MerkleProofTarget {
     pub other_value: ValueTarget,
 }
 
-impl MerkleProofGate {
+impl MerkleProofGadget {
     /// creates the targets and defines the logic of the circuit
     pub fn eval(&self, builder: &mut CircuitBuilder<F, D>) -> Result<MerkleProofTarget> {
         // create the targets
@@ -179,7 +179,7 @@ impl MerkleProofTarget {
 
 /// `MerkleProofExistenceCircuit` allows to verify proofs of existence only. If
 /// proofs of non-existence are needed, use `MerkleProofCircuit`.
-pub struct MerkleProofExistenceGate {
+pub struct MerkleProofExistenceGadget {
     pub max_depth: usize,
 }
 
@@ -191,7 +191,7 @@ pub struct MerkleProofExistenceTarget {
     pub siblings: Vec<HashOutTarget>,
 }
 
-impl MerkleProofExistenceGate {
+impl MerkleProofExistenceGadget {
     /// creates the targets and defines the logic of the circuit
     pub fn eval(&self, builder: &mut CircuitBuilder<F, D>) -> Result<MerkleProofExistenceTarget> {
         // create the targets
@@ -486,7 +486,7 @@ pub mod tests {
         let mut builder = CircuitBuilder::<F, D>::new(config);
         let mut pw = PartialWitness::<F>::new();
 
-        let targets = MerkleProofGate { max_depth }.eval(&mut builder)?;
+        let targets = MerkleProofGadget { max_depth }.eval(&mut builder)?;
         targets.set_targets(&mut pw, existence, tree.root(), proof, key, value)?;
 
         // generate & verify proof
@@ -525,7 +525,7 @@ pub mod tests {
         let mut builder = CircuitBuilder::<F, D>::new(config);
         let mut pw = PartialWitness::<F>::new();
 
-        let targets = MerkleProofExistenceGate { max_depth }.eval(&mut builder)?;
+        let targets = MerkleProofExistenceGadget { max_depth }.eval(&mut builder)?;
         targets.set_targets(&mut pw, tree.root(), proof, key, value)?;
 
         // generate & verify proof
@@ -592,7 +592,7 @@ pub mod tests {
         let mut builder = CircuitBuilder::<F, D>::new(config);
         let mut pw = PartialWitness::<F>::new();
 
-        let targets = MerkleProofGate { max_depth }.eval(&mut builder)?;
+        let targets = MerkleProofGadget { max_depth }.eval(&mut builder)?;
         targets.set_targets(&mut pw, proof.existence, tree.root(), proof, key, value)?;
 
         // generate & verify proof
@@ -633,7 +633,7 @@ pub mod tests {
         let mut builder = CircuitBuilder::<F, D>::new(config);
         let mut pw = PartialWitness::<F>::new();
 
-        let targets = MerkleProofGate { max_depth }.eval(&mut builder)?;
+        let targets = MerkleProofGadget { max_depth }.eval(&mut builder)?;
         targets.set_targets(&mut pw, true, tree2.root(), proof, key, value)?;
 
         // generate proof, expecting it to fail (since we're using the wrong

--- a/src/backends/plonky2/primitives/merkletree_circuit.rs
+++ b/src/backends/plonky2/primitives/merkletree_circuit.rs
@@ -37,20 +37,23 @@ pub struct MerkleProofGadget {
 
 pub struct MerkleProofTarget {
     max_depth: usize,
-    pub root: HashOutTarget,
-    pub key: ValueTarget,
-    pub value: ValueTarget,
-    pub existence: BoolTarget,
-    pub siblings: Vec<HashOutTarget>,
-    pub case_ii_selector: BoolTarget, // for case ii)
-    pub other_key: ValueTarget,
-    pub other_value: ValueTarget,
+    // `enabled` determines if the merkleproof verification is enabled
+    pub(crate) enabled: BoolTarget,
+    pub(crate) root: HashOutTarget,
+    pub(crate) key: ValueTarget,
+    pub(crate) value: ValueTarget,
+    pub(crate) existence: BoolTarget,
+    pub(crate) siblings: Vec<HashOutTarget>,
+    pub(crate) case_ii_selector: BoolTarget, // for case ii)
+    pub(crate) other_key: ValueTarget,
+    pub(crate) other_value: ValueTarget,
 }
 
 impl MerkleProofGadget {
     /// creates the targets and defines the logic of the circuit
     pub fn eval(&self, builder: &mut CircuitBuilder<F, D>) -> Result<MerkleProofTarget> {
-        // create the targets
+        let enabled = builder.add_virtual_bool_target_safe();
+        let root = builder.add_virtual_hash();
         let key = builder.add_virtual_value();
         let value = builder.add_virtual_value();
         // from proof struct:
@@ -115,12 +118,24 @@ impl MerkleProofGadget {
         // compute the root for the given siblings and the computed leaf_hash
         // (this is for the three cases (existence, non-existence case i, and
         // non-existence case ii).
-        // This root will be assigned in the `set_targets` method, and it is a
-        // public input.
-        let root = compute_root_from_leaf(self.max_depth, builder, &path, &leaf_hash, &siblings)?;
+        let obtained_root =
+            compute_root_from_leaf(self.max_depth, builder, &path, &leaf_hash, &siblings)?;
+
+        // check that obtained_root==root (from inputs), when enabled==true
+        let zero = builder.zero();
+        let expected_root: Vec<Target> = (0..4)
+            .map(|j| builder.select(enabled, root.elements[j], zero))
+            .collect();
+        let computed_root: Vec<Target> = (0..4)
+            .map(|j| builder.select(enabled, obtained_root.elements[j], zero))
+            .collect();
+        for j in 0..4 {
+            builder.connect(computed_root[j], expected_root[j]);
+        }
 
         Ok(MerkleProofTarget {
             max_depth: self.max_depth,
+            enabled,
             existence,
             root,
             siblings,
@@ -138,12 +153,15 @@ impl MerkleProofTarget {
     pub fn set_targets(
         &self,
         pw: &mut PartialWitness<F>,
+        // `enabled` determines if the merkleproof verification is enabled
+        enabled: bool,
         existence: bool,
         root: Hash,
         proof: MerkleProof,
         key: Value,
         value: Value,
     ) -> Result<()> {
+        pw.set_bool_target(self.enabled, enabled)?;
         pw.set_hash_target(self.root, HashOut::from_vec(root.0.to_vec()))?;
         pw.set_target_arr(&self.key.elements, &key.0)?;
         pw.set_target_arr(&self.value.elements, &value.0)?;
@@ -185,16 +203,19 @@ pub struct MerkleProofExistenceGadget {
 
 pub struct MerkleProofExistenceTarget {
     max_depth: usize,
-    pub root: HashOutTarget,
-    pub key: ValueTarget,
-    pub value: ValueTarget,
-    pub siblings: Vec<HashOutTarget>,
+    // `enabled` determines if the merkleproof verification is enabled
+    pub(crate) enabled: BoolTarget,
+    pub(crate) root: HashOutTarget,
+    pub(crate) key: ValueTarget,
+    pub(crate) value: ValueTarget,
+    pub(crate) siblings: Vec<HashOutTarget>,
 }
 
 impl MerkleProofExistenceGadget {
     /// creates the targets and defines the logic of the circuit
     pub fn eval(&self, builder: &mut CircuitBuilder<F, D>) -> Result<MerkleProofExistenceTarget> {
-        // create the targets
+        let enabled = builder.add_virtual_bool_target_safe();
+        let root = builder.add_virtual_hash();
         let key = builder.add_virtual_value();
         let value = builder.add_virtual_value();
         // siblings are padded till max_depth length
@@ -207,12 +228,24 @@ impl MerkleProofExistenceGadget {
         let path = keypath_target(self.max_depth, builder, &key);
 
         // compute the root for the given siblings and the computed leaf_hash.
-        // This root will be assigned in the `set_targets` method, and it is a
-        // public input.
-        let root = compute_root_from_leaf(self.max_depth, builder, &path, &leaf_hash, &siblings)?;
+        let obtained_root =
+            compute_root_from_leaf(self.max_depth, builder, &path, &leaf_hash, &siblings)?;
+
+        // check that obtained_root==root (from inputs), when enabled==true
+        let zero = builder.zero();
+        let expected_root: Vec<Target> = (0..4)
+            .map(|j| builder.select(enabled, root.elements[j], zero))
+            .collect();
+        let computed_root: Vec<Target> = (0..4)
+            .map(|j| builder.select(enabled, obtained_root.elements[j], zero))
+            .collect();
+        for j in 0..4 {
+            builder.connect(computed_root[j], expected_root[j]);
+        }
 
         Ok(MerkleProofExistenceTarget {
             max_depth: self.max_depth,
+            enabled,
             root,
             siblings,
             key,
@@ -226,11 +259,14 @@ impl MerkleProofExistenceTarget {
     pub fn set_targets(
         &self,
         pw: &mut PartialWitness<F>,
+        // `enabled` determines if the merkleproof verification is enabled
+        enabled: bool,
         root: Hash,
         proof: MerkleProof,
         key: Value,
         value: Value,
     ) -> Result<()> {
+        pw.set_bool_target(self.enabled, enabled)?;
         pw.set_hash_target(self.root, HashOut::from_vec(root.0.to_vec()))?;
         pw.set_target_arr(&self.key.elements, &key.0)?;
         pw.set_target_arr(&self.value.elements, &value.0)?;
@@ -487,7 +523,15 @@ pub mod tests {
         let mut pw = PartialWitness::<F>::new();
 
         let targets = MerkleProofGadget { max_depth }.eval(&mut builder)?;
-        targets.set_targets(&mut pw, existence, tree.root(), proof, key, value)?;
+        targets.set_targets(
+            &mut pw,
+            true, // verification enabled
+            existence,
+            tree.root(),
+            proof,
+            key,
+            value,
+        )?;
 
         // generate & verify proof
         let data = builder.build::<C>();
@@ -526,7 +570,7 @@ pub mod tests {
         let mut pw = PartialWitness::<F>::new();
 
         let targets = MerkleProofExistenceGadget { max_depth }.eval(&mut builder)?;
-        targets.set_targets(&mut pw, tree.root(), proof, key, value)?;
+        targets.set_targets(&mut pw, true, tree.root(), proof, key, value)?;
 
         // generate & verify proof
         let data = builder.build::<C>();
@@ -593,7 +637,15 @@ pub mod tests {
         let mut pw = PartialWitness::<F>::new();
 
         let targets = MerkleProofGadget { max_depth }.eval(&mut builder)?;
-        targets.set_targets(&mut pw, proof.existence, tree.root(), proof, key, value)?;
+        targets.set_targets(
+            &mut pw,
+            true, // verification enabled
+            proof.existence,
+            tree.root(),
+            proof,
+            key,
+            value,
+        )?;
 
         // generate & verify proof
         let data = builder.build::<C>();
@@ -634,12 +686,43 @@ pub mod tests {
         let mut pw = PartialWitness::<F>::new();
 
         let targets = MerkleProofGadget { max_depth }.eval(&mut builder)?;
-        targets.set_targets(&mut pw, true, tree2.root(), proof, key, value)?;
+        targets.set_targets(
+            &mut pw,
+            true, // verification enabled
+            true, // proof of existence
+            tree2.root(),
+            proof.clone(),
+            key,
+            value,
+        )?;
 
         // generate proof, expecting it to fail (since we're using the wrong
         // root)
         let data = builder.build::<C>();
         assert!(data.prove(pw).is_err());
+
+        // Now generate a new proof, using `enabled=false`, which should pass the verification
+        // despite containing 'wrong' witness.
+        let config = CircuitConfig::standard_recursion_config();
+        let mut builder = CircuitBuilder::<F, D>::new(config);
+        let mut pw = PartialWitness::<F>::new();
+
+        let targets = MerkleProofGadget { max_depth }.eval(&mut builder)?;
+        targets.set_targets(
+            &mut pw,
+            false, // verification disabled
+            true,  // proof of existence
+            tree2.root(),
+            proof,
+            key,
+            value,
+        )?;
+
+        // generate proof, should pass despite using wrong witness, since the
+        // `enabled=false`
+        let data = builder.build::<C>();
+        let proof = data.prove(pw)?;
+        data.verify(proof)?;
 
         Ok(())
     }

--- a/src/backends/plonky2/primitives/mod.rs
+++ b/src/backends/plonky2/primitives/mod.rs
@@ -1,3 +1,4 @@
 pub mod merkletree;
 mod merkletree_circuit;
 pub mod signature;
+mod signature_circuit;

--- a/src/backends/plonky2/primitives/signature.rs
+++ b/src/backends/plonky2/primitives/signature.rs
@@ -22,6 +22,8 @@ use plonky2::{
 
 use crate::backends::plonky2::basetypes::{Proof, Value, C, D, F, VALUE_SIZE};
 
+pub use super::signature_circuit::*;
+
 lazy_static! {
     /// Signature prover parameters
     pub static ref PP: ProverParams = Signature::prover_params().unwrap();

--- a/src/backends/plonky2/primitives/signature.rs
+++ b/src/backends/plonky2/primitives/signature.rs
@@ -23,7 +23,9 @@ use plonky2::{
 use crate::backends::plonky2::basetypes::{Proof, Value, C, D, F, VALUE_SIZE};
 
 lazy_static! {
+    /// Signature prover parameters
     pub static ref PP: ProverParams = Signature::prover_params().unwrap();
+    /// Signature verifier parameters
     pub static ref VP: VerifierParams = Signature::verifier_params().unwrap();
 }
 

--- a/src/backends/plonky2/primitives/signature_circuit.rs
+++ b/src/backends/plonky2/primitives/signature_circuit.rs
@@ -29,7 +29,7 @@ lazy_static! {
 }
 
 pub struct SignatureVerifyGadget {}
-pub struct SignatureTarget {
+pub struct SignatureVerifyTarget {
     // verifier_data of the SignatureInternalCircuit
     verifier_data_targ: VerifierCircuitTarget,
     selector: BoolTarget,
@@ -53,7 +53,7 @@ impl SignatureVerifyGadget {
 
 impl SignatureVerifyGadget {
     /// creates the targets and defines the logic of the circuit
-    pub fn eval(&self, builder: &mut CircuitBuilder<F, D>) -> Result<SignatureTarget> {
+    pub fn eval(&self, builder: &mut CircuitBuilder<F, D>) -> Result<SignatureVerifyTarget> {
         let selector = builder.add_virtual_bool_target_safe();
 
         let common_data = super::signature::VP.0.common.clone();
@@ -81,7 +81,7 @@ impl SignatureVerifyGadget {
             &common_data,
         );
 
-        Ok(SignatureTarget {
+        Ok(SignatureVerifyTarget {
             selector,
             proof: proof_targ,
             pk: pk_targ,
@@ -91,7 +91,7 @@ impl SignatureVerifyGadget {
     }
 }
 
-impl SignatureTarget {
+impl SignatureVerifyTarget {
     /// assigns the given values to the targets
     pub fn set_targets(
         &self,

--- a/src/backends/plonky2/primitives/signature_circuit.rs
+++ b/src/backends/plonky2/primitives/signature_circuit.rs
@@ -24,11 +24,11 @@ use crate::backends::plonky2::circuits::common::{CircuitBuilderPod, ValueTarget}
 use crate::backends::plonky2::primitives::signature::{PublicKey, Signature};
 
 lazy_static! {
-    // SignatureGate VerifierCircuitData
-    pub static ref S_VD: VerifierCircuitData<F,C,D> = SignatureGate::verifier_data().unwrap();
+    /// SignatureVerifyGadget VerifierCircuitData
+    pub static ref S_VD: VerifierCircuitData<F,C,D> = SignatureVerifyGadget::verifier_data().unwrap();
 }
 
-pub struct SignatureGate {}
+pub struct SignatureVerifyGadget {}
 pub struct SignatureTarget {
     // verifier_data of the SignatureInternalCircuit
     verifier_data_targ: VerifierCircuitTarget,
@@ -37,19 +37,19 @@ pub struct SignatureTarget {
     proof: ProofWithPublicInputsTarget<D>,
 }
 
-impl SignatureGate {
+impl SignatureVerifyGadget {
     pub fn verifier_data() -> Result<VerifierCircuitData<F, C, D>> {
         // notice that we use the 'zk' config
         let config = CircuitConfig::standard_recursion_zk_config();
         let mut builder = CircuitBuilder::<F, D>::new(config);
-        let circuit = SignatureGate {}.eval(&mut builder)?;
+        let circuit = SignatureVerifyGadget {}.eval(&mut builder)?;
 
         let circuit_data = builder.build::<C>();
         Ok(circuit_data.verifier_data())
     }
 }
 
-impl SignatureGate {
+impl SignatureVerifyGadget {
     /// creates the targets and defines the logic of the circuit
     pub fn eval(&self, builder: &mut CircuitBuilder<F, D>) -> Result<SignatureTarget> {
         let selector = builder.add_virtual_bool_target_safe();
@@ -63,9 +63,10 @@ impl SignatureGate {
 
         let proof_targ = builder.add_virtual_proof_with_pis(&common_data);
         builder.verify_proof::<C>(&proof_targ, &verifier_data_targ, &common_data);
-        // NOTE: we would use the `conditional_verify...` method, but since we're using the
-        // `standard_recursion_zk_config` (with zk), internally it fails to generate the
-        // `dummy_circuit`. So for the moment we use `verify_proof` (not-conditional).
+        // NOTE: we would use the `conditional_verify_proof_or_dummy` method,
+        // but since we're using the `standard_recursion_zk_config` (with zk),
+        // internally it fails to generate the `dummy_circuit`. So for the
+        // moment we use `verify_proof` (not-conditional).
         // builder.conditionally_verify_proof_or_dummy::<C>(
         //     selector,
         //     &proof_targ,
@@ -138,7 +139,7 @@ pub mod tests {
         let mut builder = CircuitBuilder::<F, D>::new(config);
         let mut pw = PartialWitness::<F>::new();
 
-        let targets = SignatureGate {}.eval(&mut builder)?;
+        let targets = SignatureVerifyGadget {}.eval(&mut builder)?;
         targets.set_targets(&mut pw, true, pk, msg, sig)?;
 
         // generate & verify proof

--- a/src/backends/plonky2/primitives/signature_circuit.rs
+++ b/src/backends/plonky2/primitives/signature_circuit.rs
@@ -1,0 +1,157 @@
+#![allow(unused)]
+use anyhow::Result;
+use lazy_static::lazy_static;
+use plonky2::{
+    field::types::Field,
+    hash::{
+        hash_types::{HashOut, HashOutTarget},
+        poseidon::PoseidonHash,
+    },
+    iop::{
+        target::{BoolTarget, Target},
+        witness::{PartialWitness, WitnessWrite},
+    },
+    plonk::circuit_builder::CircuitBuilder,
+    plonk::circuit_data::{
+        CircuitConfig, CircuitData, ProverCircuitData, VerifierCircuitData, VerifierCircuitTarget,
+    },
+    plonk::config::Hasher,
+    plonk::proof::{ProofWithPublicInputs, ProofWithPublicInputsTarget},
+};
+
+use crate::backends::plonky2::basetypes::{Hash, Value, C, D, EMPTY_HASH, EMPTY_VALUE, F};
+use crate::backends::plonky2::circuits::common::{CircuitBuilderPod, ValueTarget};
+use crate::backends::plonky2::primitives::signature::{PublicKey, Signature};
+
+lazy_static! {
+    // SignatureGate VerifierCircuitData
+    pub static ref S_VD: VerifierCircuitData<F,C,D> = SignatureGate::verifier_data().unwrap();
+}
+
+pub struct SignatureGate {}
+pub struct SignatureTarget {
+    // verifier_data of the SignatureInternalCircuit
+    verifier_data_targ: VerifierCircuitTarget,
+    selector: BoolTarget,
+    pk: ValueTarget,
+    proof: ProofWithPublicInputsTarget<D>,
+}
+
+impl SignatureGate {
+    pub fn verifier_data() -> Result<VerifierCircuitData<F, C, D>> {
+        // notice that we use the 'zk' config
+        let config = CircuitConfig::standard_recursion_zk_config();
+        let mut builder = CircuitBuilder::<F, D>::new(config);
+        let circuit = SignatureGate {}.eval(&mut builder)?;
+
+        let circuit_data = builder.build::<C>();
+        Ok(circuit_data.verifier_data())
+    }
+}
+
+impl SignatureGate {
+    /// creates the targets and defines the logic of the circuit
+    pub fn eval(&self, builder: &mut CircuitBuilder<F, D>) -> Result<SignatureTarget> {
+        let selector = builder.add_virtual_bool_target_safe();
+
+        let common_data = super::signature::VP.0.common.clone();
+
+        let pk_targ = builder.add_virtual_value();
+
+        let verifier_data_targ =
+            builder.add_virtual_verifier_data(common_data.config.fri_config.cap_height);
+
+        let proof_targ = builder.add_virtual_proof_with_pis(&common_data);
+        builder.verify_proof::<C>(&proof_targ, &verifier_data_targ, &common_data);
+        // NOTE: we would use the `conditional_verify...` method, but since we're using the
+        // `standard_recursion_zk_config` (with zk), internally it fails to generate the
+        // `dummy_circuit`. So for the moment we use `verify_proof` (not-conditional).
+        // builder.conditionally_verify_proof_or_dummy::<C>(
+        //     selector,
+        //     &proof_targ,
+        //     &verifier_data_targ,
+        //     &common_data,
+        // )?;
+
+        Ok(SignatureTarget {
+            selector,
+            proof: proof_targ,
+            pk: pk_targ,
+            verifier_data_targ,
+        })
+    }
+}
+
+impl SignatureTarget {
+    /// assigns the given values to the targets
+    pub fn set_targets(
+        &self,
+        pw: &mut PartialWitness<F>,
+        selector: bool,
+        pk: PublicKey,
+        msg: Value,
+        signature: Signature,
+    ) -> Result<()> {
+        pw.set_bool_target(self.selector, selector)?;
+        pw.set_target_arr(&self.pk.elements, &pk.0 .0)?;
+
+        // note that this hash is checked again in-circuit at the `SignatureInternalCircuit`
+        let s = Value(PoseidonHash::hash_no_pad(&[pk.0 .0, msg.0].concat()).elements);
+        let public_inputs: Vec<F> = [pk.0 .0, msg.0, s.0].concat();
+
+        pw.set_proof_with_pis_target(
+            &self.proof,
+            &ProofWithPublicInputs {
+                proof: signature.0,
+                public_inputs,
+            },
+        )?;
+
+        pw.set_verifier_data_target(
+            &self.verifier_data_targ,
+            &super::signature::VP.0.verifier_only,
+        )?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use crate::backends::plonky2::basetypes::Hash;
+    use crate::backends::plonky2::primitives::signature::SecretKey;
+
+    use super::*;
+
+    // Note: this test must be run with the `--release` flag.
+    #[test]
+    fn test_signature_gate() -> Result<()> {
+        // generate a valid signature
+        let sk = SecretKey::new();
+        let pk = sk.public_key();
+        let msg = Value::from(42);
+        let sig = sk.sign(msg)?;
+        sig.verify(&pk, msg)?;
+
+        // circuit
+        let config = CircuitConfig::standard_recursion_zk_config();
+        let mut builder = CircuitBuilder::<F, D>::new(config);
+        let mut pw = PartialWitness::<F>::new();
+
+        let targets = SignatureGate {}.eval(&mut builder)?;
+        targets.set_targets(&mut pw, true, pk, msg, sig)?;
+
+        // generate & verify proof
+        let data = builder.build::<C>();
+        let proof = data.prove(pw)?;
+        data.verify(proof.clone())?;
+
+        // verify the proof with the lazy_static loaded verifier_data (S_VD)
+        S_VD.verify(ProofWithPublicInputs {
+            proof: proof.proof.clone(),
+            public_inputs: vec![],
+        })?;
+
+        Ok(())
+    }
+}

--- a/src/backends/plonky2/primitives/signature_circuit.rs
+++ b/src/backends/plonky2/primitives/signature_circuit.rs
@@ -34,7 +34,8 @@ pub struct SignatureVerifyGadget {}
 pub struct SignatureVerifyTarget {
     // verifier_data of the SignatureInternalCircuit
     verifier_data_targ: VerifierCircuitTarget,
-    selector: BoolTarget,
+    // `enabled` determines if the signature verification is enabled
+    enabled: BoolTarget,
     pk: ValueTarget,
     msg: ValueTarget,
     // proof of the SignatureInternalCircuit (=signature::Signature.0)
@@ -57,7 +58,7 @@ impl SignatureVerifyGadget {
 impl SignatureVerifyGadget {
     /// creates the targets and defines the logic of the circuit
     pub fn eval(&self, builder: &mut CircuitBuilder<F, D>) -> Result<SignatureVerifyTarget> {
-        let selector = builder.add_virtual_bool_target_safe();
+        let enabled = builder.add_virtual_bool_target_safe();
 
         let common_data = super::signature::VP.0.common.clone();
 
@@ -94,7 +95,7 @@ impl SignatureVerifyGadget {
         // (signature::DUMMY_PROOF).
         let dummy_proof_targ = builder.add_virtual_proof_with_pis(&common_data);
         builder.conditionally_verify_proof::<C>(
-            selector,
+            enabled,
             &proof_targ,
             &verifier_data_targ,
             &dummy_proof_targ,
@@ -104,7 +105,7 @@ impl SignatureVerifyGadget {
 
         Ok(SignatureVerifyTarget {
             verifier_data_targ,
-            selector,
+            enabled,
             pk: pk_targ,
             msg: msg_targ,
             proof: proof_targ,
@@ -118,12 +119,12 @@ impl SignatureVerifyTarget {
     pub fn set_targets(
         &self,
         pw: &mut PartialWitness<F>,
-        selector: bool,
+        enabled: bool,
         pk: PublicKey,
         msg: Value,
         signature: Signature,
     ) -> Result<()> {
-        pw.set_bool_target(self.selector, selector)?;
+        pw.set_bool_target(self.enabled, enabled)?;
         pw.set_target_arr(&self.pk.elements, &pk.0 .0)?;
         pw.set_target_arr(&self.msg.elements, &msg.0)?;
 
@@ -215,20 +216,20 @@ pub mod tests {
         let mut builder = CircuitBuilder::<F, D>::new(config);
         let mut pw = PartialWitness::<F>::new();
         let targets = SignatureVerifyGadget {}.eval(&mut builder)?;
-        targets.set_targets(&mut pw, true, pk.clone(), msg, sig.clone())?; // selector=true
+        targets.set_targets(&mut pw, true, pk.clone(), msg, sig.clone())?; // enabled=true
 
         // generate proof, and expect it to fail
         let data = builder.build::<C>();
         assert!(data.prove(pw).is_err()); // expect prove to fail
 
         // build the circuit again, but now disable the selector that disables
-        // the in-circuit signature verification
+        // the in-circuit signature verification (ie. `enabled=false`)
         let config = CircuitConfig::standard_recursion_zk_config();
         let mut builder = CircuitBuilder::<F, D>::new(config);
         let mut pw = PartialWitness::<F>::new();
 
         let targets = SignatureVerifyGadget {}.eval(&mut builder)?;
-        targets.set_targets(&mut pw, false, pk, msg, sig)?; // selector=false
+        targets.set_targets(&mut pw, false, pk, msg, sig)?; // enabled=false
 
         // generate & verify proof
         let data = builder.build::<C>();

--- a/src/backends/plonky2/primitives/signature_circuit.rs
+++ b/src/backends/plonky2/primitives/signature_circuit.rs
@@ -35,9 +35,9 @@ pub struct SignatureVerifyTarget {
     // verifier_data of the SignatureInternalCircuit
     verifier_data_targ: VerifierCircuitTarget,
     // `enabled` determines if the signature verification is enabled
-    enabled: BoolTarget,
-    pk: ValueTarget,
-    msg: ValueTarget,
+    pub(crate) enabled: BoolTarget,
+    pub(crate) pk: ValueTarget,
+    pub(crate) msg: ValueTarget,
     // proof of the SignatureInternalCircuit (=signature::Signature.0)
     proof: ProofWithPublicInputsTarget<D>,
     dummy_proof: ProofWithPublicInputsTarget<D>,

--- a/src/backends/plonky2/signedpod.rs
+++ b/src/backends/plonky2/signedpod.rs
@@ -11,7 +11,7 @@ use crate::middleware::{
 
 use super::primitives::signature::{PublicKey, SecretKey, Signature};
 
-pub struct Signer(SecretKey);
+pub struct Signer(pub SecretKey);
 
 impl PodSigner for Signer {
     fn sign(&mut self, _params: &Params, kvs: &HashMap<Hash, Value>) -> Result<Box<dyn Pod>> {
@@ -34,9 +34,9 @@ impl PodSigner for Signer {
 
 #[derive(Clone, Debug)]
 pub struct SignedPod {
-    id: PodId,
-    signature: Signature,
-    dict: Dictionary,
+    pub id: PodId,
+    pub signature: Signature,
+    pub dict: Dictionary,
 }
 
 impl Pod for SignedPod {

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -105,8 +105,8 @@ pub struct Params {
     // in a custom predicate
     pub max_custom_predicate_arity: usize,
     pub max_custom_batch_size: usize,
-    // maximum depth for merkle tree gates
-    pub max_depth_mt_gate: usize,
+    // maximum depth for merkle tree gadget
+    pub max_depth_mt_gadget: usize,
 }
 
 impl Default for Params {
@@ -121,7 +121,7 @@ impl Default for Params {
             max_operation_args: 5,
             max_custom_predicate_arity: 5,
             max_custom_batch_size: 5,
-            max_depth_mt_gate: 32,
+            max_depth_mt_gadget: 32,
         }
     }
 }


### PR DESCRIPTION
This PR implements the SignedPod verification gadget `SignedPodVerifyGadget`; it depends on #167, and resolves #157.

- add boolean selector to the MerkleProofGadget, to allow skipping proof verifications when all the slots are not used (eg. in the SignedPod circuit)
- move existing signedpod's circuits draft to its own file
- implement SignedPodVerify circuit