### PR TITLE
Re-implement serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ schemars = "0.8.22"
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"
+jsonschema = "0.30.0"
 
 [features]
 default = ["backend_plonky2"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ schemars = "0.8.22"
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"
+# Used only for testing JSON Schema generation and validation.
 jsonschema = "0.30.0"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ schemars = "1.0.0-alpha.17"
 # [patch."https://github.com/0xPolygonZero/plonky2"]
 # plonky2 = { path = "../plonky2/plonky2" }
 
+[dev-dependencies]
+pretty_assertions = "1.4.1"
+
 [features]
 default = ["backend_plonky2"]
 backend_plonky2 = ["plonky2"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ plonky2 = { git = "https://github.com/0xPolygonZero/plonky2", optional = true }
 serde = "1.0.219"
 serde_json = "1.0.140"
 base64 = "0.22.1"
-schemars = "1.0.0-alpha.17"
+schemars = "0.8.22"
 
 # Uncomment for debugging with https://github.com/ed255/plonky2/ at branch `feat/debug`.  The repo directory needs to be checked out next to the pod2 repo directory.
 # [patch."https://github.com/0xPolygonZero/plonky2"]

--- a/src/backends/plonky2/mainpod/operation.rs
+++ b/src/backends/plonky2/mainpod/operation.rs
@@ -2,14 +2,14 @@ use std::fmt;
 
 use anyhow::{anyhow, Result};
 use plonky2::field::types::Field;
+use serde::{Deserialize, Serialize};
 
-// use serde::{Deserialize, Serialize};
 use crate::{
     backends::plonky2::{mainpod::Statement, primitives::merkletree::MerkleClaimAndProof},
     middleware::{self, OperationType, Params, ToFields, F},
 };
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum OperationArg {
     None,
     Index(usize),
@@ -31,7 +31,7 @@ impl OperationArg {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum OperationAux {
     None,
     MerkleProofIndex(usize),
@@ -47,7 +47,7 @@ impl ToFields for OperationAux {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Operation(pub OperationType, pub Vec<OperationArg>, pub OperationAux);
 
 impl Operation {

--- a/src/backends/plonky2/mainpod/statement.rs
+++ b/src/backends/plonky2/mainpod/statement.rs
@@ -1,13 +1,13 @@
 use std::fmt;
 
 use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
 
-// use serde::{Deserialize, Serialize};
 use crate::middleware::{
     self, NativePredicate, Params, Predicate, StatementArg, ToFields, WildcardValue,
 };
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Statement(pub Predicate, pub Vec<StatementArg>);
 
 impl Statement {

--- a/src/backends/plonky2/mock/mainpod.rs
+++ b/src/backends/plonky2/mock/mainpod.rs
@@ -5,15 +5,15 @@
 use std::{any::Any, fmt};
 
 use anyhow::{anyhow, Result};
+use base64::{prelude::BASE64_STANDARD, Engine};
+use serde::{Deserialize, Serialize};
 
-// use base64::prelude::*;
-// use serde::{Deserialize, Serialize};
-use crate::backends::plonky2::mainpod::process_private_statements_operations;
 use crate::{
     backends::plonky2::{
         mainpod::{
             extract_merkle_proofs, hash_statements, layout_statements, normalize_statement,
-            process_public_statements_operations, Operation, Statement,
+            process_private_statements_operations, process_public_statements_operations, Operation,
+            Statement,
         },
         primitives::merkletree::MerkleClaimAndProof,
     },
@@ -31,7 +31,7 @@ impl PodProver for MockProver {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MockMainPod {
     params: Params,
     id: PodId,
@@ -166,14 +166,14 @@ impl MockMainPod {
         })
     }
 
-    // pub fn deserialize(serialized: String) -> Result<Self> {
-    //     let proof = String::from_utf8(BASE64_STANDARD.decode(&serialized)?)
-    //         .map_err(|e| anyhow::anyhow!("Invalid base64 encoding: {}", e))?;
-    //     let pod: MockMainPod = serde_json::from_str(&proof)
-    //         .map_err(|e| anyhow::anyhow!("Failed to parse proof: {}", e))?;
+    pub fn deserialize(serialized: String) -> Result<Self> {
+        let proof = String::from_utf8(BASE64_STANDARD.decode(&serialized)?)
+            .map_err(|e| anyhow::anyhow!("Invalid base64 encoding: {}", e))?;
+        let pod: MockMainPod = serde_json::from_str(&proof)
+            .map_err(|e| anyhow::anyhow!("Failed to parse proof: {}", e))?;
 
-    //     Ok(pod)
-    // }
+        Ok(pod)
+    }
 }
 
 impl Pod for MockMainPod {
@@ -282,8 +282,7 @@ impl Pod for MockMainPod {
     }
 
     fn serialized_proof(&self) -> String {
-        todo!()
-        // BASE64_STANDARD.encode(serde_json::to_string(self).unwrap())
+        BASE64_STANDARD.encode(serde_json::to_string(self).unwrap())
     }
 }
 

--- a/src/backends/plonky2/mock/mainpod.rs
+++ b/src/backends/plonky2/mock/mainpod.rs
@@ -166,7 +166,10 @@ impl MockMainPod {
         })
     }
 
-    pub fn deserialize(serialized: String) -> Result<Self> {
+    // MockMainPods include some internal private state which is necessary
+    // for verification. In non-mock Pods, this state will not be necessary,
+    // as the public statements can be verified using a ZK proof.
+    pub(crate) fn deserialize(serialized: String) -> Result<Self> {
         let proof = String::from_utf8(BASE64_STANDARD.decode(&serialized)?)
             .map_err(|e| anyhow::anyhow!("Invalid base64 encoding: {}", e))?;
         let pod: MockMainPod = serde_json::from_str(&proof)

--- a/src/backends/plonky2/mock/signedpod.rs
+++ b/src/backends/plonky2/mock/signedpod.rs
@@ -44,7 +44,7 @@ pub struct MockSignedPod {
 }
 
 impl MockSignedPod {
-    pub fn deserialize(id: PodId, signature: String, kvs: HashMap<Key, Value>) -> Self {
+    pub(crate) fn new(id: PodId, signature: String, kvs: HashMap<Key, Value>) -> Self {
         Self { id, signature, kvs }
     }
 }

--- a/src/backends/plonky2/mock/signedpod.rs
+++ b/src/backends/plonky2/mock/signedpod.rs
@@ -43,15 +43,11 @@ pub struct MockSignedPod {
     kvs: HashMap<Key, Value>,
 }
 
-// impl MockSignedPod {
-//     pub fn deserialize(id: PodId, signature: String, dict: Dictionary) -> Self {
-//         Self {
-//             id,
-//             signature,
-//             dict,
-//         }
-//     }
-// }
+impl MockSignedPod {
+    pub fn deserialize(id: PodId, signature: String, kvs: HashMap<Key, Value>) -> Self {
+        Self { id, signature, kvs }
+    }
+}
 
 impl Pod for MockSignedPod {
     fn verify(&self) -> Result<()> {

--- a/src/backends/plonky2/primitives/merkletree.rs
+++ b/src/backends/plonky2/primitives/merkletree.rs
@@ -4,8 +4,8 @@ use std::{collections::HashMap, fmt, iter::IntoIterator};
 
 use anyhow::{anyhow, Result};
 use plonky2::field::types::Field;
+use serde::{Deserialize, Serialize};
 
-// use serde::{Deserialize, Serialize};
 pub use super::merkletree_circuit::*;
 use crate::middleware::{hash_fields, Hash, RawValue, EMPTY_HASH, EMPTY_VALUE, F};
 
@@ -208,7 +208,7 @@ impl fmt::Display for MerkleTree {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MerkleProof {
     // note: currently we don't use the `_existence` field, we would use if we merge the methods
     // `verify` and `verify_nonexistence` into a single one
@@ -260,7 +260,7 @@ impl MerkleProof {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MerkleClaimAndProof {
     pub root: Hash,
     pub key: RawValue,

--- a/src/frontend/custom.rs
+++ b/src/frontend/custom.rs
@@ -4,7 +4,6 @@ use std::{collections::HashMap, fmt, hash as h, iter, iter::zip, sync::Arc};
 use anyhow::{anyhow, Result};
 use schemars::JsonSchema;
 
-// use serde::{Deserialize, Serialize};
 use crate::{
     frontend::{AnchoredKey, Statement, StatementArg},
     middleware::{

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -7,7 +7,6 @@ use anyhow::{anyhow, Result};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
-// use schemars::JsonSchema;
 use crate::middleware::{
     self, check_st_tmpl, hash_str, AnchoredKey, Key, MainPodInputs, NativeOperation,
     NativePredicate, OperationAux, OperationType, Params, PodId, PodProver, PodSigner, Predicate,

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -5,10 +5,9 @@ use std::{collections::HashMap, convert::From, fmt};
 
 use anyhow::{anyhow, Result};
 use itertools::Itertools;
+use serde::{Deserialize, Serialize};
 
 // use schemars::JsonSchema;
-
-// use serde::{Deserialize, Serialize};
 use crate::middleware::{
     self, check_st_tmpl, hash_str, AnchoredKey, Key, MainPodInputs, NativeOperation,
     NativePredicate, OperationAux, OperationType, Params, PodId, PodProver, PodSigner, Predicate,
@@ -17,8 +16,10 @@ use crate::middleware::{
 
 mod custom;
 mod operation;
+mod serialization;
 pub use custom::*;
 pub use operation::*;
+use serialization::*;
 
 /// This type is just for presentation purposes.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -66,8 +67,8 @@ impl SignedPodBuilder {
 
 /// SignedPod is a wrapper on top of backend::SignedPod, which additionally stores the
 /// string<-->hash relation of the keys.
-#[derive(Debug, Clone)]
-// #[serde(try_from = "SignedPodHelper", into = "SignedPodHelper")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(try_from = "SignedPodHelper", into = "SignedPodHelper")]
 pub struct SignedPod {
     pub pod: Box<dyn middleware::Pod>,
     // We store a copy of the key values for quick access
@@ -591,8 +592,8 @@ impl MainPodBuilder {
     }
 }
 
-#[derive(Debug, Clone)]
-// #[serde(try_from = "MainPodHelper", into = "MainPodHelper")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(try_from = "MainPodHelper", into = "MainPodHelper")]
 pub struct MainPod {
     pub pod: Box<dyn middleware::Pod>,
     pub public_statements: Vec<Statement>,

--- a/src/frontend/operation.rs
+++ b/src/frontend/operation.rs
@@ -1,6 +1,5 @@
 use std::fmt;
 
-// use serde::{Deserialize, Serialize};
 use crate::{
     frontend::SignedPod,
     middleware::{AnchoredKey, OperationAux, OperationType, Statement, Value},

--- a/src/frontend/serialization.rs
+++ b/src/frontend/serialization.rs
@@ -31,8 +31,7 @@ impl TryFrom<SignedPodHelper> for SignedPod {
         }
 
         let dict = Dictionary::new(helper.entries.clone())?.clone();
-        let pod =
-            MockSignedPod::deserialize(PodId(dict.commitment()), helper.proof, dict.kvs().clone());
+        let pod = MockSignedPod::new(PodId(dict.commitment()), helper.proof, dict.kvs().clone());
 
         Ok(SignedPod {
             pod: Box::new(pod),

--- a/src/frontend/serialization.rs
+++ b/src/frontend/serialization.rs
@@ -165,7 +165,7 @@ mod tests {
                 "value {:#?} should equal deserialized {:#?}",
                 value, deserialized
             );
-            let expected_deserialized: TypedValue = serde_json::from_str(&expected).unwrap();
+            let expected_deserialized: TypedValue = serde_json::from_str(expected).unwrap();
             assert_eq!(value, expected_deserialized);
         }
     }

--- a/src/frontend/serialization.rs
+++ b/src/frontend/serialization.rs
@@ -253,6 +253,9 @@ mod tests {
     }
 
     #[test]
+    // This tests that we can generate JSON Schemas for the MainPod and
+    // SignedPod types, and that we can validate real Signed and Main Pods
+    // against the schemas.
     fn test_schema() {
         let mainpod_schema = schema_for!(MainPodHelper);
         let signedpod_schema = schema_for!(SignedPodHelper);

--- a/src/middleware/basetypes.rs
+++ b/src/middleware/basetypes.rs
@@ -55,6 +55,7 @@ use plonky2::{
     hash::poseidon::PoseidonHash,
     plonk::config::Hasher,
 };
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::serialization::*;
@@ -70,8 +71,7 @@ pub const EMPTY_VALUE: RawValue = RawValue([F::ZERO, F::ZERO, F::ZERO, F::ZERO])
 pub const SELF_ID_HASH: Hash = Hash([F::ONE, F::ZERO, F::ZERO, F::ZERO]);
 pub const EMPTY_HASH: Hash = Hash([F::ZERO, F::ZERO, F::ZERO, F::ZERO]);
 
-#[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq, Serialize, Deserialize)]
-// #[schemars(rename = "RawValue")]
+#[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct RawValue(
     #[serde(
         serialize_with = "serialize_value_tuple",
@@ -79,8 +79,8 @@ pub struct RawValue(
     )]
     // We know that Serde will serialize and deserialize this as a string, so we can
     // use the JsonSchema to validate the format.
-    // #[schemars(with = "String", regex(pattern = r"^[0-9a-fA-F]{64}$"))]
-    pub  [F; VALUE_SIZE],
+    #[schemars(with = "String", regex(pattern = r"^[0-9a-fA-F]{64}$"))]
+    pub [F; VALUE_SIZE],
 );
 
 impl ToFields for RawValue {
@@ -147,14 +147,14 @@ impl fmt::Display for RawValue {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, Hash, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, Hash, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct Hash(
     #[serde(
         serialize_with = "serialize_hash_tuple",
         deserialize_with = "deserialize_hash_tuple"
     )]
-    // #[schemars(with = "String", regex(pattern = r"^[0-9a-fA-F]{64}$"))]
-    pub  [F; HASH_SIZE],
+    #[schemars(with = "String", regex(pattern = r"^[0-9a-fA-F]{64}$"))]
+    pub [F; HASH_SIZE],
 );
 
 pub fn hash_value(input: &RawValue) -> Hash {

--- a/src/middleware/basetypes.rs
+++ b/src/middleware/basetypes.rs
@@ -55,15 +55,10 @@ use plonky2::{
     hash::poseidon::PoseidonHash,
     plonk::config::Hasher,
 };
+use serde::{Deserialize, Serialize};
 
-use crate::middleware::{
-    // serialization::{
-    //     deserialize_hash_tuple, deserialize_value_tuple, serialize_hash_tuple,
-    //     serialize_value_tuple,
-    // },
-    Params,
-    ToFields,
-};
+use super::serialization::*;
+use crate::middleware::{Params, ToFields};
 
 /// F is the native field we use everywhere.  Currently it's Goldilocks from plonky2
 pub type F = GoldilocksField;
@@ -75,17 +70,17 @@ pub const EMPTY_VALUE: RawValue = RawValue([F::ZERO, F::ZERO, F::ZERO, F::ZERO])
 pub const SELF_ID_HASH: Hash = Hash([F::ONE, F::ZERO, F::ZERO, F::ZERO]);
 pub const EMPTY_HASH: Hash = Hash([F::ZERO, F::ZERO, F::ZERO, F::ZERO]);
 
-#[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq, Serialize, Deserialize)]
 // #[schemars(rename = "RawValue")]
 pub struct RawValue(
-    // #[serde(
-    //     serialize_with = "serialize_value_tuple",
-    //     deserialize_with = "deserialize_value_tuple"
-    // )]
+    #[serde(
+        serialize_with = "serialize_value_tuple",
+        deserialize_with = "deserialize_value_tuple"
+    )]
     // We know that Serde will serialize and deserialize this as a string, so we can
     // use the JsonSchema to validate the format.
     // #[schemars(with = "String", regex(pattern = r"^[0-9a-fA-F]{64}$"))]
-    pub [F; VALUE_SIZE],
+    pub  [F; VALUE_SIZE],
 );
 
 impl ToFields for RawValue {
@@ -152,14 +147,14 @@ impl fmt::Display for RawValue {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, Hash, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Hash(
-    // #[serde(
-    //     serialize_with = "serialize_hash_tuple",
-    //     deserialize_with = "deserialize_hash_tuple"
-    // )]
+    #[serde(
+        serialize_with = "serialize_hash_tuple",
+        deserialize_with = "deserialize_hash_tuple"
+    )]
     // #[schemars(with = "String", regex(pattern = r"^[0-9a-fA-F]{64}$"))]
-    pub [F; HASH_SIZE],
+    pub  [F; HASH_SIZE],
 );
 
 pub fn hash_value(input: &RawValue) -> Hash {

--- a/src/middleware/containers.rs
+++ b/src/middleware/containers.rs
@@ -171,8 +171,10 @@ impl<'de> Deserialize<'de> for Set {
 /// array index (integer).
 ///    leaf.key=i
 ///    leaf.value=original_value
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
+#[serde(transparent)]
 pub struct Array {
+    #[serde(skip)]
     mt: MerkleTree,
     array: Vec<Value>,
 }
@@ -223,15 +225,6 @@ impl PartialEq for Array {
     }
 }
 impl Eq for Array {}
-
-impl Serialize for Array {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        self.array.serialize(serializer)
-    }
-}
 
 impl<'de> Deserialize<'de> for Array {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/src/middleware/custom.rs
+++ b/src/middleware/custom.rs
@@ -2,15 +2,14 @@ use std::{fmt, iter, sync::Arc};
 
 use anyhow::{anyhow, Result};
 use plonky2::field::types::Field;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-// use schemars::JsonSchema;
-use crate::{
-    middleware::HASH_SIZE,
-    middleware::{hash_fields, Hash, Key, NativePredicate, Params, ToFields, Value, F},
+use crate::middleware::{
+    hash_fields, Hash, Key, NativePredicate, Params, ToFields, Value, F, HASH_SIZE,
 };
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct Wildcard {
     pub name: String,
     pub index: usize,
@@ -34,7 +33,7 @@ impl ToFields for Wildcard {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub enum KeyOrWildcard {
     Key(Key),
     Wildcard(Wildcard),
@@ -61,7 +60,7 @@ impl ToFields for KeyOrWildcard {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub enum StatementTmplArg {
     None,
     Literal(Value),
@@ -125,7 +124,7 @@ impl fmt::Display for StatementTmplArg {
 }
 
 /// Statement Template for a Custom Predicate
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct StatementTmpl {
     pub pred: Predicate,
     pub args: Vec<StatementTmplArg>,
@@ -177,7 +176,7 @@ impl ToFields for StatementTmpl {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 /// NOTE: fields are not public (outside of crate) to enforce the struct instantiation through
 /// the `::and/or` methods, which performs checks on the values.
@@ -278,7 +277,7 @@ impl fmt::Display for CustomPredicate {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct CustomPredicateBatch {
     pub name: String,
     pub predicates: Vec<CustomPredicate>,
@@ -315,7 +314,7 @@ impl CustomPredicateBatch {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct CustomPredicateRef {
     pub batch: Arc<CustomPredicateBatch>,
     pub index: usize,
@@ -330,7 +329,7 @@ impl CustomPredicateRef {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "type", content = "value")]
 pub enum Predicate {
     Native(NativePredicate),

--- a/src/middleware/custom.rs
+++ b/src/middleware/custom.rs
@@ -2,16 +2,15 @@ use std::{fmt, iter, sync::Arc};
 
 use anyhow::{anyhow, Result};
 use plonky2::field::types::Field;
+use serde::{Deserialize, Serialize};
 
 // use schemars::JsonSchema;
-
-// use serde::{Deserialize, Serialize};
 use crate::{
     middleware::HASH_SIZE,
     middleware::{hash_fields, Hash, Key, NativePredicate, Params, ToFields, Value, F},
 };
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Wildcard {
     pub name: String,
     pub index: usize,
@@ -35,7 +34,7 @@ impl ToFields for Wildcard {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum KeyOrWildcard {
     Key(Key),
     Wildcard(Wildcard),
@@ -62,7 +61,7 @@ impl ToFields for KeyOrWildcard {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum StatementTmplArg {
     None,
     Literal(Value),
@@ -126,7 +125,7 @@ impl fmt::Display for StatementTmplArg {
 }
 
 /// Statement Template for a Custom Predicate
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct StatementTmpl {
     pub pred: Predicate,
     pub args: Vec<StatementTmplArg>,
@@ -178,7 +177,7 @@ impl ToFields for StatementTmpl {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 /// NOTE: fields are not public (outside of crate) to enforce the struct instantiation through
 /// the `::and/or` methods, which performs checks on the values.
 pub struct CustomPredicate {
@@ -278,7 +277,7 @@ impl fmt::Display for CustomPredicate {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct CustomPredicateBatch {
     pub name: String,
     pub predicates: Vec<CustomPredicate>,
@@ -315,7 +314,7 @@ impl CustomPredicateBatch {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct CustomPredicateRef {
     pub batch: Arc<CustomPredicateBatch>,
     pub index: usize,
@@ -330,8 +329,8 @@ impl CustomPredicateRef {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
-// #[serde(tag = "type", content = "value")]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "value")]
 pub enum Predicate {
     Native(NativePredicate),
     BatchSelf(usize),

--- a/src/middleware/custom.rs
+++ b/src/middleware/custom.rs
@@ -178,6 +178,7 @@ impl ToFields for StatementTmpl {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 /// NOTE: fields are not public (outside of crate) to enforce the struct instantiation through
 /// the `::and/or` methods, which performs checks on the values.
 pub struct CustomPredicate {

--- a/src/middleware/custom.rs
+++ b/src/middleware/custom.rs
@@ -34,6 +34,7 @@ impl ToFields for Wildcard {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", content = "value")]
 pub enum KeyOrWildcard {
     Key(Key),
     Wildcard(Wildcard),
@@ -61,6 +62,7 @@ impl ToFields for KeyOrWildcard {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", content = "value")]
 pub enum StatementTmplArg {
     None,
     Literal(Value),

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -405,8 +405,7 @@ impl From<&Value> for Hash {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, JsonSchema)]
-#[schemars(with = "String")]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Key {
     name: String,
     hash: Hash,
@@ -474,6 +473,16 @@ impl<'de> Deserialize<'de> for Key {
     {
         let name = String::deserialize(deserializer)?;
         Ok(Key::new(name))
+    }
+}
+
+impl JsonSchema for Key {
+    fn schema_name() -> String {
+        "Key".to_string()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <String>::json_schema(gen)
     }
 }
 

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -376,6 +376,7 @@ impl<'de> Deserialize<'de> for Key {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AnchoredKey {
     pub pod_id: PodId,
     pub key: Key,

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -435,6 +435,7 @@ impl fmt::Display for PodType {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Params {
     pub max_input_signed_pods: usize,
     pub max_input_main_pods: usize,

--- a/src/middleware/operation.rs
+++ b/src/middleware/operation.rs
@@ -3,8 +3,8 @@ use std::{fmt, iter, sync::Arc};
 use anyhow::{anyhow, Result};
 use log::error;
 use plonky2::field::types::Field;
+use serde::{Deserialize, Serialize};
 
-// use serde::{Deserialize, Serialize};
 use crate::{
     backends::plonky2::primitives::merkletree::MerkleProof,
     middleware::{
@@ -14,7 +14,7 @@ use crate::{
     },
 };
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum OperationType {
     Native(NativeOperation),
     Custom(CustomPredicateRef),
@@ -54,7 +54,7 @@ impl ToFields for OperationType {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum NativeOperation {
     None = 0,
     NewEntry = 1,

--- a/src/middleware/serialization.rs
+++ b/src/middleware/serialization.rs
@@ -1,8 +1,9 @@
-// TODO: Reenable
-/*
-use plonky2::field::types::Field;
-use serde::Deserialize;
+use std::collections::{HashMap, HashSet};
 
+use plonky2::field::types::Field;
+use serde::{ser::SerializeSeq, Deserialize, Serialize, Serializer};
+
+use super::Key;
 use crate::middleware::{F, HASH_SIZE, VALUE_SIZE};
 
 fn serialize_field_tuple<S, const N: usize>(
@@ -69,4 +70,54 @@ where
 {
     deserialize_field_tuple::<D, VALUE_SIZE>(deserializer)
 }
-*/
+
+pub fn serialize_i64<S>(value: &i64, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(&value.to_string())
+}
+
+pub fn deserialize_i64<'de, D>(deserializer: D) -> Result<i64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    String::deserialize(deserializer)?
+        .parse()
+        .map_err(serde::de::Error::custom)
+}
+
+// In order to serialize a Dictionary consistently, we want to order the
+// key-value pairs by the key's name field. This has no effect on the hashes
+// of the keys and therefore on the Merkle tree, but it makes the serialized
+// output deterministic.
+pub fn ordered_map<S, V: Serialize>(
+    value: &HashMap<Key, V>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    // Convert to Vec and sort by the key's name field
+    let mut pairs: Vec<_> = value.iter().collect();
+    pairs.sort_by(|(k1, _), (k2, _)| k1.name.cmp(&k2.name));
+
+    // Serialize as a map
+    use serde::ser::SerializeMap;
+    let mut map = serializer.serialize_map(Some(pairs.len()))?;
+    for (k, v) in pairs {
+        map.serialize_entry(k, v)?;
+    }
+    map.end()
+}
+
+pub fn ordered_set<S, V: Serialize>(value: &HashSet<V>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut set = serializer.serialize_seq(Some(value.len()))?;
+    for v in value {
+        set.serialize_element(v)?;
+    }
+    set.end()
+}

--- a/src/middleware/serialization.rs
+++ b/src/middleware/serialization.rs
@@ -121,7 +121,7 @@ where
 {
     let mut set = serializer.serialize_seq(Some(value.len()))?;
     let mut sorted_values: Vec<&Value> = value.iter().collect();
-    sorted_values.sort_by(|a, b| a.cmp(b));
+    sorted_values.sort();
     for v in sorted_values {
         set.serialize_element(v)?;
     }

--- a/src/middleware/statement.rs
+++ b/src/middleware/statement.rs
@@ -2,8 +2,8 @@ use std::{fmt, iter};
 
 use anyhow::{anyhow, Result};
 use plonky2::field::types::Field;
+use serde::{Deserialize, Serialize};
 // use schemars::JsonSchema;
-// use serde::{Deserialize, Serialize};
 use strum_macros::FromRepr;
 
 use crate::middleware::{
@@ -20,7 +20,7 @@ pub const STATEMENT_ARG_F_LEN: usize = 8;
 pub const OPERATION_ARG_F_LEN: usize = 1;
 pub const OPERATION_AUX_F_LEN: usize = 1;
 
-#[derive(Clone, Copy, Debug, FromRepr, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, FromRepr, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum NativePredicate {
     None = 0,
     ValueOf = 1,
@@ -49,7 +49,7 @@ impl ToFields for NativePredicate {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum WildcardValue {
     PodId(PodId),
     Key(Key),
@@ -83,7 +83,7 @@ impl ToFields for WildcardValue {
 }
 
 /// Type encapsulating statements with their associated arguments.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum Statement {
     None,
     ValueOf(AnchoredKey, Value),
@@ -275,7 +275,7 @@ impl fmt::Display for Statement {
 }
 
 /// Statement argument type. Useful for statement decompositions.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum StatementArg {
     None,
     Literal(Value),

--- a/src/middleware/statement.rs
+++ b/src/middleware/statement.rs
@@ -2,8 +2,8 @@ use std::{fmt, iter};
 
 use anyhow::{anyhow, Result};
 use plonky2::field::types::Field;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-// use schemars::JsonSchema;
 use strum_macros::FromRepr;
 
 use crate::middleware::{
@@ -20,7 +20,7 @@ pub const STATEMENT_ARG_F_LEN: usize = 8;
 pub const OPERATION_ARG_F_LEN: usize = 1;
 pub const OPERATION_AUX_F_LEN: usize = 1;
 
-#[derive(Clone, Copy, Debug, FromRepr, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, FromRepr, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
 pub enum NativePredicate {
     None = 0,
     ValueOf = 1,
@@ -49,7 +49,7 @@ impl ToFields for NativePredicate {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub enum WildcardValue {
     PodId(PodId),
     Key(Key),
@@ -83,7 +83,7 @@ impl ToFields for WildcardValue {
 }
 
 /// Type encapsulating statements with their associated arguments.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "predicate", content = "args")]
 pub enum Statement {
     None,

--- a/src/middleware/statement.rs
+++ b/src/middleware/statement.rs
@@ -84,6 +84,7 @@ impl ToFields for WildcardValue {
 
 /// Type encapsulating statements with their associated arguments.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "predicate", content = "args")]
 pub enum Statement {
     None,
     ValueOf(AnchoredKey, Value),


### PR DESCRIPTION
Closes #195 

Re-implements serialization based on the new refactored code.

Serialization format should be pretty similar to how it was before, with some small cosmetic changes.

I've had to implement a few more custom serialization functions, in order to avoid serializing middleware data. I've commented in the places where this was necessary, so that we can be aware that those custom serialization functions will not automatically track changes to the types in the way that Serde's attribute-based serialization does.

The new version has more tests, and in particular has an end-to-end test which:

- Serializes a SignedPod, and two quite different MainPods
- Generates JSON Schemas for SignedPod and MainPod
- Tests that the real SignedPod and MainPods can be validated at runtime using the schemas