### PR TITLE
Padding in set target

### DIFF
--- a/src/backends/plonky2/circuits/mainpod.rs
+++ b/src/backends/plonky2/circuits/mainpod.rs
@@ -707,12 +707,11 @@ mod tests {
         );
 
         let merkle_proofs = vec![MerkleClaimAndProof::new(
-            params.max_depth_mt_gadget,
             Hash::from(root.raw()),
             key,
             None,
-            &no_key_pf,
-        )?];
+            no_key_pf,
+        )];
         let prev_statements = vec![root_st, key_st];
         operation_verify(st, op, prev_statements, merkle_proofs.clone())?;
 

--- a/src/backends/plonky2/circuits/mainpod.rs
+++ b/src/backends/plonky2/circuits/mainpod.rs
@@ -492,11 +492,15 @@ impl MainPodVerifyTarget {
             self.statements[i].set_targets(pw, &self.params, st)?;
             self.operations[i].set_targets(pw, &self.params, op)?;
         }
-        assert_eq!(input.merkle_proofs.len(), self.params.max_merkle_proofs);
+        assert!(input.merkle_proofs.len() <= self.params.max_merkle_proofs);
         for (i, mp) in input.merkle_proofs.iter().enumerate() {
-            assert_eq!(mp.proof.siblings.len(), self.params.max_depth_mt_gadget);
-            self.merkle_proofs[i].set_targets(pw, mp)?;
+            self.merkle_proofs[i].set_targets(pw, true, mp)?;
         }
+        let pad_mp = MerkleClaimAndProof::empty();
+        for i in input.merkle_proofs.len()..self.params.max_merkle_proofs {
+            self.merkle_proofs[i].set_targets(pw, false, &pad_mp)?;
+        }
+        // Padding
         Ok(())
     }
 }
@@ -579,7 +583,7 @@ mod tests {
         for (merkle_proof_target, merkle_proof) in
             merkle_proofs_target.iter().zip(merkle_proofs.iter())
         {
-            merkle_proof_target.set_targets(&mut pw, &merkle_proof)?
+            merkle_proof_target.set_targets(&mut pw, true, &merkle_proof)?
         }
 
         // generate & verify proof

--- a/src/backends/plonky2/circuits/mainpod.rs
+++ b/src/backends/plonky2/circuits/mainpod.rs
@@ -496,11 +496,11 @@ impl MainPodVerifyTarget {
         for (i, mp) in input.merkle_proofs.iter().enumerate() {
             self.merkle_proofs[i].set_targets(pw, true, mp)?;
         }
+        // Padding
         let pad_mp = MerkleClaimAndProof::empty();
         for i in input.merkle_proofs.len()..self.params.max_merkle_proofs {
             self.merkle_proofs[i].set_targets(pw, false, &pad_mp)?;
         }
-        // Padding
         Ok(())
     }
 }

--- a/src/backends/plonky2/circuits/signedpod.rs
+++ b/src/backends/plonky2/circuits/signedpod.rs
@@ -134,13 +134,7 @@ impl SignedPodVerifyTarget {
                 let (v, proof) = pod.dict.prove(k)?;
                 self.mt_proofs[i].set_targets(
                     pw,
-                    &MerkleClaimAndProof::new(
-                        self.params.max_depth_mt_gadget,
-                        pod.dict.commitment(),
-                        k.raw(),
-                        Some(v.raw()),
-                        &proof,
-                    )?,
+                    &MerkleClaimAndProof::new(pod.dict.commitment(), k.raw(), Some(v.raw()), proof),
                 )?;
                 Ok(v)
             })
@@ -160,13 +154,7 @@ impl SignedPodVerifyTarget {
 
             self.mt_proofs[curr].set_targets(
                 pw,
-                &MerkleClaimAndProof::new(
-                    self.params.max_depth_mt_gadget,
-                    pod.dict.commitment(),
-                    k.raw(),
-                    Some(v.raw()),
-                    &proof,
-                )?,
+                &MerkleClaimAndProof::new(pod.dict.commitment(), k.raw(), Some(v.raw()), proof),
             )?;
             curr += 1;
         }
