### PR TITLE
complete full zukyc example doc

### DIFF
--- a/book/src/examples.md
+++ b/book/src/examples.md
@@ -60,6 +60,10 @@ statement loan_check(receiver: PubKey):
          - gt(paystub.issue_date, NOW_MINUS_7D) # issue_date is less than 7d old
          # Annual salary is at least $20,000
          - gt(paystub.annual_salary, 20000)
+         # Private key knowledge
+         - hash(0, sk, gov_id.pk)
+         # Nullifier
+         - hash("ZooKyc", sk, nullifier)
 ```
 
 ## ZuKYC (simplified for P1)

--- a/book/src/operations.md
+++ b/book/src/operations.md
@@ -23,6 +23,7 @@ The following table summarises the natively-supported operations:
 | 13   | `SumOf`               | `s1`, `s2`, `s3`    | `s1 = ValueOf(ak1, value1)`, `s2 = ValueOf(ak2, value2)`, `s3 = ValueOf(ak3, value3)`, `value1 = value2 + value3`     | `SumOf(ak1, ak2, ak3)`                                         |
 | 14   | `ProductOf`           | `s1`, `s2`, `s3`    | `s1 = ValueOf(ak1, value1)`, `s2 = ValueOf(ak2, value2)`, `s3 = ValueOf(ak3, value3)`, `value1 = value2 * value3`     | `ProductOf(ak1, ak2, ak3)`                                     |
 | 15   | `MaxOf`               | `s1`, `s2`, `s3`    | `s1 = ValueOf(ak1, value1)`, `s2 = ValueOf(ak2, value2)`, `s3 = ValueOf(ak3, value3)`, `value1 = max(value2, value3)` | `MaxOf(ak1, ak2, ak3)`                                         |
+| 16   | `HashOf`              | `s1`, `s2`, `s3`    | `s1 = ValueOf(ak1, value1)`, `s2 = ValueOf(ak2, value2)`, `s3 = ValueOf(ak3, value3)`, `value1 = hash(value2, value3)`| `HashOf(ak1, ak2, ak3)`                                        |
 
 <!-- NOTE: should we 'uniformize' the names? eg. currently we have `EntryGt` and `GtToNEq` -->
 

--- a/book/src/statements.md
+++ b/book/src/statements.md
@@ -35,6 +35,7 @@ The following table summarises the natively-supported statements, where we write
 | 8    | `SumOf`       | `ak1`, `ak2`, `ak3` | `value_of(ak1) = value_of(ak2) + value_of(ak3)`                   |
 | 9    | `ProductOf`   | `ak1`, `ak2`, `ak3` | `value_of(ak1) = value_of(ak2) * value_of(ak3)`                   |
 | 10   | `MaxOf`       | `ak1`, `ak2`, `ak3` | `value_of(ak1) = max(value_of(ak2), value_of(ak3))`               |
+| 11   | `HashOf`      | `ak1`, `ak2`, `ak3` | `value_of(ak1) = hash(value_of(ak2), value_of(ak3))`              |
 
 ### Frontend statements
 
@@ -62,6 +63,8 @@ AnchoredKey::Integer)
 ProductOf(prod: AnchoredKey::Integer, arg1: AnchoredKey::Integer, arg2: AnchoredKey::Integer)
 
 MaxOf(max: AnchoredKey::Integer, arg1: AnchoredKey::Integer, arg2: AnchoredKey::Integer)
+
+HashOf(ak1: AnchoredKey::Raw, arg1: AnchoredKey::Raw, arg2: AnchoredKey::Raw)
 ```
 
 The following statements relate to Merkle trees and compound types; they are explained in detail on a [separate page](./merklestatements.md).
@@ -95,10 +98,6 @@ ContainsValue(root: AnchoredKey::Array, value: AnchoredKey)
 
 
 In the future, we may also reserve statement IDs for "precompiles" such as:
-```
-PoseidonHashOf(A.hash, B.preimage) // perhaps a hash_of predicate can be parametrized by an enum representing the hash scheme; rather than having a bunch of specific things like SHA256_hash_of and poseidon_hash_of etc.
-```
-
 ```
 EcdsaPrivToPubOf(A.pubkey, B.privkey)
 ```


### PR DESCRIPTION
Document the missing parts of the full ZuKYC example.

This requires defining the `Hash` native predicate and `HashOf` native operation.
The public key derivation is just a hash following the current spec of our signature scheme.  This will change to something more complex if we change the signature scheme, and in that case I think we should rely on an introductory gadget for the key derivation.

I've defined the Hash as taking 2 values so that we can create chains to absorb data of dynamic size.