### PR TITLE
chore(qol): add rust-analyzer.toml

### DIFF
--- a/rust-analyzer.toml
+++ b/rust-analyzer.toml
@@ -1,1 +1,1 @@
-imports.prefix = "by_crate"
+imports.prefix = "crate"

--- a/rust-analyzer.toml
+++ b/rust-analyzer.toml
@@ -1,0 +1,1 @@
+imports.prefix = "by_crate"


### PR DESCRIPTION
This PR adds a `rust-analyzer.toml` which defaults to absolute imports in LSP-capable editors.