@@ -174,7 +162,7 @@ impl SignedPodVerifyTarget {
         assert!(curr <= self.params.max_signed_pod_values);
 
         // add the proofs of empty leaves (if needed), till the max_signed_pod_values
-        let mut mp = MerkleClaimAndProof::empty(self.params.max_depth_mt_gadget);
+        let mut mp = MerkleClaimAndProof::empty();
         mp.root = pod.dict.commitment();
         for i in curr..self.params.max_signed_pod_values {
             self.mt_proofs[i].set_targets(pw, &mp)?;

--- a/src/backends/plonky2/circuits/signedpod.rs
+++ b/src/backends/plonky2/circuits/signedpod.rs
@@ -134,6 +134,7 @@ impl SignedPodVerifyTarget {
                 let (v, proof) = pod.dict.prove(k)?;
                 self.mt_proofs[i].set_targets(
                     pw,
+                    true,
                     &MerkleClaimAndProof::new(pod.dict.commitment(), k.raw(), Some(v.raw()), proof),
                 )?;
                 Ok(v)
@@ -154,6 +155,7 @@ impl SignedPodVerifyTarget {
 
             self.mt_proofs[curr].set_targets(
                 pw,
+                true,
                 &MerkleClaimAndProof::new(pod.dict.commitment(), k.raw(), Some(v.raw()), proof),
             )?;
             curr += 1;
@@ -165,7 +167,7 @@ impl SignedPodVerifyTarget {
         let mut mp = MerkleClaimAndProof::empty();
         mp.root = pod.dict.commitment();
         for i in curr..self.params.max_signed_pod_values {
-            self.mt_proofs[i].set_targets(pw, &mp)?;
+            self.mt_proofs[i].set_targets(pw, false, &mp)?;
         }
 
         // get the signer pk

--- a/src/backends/plonky2/mainpod/operation.rs
+++ b/src/backends/plonky2/mainpod/operation.rs
@@ -74,16 +74,15 @@ impl Operation {
             })
             .collect::<Result<Vec<_>>>()?;
         let deref_aux = match self.2 {
-            OperationAux::None => Ok(crate::middleware::OperationAux::None),
-            OperationAux::MerkleProofIndex(i) => merkle_proofs
-                .get(i)
-                .cloned()
-                .ok_or(anyhow!("Missing Merkle proof index {}", i))
-                .and_then(|mp| {
-                    mp.try_into()
-                        .map(crate::middleware::OperationAux::MerkleProof)
-                }),
-        }?;
+            OperationAux::None => crate::middleware::OperationAux::None,
+            OperationAux::MerkleProofIndex(i) => crate::middleware::OperationAux::MerkleProof(
+                merkle_proofs
+                    .get(i)
+                    .ok_or(anyhow!("Missing Merkle proof index {}", i))?
+                    .proof
+                    .clone(),
+            ),
+        };
         middleware::Operation::op(self.0.clone(), &deref_args, &deref_aux)
     }
 }

--- a/src/backends/plonky2/primitives/merkletree.rs
+++ b/src/backends/plonky2/primitives/merkletree.rs
@@ -262,8 +262,6 @@ impl MerkleProof {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct MerkleClaimAndProof {
-    /// `enabled` determines if the merkleproof verification is enabled
-    pub enabled: bool,
     pub root: Hash,
     pub key: RawValue,
     pub value: RawValue,
@@ -273,7 +271,6 @@ pub struct MerkleClaimAndProof {
 impl MerkleClaimAndProof {
     pub fn empty() -> Self {
         Self {
-            enabled: false,
             root: EMPTY_HASH,
             key: EMPTY_VALUE,
             value: EMPTY_VALUE,
@@ -286,7 +283,6 @@ impl MerkleClaimAndProof {
     }
     pub fn new(root: Hash, key: RawValue, value: Option<RawValue>, proof: MerkleProof) -> Self {
         Self {
-            enabled: true,
             root,
             key,
             value: value.unwrap_or(EMPTY_VALUE),
@@ -295,36 +291,9 @@ impl MerkleClaimAndProof {
     }
 }
 
-impl TryFrom<MerkleClaimAndProof> for MerkleProof {
-    type Error = anyhow::Error;
-    fn try_from(mp: MerkleClaimAndProof) -> Result<Self> {
-        if !mp.enabled {
-            return Err(anyhow!("Not a valid Merkle proof."));
-        }
-        Ok(MerkleProof {
-            existence: mp.proof.existence,
-            // Trim padding (if any).
-            siblings: mp
-                .proof
-                .siblings
-                .into_iter()
-                .rev()
-                .skip_while(|s| s == &EMPTY_HASH)
-                .collect::<Vec<_>>()
-                .into_iter()
-                .rev()
-                .collect(),
-            other_leaf: mp.proof.other_leaf,
-        })
-    }
-}
-
 impl fmt::Display for MerkleClaimAndProof {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match MerkleProof::try_from(self.clone()) {
-            Err(_) => write!(f, "∅"),
-            Ok(mp) => mp.fmt(f),
-        }
+        self.proof.fmt(f)
     }
 }
 

--- a/src/backends/plonky2/primitives/merkletree.rs
+++ b/src/backends/plonky2/primitives/merkletree.rs
@@ -1,10 +1,6 @@
 //! Module that implements the MerkleTree specified at
 //! https://0xparc.github.io/pod2/merkletree.html .
-use std::{
-    collections::HashMap,
-    fmt,
-    iter::{self, IntoIterator},
-};
+use std::{collections::HashMap, fmt, iter::IntoIterator};
 
 use anyhow::{anyhow, Result};
 use plonky2::field::types::Field;
@@ -271,12 +267,11 @@ pub struct MerkleClaimAndProof {
     pub root: Hash,
     pub key: RawValue,
     pub value: RawValue,
-    /// The siblings in this proof are padded to max_depth
     pub proof: MerkleProof,
 }
 
 impl MerkleClaimAndProof {
-    pub fn empty(max_depth: usize) -> Self {
+    pub fn empty() -> Self {
         Self {
             enabled: false,
             root: EMPTY_HASH,
@@ -284,42 +279,18 @@ impl MerkleClaimAndProof {
             value: EMPTY_VALUE,
             proof: MerkleProof {
                 existence: true,
-                siblings: iter::repeat(EMPTY_HASH).take(max_depth).collect(),
+                siblings: vec![],
                 other_leaf: None,
             },
         }
     }
-    pub fn new(
-        max_depth: usize,
-        root: Hash,
-        key: RawValue,
-        value: Option<RawValue>,
-        proof: &MerkleProof,
-    ) -> Result<Self> {
-        if proof.siblings.len() > max_depth {
-            Err(anyhow!(
-                "Number of siblings ({}) exceeds maximum depth ({})",
-                proof.siblings.len(),
-                max_depth
-            ))
-        } else {
-            Ok(Self {
-                enabled: true,
-                root,
-                key,
-                value: value.unwrap_or(EMPTY_VALUE),
-                proof: MerkleProof {
-                    existence: proof.existence,
-                    siblings: proof
-                        .siblings
-                        .iter()
-                        .cloned()
-                        .chain(iter::repeat(EMPTY_HASH))
-                        .take(max_depth)
-                        .collect(),
-                    other_leaf: proof.other_leaf,
-                },
-            })
+    pub fn new(root: Hash, key: RawValue, value: Option<RawValue>, proof: MerkleProof) -> Self {
+        Self {
+            enabled: true,
+            root,
+            key,
+            value: value.unwrap_or(EMPTY_VALUE),
+            proof,
         }
     }
 }

--- a/src/backends/plonky2/primitives/signature_circuit.rs
+++ b/src/backends/plonky2/primitives/signature_circuit.rs
@@ -176,7 +176,7 @@ pub mod tests {
     use crate::{backends::plonky2::primitives::signature::SecretKey, middleware::Hash};
 
     #[test]
-    fn test_signature_gadget() -> Result<()> {
+    fn test_signature_gadget_enabled() -> Result<()> {
         // generate a valid signature
         let sk = SecretKey::new_rand();
         let pk = sk.public_key();


### PR DESCRIPTION
Resolve https://github.com/0xPARC/pod2/issues/183 with a twist

The issue was about processing the witness outside of the `set_target` method, and that processing includes padding.  Part of this change was already started in https://github.com/0xPARC/pod2/pull/196

My original arguments for this pattern were:
- Make the code around the circuit as simple and transparent as possible so that we focus on the constraint logic
- Allow writing tests that use `set_targets` and directly set all the witness values

But once I started applying this pattern in the MainCircuit I noticed some issues.  Here are my counter arguments:
- The code looks more clean by doing the padding inside `set_targets` because it allows reusing existing types as arguments to `set_targets` (and those types are not yet padded).  It also allows having the padding logic in the circuit code, which makes sense because the circuit logic defines what is considered padding. 
- We're not doing any test that requires direct manipulation of witness values that would not be supported by `set_targets` methods that do some processing
  - If we had such requirement we could resolve it with: a `test_set_targets` method that does what the test needs.  Or setting the targets in the test by making the `FooTarget` fields `pub(crate)`

So for this reason I'm reverting the merkle tree padding outside of `set_target` from  https://github.com/0xPARC/pod2/pull/196

In this PR i also remove the `enabled` from `MerkleClaimAndProof` following the discussion https://github.com/0xPARC/pod2/pull/196#discussion_r2048325507 because it makes things more clear and less error prone, and the `enabled: bool` is not actually used in the random access, it's the `BoolTarget` counterpart, which still exists inside of `MerkleClaimAndProofTarget`. 