### PR TITLE
Add RecursiveCircuit

### DIFF
--- a/.github/workflows/typos.toml
+++ b/.github/workflows/typos.toml
@@ -7,3 +7,4 @@ aks = "aks" # anchored keys
 nin = "nin" # not in
 kow = "kow" # key or wildcard
 KOW = "KOW" # Key Or Wildcard
+datas = "datas" # plural (for 'verifier_datas', a vector of 'verifier_data')

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ serde = "1.0.219"
 serde_json = "1.0.140"
 base64 = "0.22.1"
 schemars = "0.8.22"
+hashbrown = { version = "0.14.3", default-features = false, features = ["serde"] }
 
 # Uncomment for debugging with https://github.com/ed255/plonky2/ at branch `feat/debug`.  The repo directory needs to be checked out next to the pod2 repo directory.
 # [patch."https://github.com/0xPolygonZero/plonky2"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ hashbrown = { version = "0.14.3", default-features = false, features = ["serde"]
 
 # Uncomment for debugging with https://github.com/ed255/plonky2/ at branch `feat/debug`.  The repo directory needs to be checked out next to the pod2 repo directory.
 # [patch."https://github.com/0xPolygonZero/plonky2"]
-# plonky2 = { path = "../../plonky2/plonky2" }
+# plonky2 = { path = "../plonky2/plonky2" }
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,8 @@ env_logger = "0.11"
 lazy_static = "1.5.0"
 thiserror = { version = "2.0.12" }
 # enabled by features:
-plonky2 = { git = "https://github.com/0xPolygonZero/plonky2", optional = true }
+# plonky2 = { git = "https://github.com/0xPolygonZero/plonky2", optional = true }
+plonky2 = { path = "../../plonky2/plonky2", optional = true }
 serde = "1.0.219"
 serde_json = "1.0.140"
 base64 = "0.22.1"
@@ -28,7 +29,7 @@ hashbrown = { version = "0.14.3", default-features = false, features = ["serde"]
 
 # Uncomment for debugging with https://github.com/ed255/plonky2/ at branch `feat/debug`.  The repo directory needs to be checked out next to the pod2 repo directory.
 # [patch."https://github.com/0xPolygonZero/plonky2"]
-# plonky2 = { path = "../plonky2/plonky2" }
+# plonky2 = { path = "../../plonky2/plonky2" }
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,7 @@ env_logger = "0.11"
 lazy_static = "1.5.0"
 thiserror = { version = "2.0.12" }
 # enabled by features:
-# plonky2 = { git = "https://github.com/0xPolygonZero/plonky2", optional = true }
-plonky2 = { path = "../../plonky2/plonky2", optional = true }
+plonky2 = { git = "https://github.com/0xPolygonZero/plonky2", optional = true }
 serde = "1.0.219"
 serde_json = "1.0.140"
 base64 = "0.22.1"

--- a/src/backends/plonky2/mod.rs
+++ b/src/backends/plonky2/mod.rs
@@ -4,6 +4,7 @@ mod error;
 pub mod mainpod;
 pub mod mock;
 pub mod primitives;
+pub mod recursion;
 pub mod signedpod;
 
 pub use error::*;

--- a/src/backends/plonky2/recursion/circuit.rs
+++ b/src/backends/plonky2/recursion/circuit.rs
@@ -43,7 +43,7 @@ use plonky2::{
         },
         proof::{ProofWithPublicInputs, ProofWithPublicInputsTarget},
     },
-    recursion::dummy_circuit::cyclic_base_proof,
+    recursion::dummy_circuit::{dummy_circuit, dummy_proof as plonky2_dummy_proof},
 };
 
 use crate::{
@@ -85,10 +85,14 @@ pub fn new_params<I: InnerCircuit>(
     arity: usize,
     inner_params: &I::Params,
 ) -> Result<RecursiveParams> {
-    let circuit_data = RecursiveCircuit::<I>::circuit_data(arity, &inner_params)?;
+    dbg!("A 0");
+    let circuit_data = RecursiveCircuit::<I>::circuit_data(arity, inner_params)?;
+    dbg!("A 1");
     let common_data = circuit_data.common.clone();
     let verifier_data = circuit_data.verifier_data();
-    let dummy_proof = RecursiveCircuit::<I>::dummy_proof(circuit_data);
+    dbg!("A 2");
+    let dummy_proof = RecursiveCircuit::<I>::dummy_proof(circuit_data)?;
+    dbg!("A 3");
     Ok(RecursiveParams {
         arity,
         common_data,
@@ -102,14 +106,13 @@ pub struct RecursiveCircuit<I: InnerCircuit> {
     params: RecursiveParams,
     prover: ProverCircuitData<F, C, D>,
     targets: RecursiveCircuitTargets<I>,
-    // verifier_data: VerifierCircuitData<F, C, D>,
 }
+
 #[derive(Clone, Debug)]
 pub struct RecursiveCircuitTargets<I: InnerCircuit> {
     selectors_targ: Vec<BoolTarget>,
     innercircuit_targ: I,
     proofs_targ: Vec<ProofWithPublicInputsTarget<D>>,
-    // cyclic-recursion params:
     verifier_data_targ: Vec<VerifierCircuitTarget>,
 }
 
@@ -131,18 +134,13 @@ impl<I: InnerCircuit> RecursiveCircuit<I> {
         Ok(proof)
     }
 
-    pub fn build(
-        params: &RecursiveParams,
-        inner_params: &I::Params,
-        // self's verifier_data
-        // verifier_data: VerifierCircuitData<F, C, D>, // TODO rm
-        // common_data: CommonCircuitData<F, D>, // TODO wip. TODO move to a RecursiveCircuitBuilder
-    ) -> Result<Self> {
+    /// builds the targets and returns also a ProverCircuitData
+    pub fn build(params: &RecursiveParams, inner_params: &I::Params) -> Result<Self> {
         let config = CircuitConfig::standard_recursion_config();
         let mut builder = CircuitBuilder::new(config.clone());
 
         let targets: RecursiveCircuitTargets<I> =
-            Self::build_opt(&mut builder, params, inner_params)?;
+            Self::build_targets(&mut builder, params, inner_params)?;
 
         println!("RecursiveCircuit<I> num_gates {}", builder.num_gates());
 
@@ -154,13 +152,11 @@ impl<I: InnerCircuit> RecursiveCircuit<I> {
         })
     }
 
-    pub fn build_opt(
+    /// builds the targets
+    pub fn build_targets(
         builder: &mut CircuitBuilder<F, D>,
         params: &RecursiveParams,
         inner_params: &I::Params,
-        // self's verifier_data
-        // verifier_data: VerifierCircuitData<F, C, D>, // TODO rm
-        // common_data: CommonCircuitData<F, D>, // TODO wip. TODO move to a RecursiveCircuitBuilder
     ) -> Result<RecursiveCircuitTargets<I>> {
         let selectors_targ: Vec<BoolTarget> = (0..params.arity)
             .map(|_| builder.add_virtual_bool_target_safe())
@@ -168,14 +164,28 @@ impl<I: InnerCircuit> RecursiveCircuit<I> {
 
         // proof verification
         let verifier_data_targ: Vec<VerifierCircuitTarget> = (0..params.arity)
-            .map(|_| builder.add_verifier_data_public_inputs())
+            // .map(|_| builder.add_verifier_data_public_inputs())
+            .map(|_| builder.add_virtual_verifier_data(builder.config.fri_config.cap_height)) // TODO WIP
             .collect();
         let proofs_targ: Result<Vec<ProofWithPublicInputsTarget<D>>> = (0..params.arity)
             .map(|i| {
                 let proof_targ = builder.add_virtual_proof_with_pis(&params.common_data);
-                builder.conditionally_verify_cyclic_proof_or_dummy::<C>(
+                builder.register_public_inputs(&verifier_data_targ[i].circuit_digest.elements);
+                for j in 0..builder.config.fri_config.num_cap_elements() {
+                    builder.register_public_inputs(
+                        &verifier_data_targ[i].constants_sigmas_cap.0[j].elements,
+                    );
+                }
+
+                // builder.conditionally_verify_cyclic_proof_or_dummy::<C>(
+                //     selectors_targ[i],
+                //     &proof_targ,
+                //     &params.common_data,
+                // )?;
+                builder.conditionally_verify_proof_or_dummy::<C>(
                     selectors_targ[i],
                     &proof_targ,
+                    &verifier_data_targ[i],
                     &params.common_data,
                 )?;
                 Ok(proof_targ)
@@ -189,6 +199,7 @@ impl<I: InnerCircuit> RecursiveCircuit<I> {
             .iter()
             .flat_map(|proof_pis| proof_pis.public_inputs.clone())
             .collect();
+        dbg!(pub_inp.len());
 
         // build the InnerCircuits logic
         let innercircuit_targ: I =
@@ -211,7 +222,7 @@ impl<I: InnerCircuit> RecursiveCircuit<I> {
     ) -> Result<()> {
         let n = recursive_proofs.len();
         assert!(n <= self.params.arity);
-        // assert_eq!(recursive_proofs.len(), verifier_datas.len()); // TODO WIP
+        // assert_eq!(recursive_proofs.len(), verifier_datas.len()); // TODO uncomment
 
         // fill the missing proofs with dummy_proofs
         let dummy_proofs: Vec<Proof> = (n..self.params.arity)
@@ -270,8 +281,11 @@ impl<I: InnerCircuit> RecursiveCircuit<I> {
     ) -> Result<CircuitData<F, C, D>> {
         let data: CircuitData<F, C, D> = common_data_for_recursion::<I>(arity, inner_params)?;
         let common_data = data.common.clone();
+        dbg!(&common_data.num_public_inputs);
         let verifier_data = data.verifier_data();
-        let dummy_proof = Self::dummy_proof(data);
+        dbg!("F 0");
+        let dummy_proof = Self::dummy_proof(data)?;
+        dbg!("F 1");
         let params = RecursiveParams {
             arity,
             common_data,
@@ -283,20 +297,27 @@ impl<I: InnerCircuit> RecursiveCircuit<I> {
         let config = CircuitConfig::standard_recursion_config();
         let mut builder = CircuitBuilder::new(config);
 
-        let _ = Self::build_opt(&mut builder, &params, inner_params)?;
+        let _ = Self::build_targets(&mut builder, &params, inner_params)?;
         let data = builder.build::<C>();
+        dbg!(data.common.num_public_inputs);
 
         Ok(data)
     }
 
-    pub fn dummy_proof(circuit_data: CircuitData<F, C, D>) -> Proof {
-        let verifier_data = circuit_data.verifier_data();
-        let dummy_proof_pis = cyclic_base_proof(
-            &circuit_data.common,
-            &verifier_data.verifier_only,
-            HashMap::new(),
-        );
-        dummy_proof_pis.proof
+    pub fn dummy_proof(circuit_data: CircuitData<F, C, D>) -> Result<Proof> {
+        // let verifier_data = circuit_data.verifier_data();
+        // let dummy_proof_pis = cyclic_base_proof(
+        //     &circuit_data.common,
+        //     &verifier_data.verifier_only,
+        //     HashMap::new(),
+        // );
+        dbg!("C 0");
+        dbg!(circuit_data.common.num_public_inputs);
+        dbg!(circuit_data.prover_only.generators.len());
+        let dummy_circuit_data = dummy_circuit(&circuit_data.common);
+        let dummy_proof_pis = plonky2_dummy_proof(&dummy_circuit_data, HashMap::new())?;
+        dbg!("C 1");
+        Ok(dummy_proof_pis.proof)
     }
 
     pub fn prepare_public_inputs(
@@ -331,11 +352,18 @@ fn common_data_for_recursion<I: InnerCircuit>(
     // 2nd
     let config = CircuitConfig::standard_recursion_config();
     let mut builder = CircuitBuilder::<F, D>::new(config.clone());
-    let verifier_data = builder.add_virtual_verifier_data(data.common.config.fri_config.cap_height);
-    // proofs
+    // let verifier_data_i =
+    //     builder.add_virtual_verifier_data(data.common.config.fri_config.cap_height);
     for _ in 0..arity {
+        let verifier_data_i =
+            builder.add_virtual_verifier_data(builder.config.fri_config.cap_height);
+        builder.register_public_inputs(&verifier_data_i.circuit_digest.elements);
+        for i in 0..builder.config.fri_config.num_cap_elements() {
+            builder.register_public_inputs(&verifier_data_i.constants_sigmas_cap.0[i].elements);
+        }
+
         let proof = builder.add_virtual_proof_with_pis(&data.common);
-        builder.verify_proof::<C>(&proof, &verifier_data, &data.common);
+        builder.verify_proof::<C>(&proof, &verifier_data_i, &data.common);
     }
     let data = builder.build::<C>();
 
@@ -343,27 +371,38 @@ fn common_data_for_recursion<I: InnerCircuit>(
     let config = CircuitConfig::standard_recursion_config();
     let mut builder = CircuitBuilder::<F, D>::new(config.clone());
 
-    builder.add_gate(
-        // add a ConstantGate, because without this, when later generating the `dummy_circuit`
-        // (inside the `conditionally_verify_cyclic_proof_or_dummy`), it fails due the
-        // `CommonCircuitData` of the generated circuit not matching the given `CommonCircuitData`
-        // to create it. Without this it fails because it misses a ConstantGate.
-        plonky2::gates::constant::ConstantGate::new(config.num_constants),
-        vec![],
-    );
+    // TODO WIP
+    // builder.add_gate(
+    //     // add a ConstantGate, because without this, when later generating the `dummy_circuit`
+    //     // (inside the `conditionally_verify_cyclic_proof_or_dummy`), it fails due the
+    //     // `CommonCircuitData` of the generated circuit not matching the given `CommonCircuitData`
+    //     // to create it. Without this it fails because it misses a ConstantGate.
+    //     plonky2::gates::constant::ConstantGate::new(config.num_constants),
+    //     vec![],
+    // );
+
+    // cyclic_recursion proofs
+    // let verifier_data_i = builder.add_verifier_data_public_inputs(); // TODO TMP
+    for _ in 0..arity {
+        let verifier_data_i =
+            builder.add_virtual_verifier_data(builder.config.fri_config.cap_height);
+        builder.register_public_inputs(&verifier_data_i.circuit_digest.elements);
+        for i in 0..builder.config.fri_config.num_cap_elements() {
+            builder.register_public_inputs(&verifier_data_i.constants_sigmas_cap.0[i].elements);
+        }
+
+        let proof = builder.add_virtual_proof_with_pis(&data.common);
+        builder.verify_proof::<C>(&proof, &verifier_data_i, &data.common);
+    }
+    dbg!(data.common.num_public_inputs);
 
     // set the targets for the InnerCircuit
     let _ = I::build(&mut builder, inner_params, vec![], vec![])?;
 
-    // cyclic_recursion proofs
-    let verifier_data = builder.add_verifier_data_public_inputs();
-    for _ in 0..arity {
-        let proof = builder.add_virtual_proof_with_pis(&data.common);
-        builder.verify_proof::<C>(&proof, &verifier_data, &data.common);
-    }
-
     // pad min gates
     let n_gates = compute_num_gates(arity)?;
+    dbg!(n_gates);
+    dbg!(builder.num_gates());
     while builder.num_gates() < n_gates {
         builder.add_gate(NoopGate, vec![]);
     }
@@ -580,19 +619,15 @@ mod tests {
 
     */
 
-    fn test_recursive_circuit_opt(
-        // arity: number of cyclic recursion proofs verified at each node of the
-        // recursion tree
-        arity: usize,
-        // n_steps: determines the number of recursive steps. Notice that when
-        // arity>1, n_steps determines the number of levels of the recursive
-        // tree
-        n_steps: usize,
-    ) -> Result<()> {
+    #[test]
+    fn test_recursive_circuit() -> Result<()> {
+        let arity: usize = 1;
+
         type RC<I> = RecursiveCircuit<I>;
         let inner_params = ();
-
+        dbg!("B 0");
         let params: RecursiveParams = new_params::<Circuit1>(arity, &inner_params)?;
+        dbg!("B 1");
 
         // build the circuit_data & verifier_data for the recursive circuit
         let start = Instant::now();
@@ -602,45 +637,19 @@ mod tests {
         let circuit_data_2 = RC::<Circuit2>::circuit_data(arity, &inner_params)?;
         let verifier_data_2 = circuit_data_2.verifier_data();
 
-        // let circuit_data_3 = RC::<Circuit3>::circuit_data(arity, &inner_params)?;
-        // let verifier_data_3 = circuit_data_3.verifier_data();
-
-        // let dummy_proof = RC::<Circuit1>::dummy_proof(circuit_data_1);
         println!(
             "circuit_data,prover,dummy_proof generated {:?}",
             start.elapsed()
         );
 
-        // build 1st circuit: circuit1, a RecursiveCircuit which uses as
-        // InnerCircuit the Circuit1
         let mut circuit1 = RC::<Circuit1>::build(&params, &())?;
-
-        // build 2nd circuit: circuit2, a RecursiveCircuit which uses as
-        // InnerCircuit the Circuit2
         let mut circuit2 = RC::<Circuit2>::build(&params, &())?;
-
-        // build 3rd circuit: circuit3, a RecursiveCircuit which uses as
-        // InnerCircuit the Circuit3
-        // let circuit3 = RC::<Circuit3>::build(&params, &())?;
-
-        // TODO use circuit4 in the test
-        // circuit4 is the Circuit3 without the RecursiveCircuit wrapper
-        // let mut builder4 = CircuitBuilder::new(config);
-        // let mut circuit4 = Circuit3::build(&mut builder4, &(), vec![], vec![])?;
-        // println!("Circuit4 num_gates {}", builder4.num_gates());
-
-        // we start with 0 proofs at the first iteration, which means that
-        // internally at RecursiveCircuit.set_targets, it will use all
-        // dummy_proofs
 
         dbg!("circuit1.prove");
         let inp = HashOut::<F>::ZERO;
         let inner_inputs = (inp, circuit1_io(inp));
-        let proof_1a =
-            // circuit1.prove(inner_inputs, vec![], vec![verifier_data_1.clone()])?;
-            circuit1.prove(inner_inputs, vec![], vec![])?;
+        let proof_1a = circuit1.prove(inner_inputs, vec![], vec![])?;
         let public_inputs = RC::<Circuit1>::prepare_public_inputs(vec![], verifier_data_1.clone());
-        // Notice that this is the `verifier_data` of Circuit1:
         verifier_data_1.clone().verify(ProofWithPublicInputs {
             proof: proof_1a.clone(),
             public_inputs: public_inputs.clone(),
@@ -655,63 +664,32 @@ mod tests {
             vec![verifier_data_1.clone()],
         )?;
         let public_inputs = RC::<Circuit1>::prepare_public_inputs(vec![], verifier_data_1.clone());
-        // Notice that this is the `verifier_data` of Circuit1:
         verifier_data_1.clone().verify(ProofWithPublicInputs {
             proof: proof_1b.clone(),
             public_inputs: public_inputs.clone(),
         })?;
 
-        // do one more iteration, but now with Circuit2
+        // generate a standalone proof of Circuit2
         dbg!("circuit2.prove");
         let inner_inputs = (inp, circuit2_io(inp));
         let proof_2 = circuit2.prove(inner_inputs, vec![], vec![verifier_data_2.clone()])?;
         let public_inputs = RC::<Circuit2>::prepare_public_inputs(vec![], verifier_data_2.clone());
-        // Notice that this is the `verifier_data` of Circuit1:
         verifier_data_2.clone().verify(ProofWithPublicInputs {
             proof: proof_2.clone(),
             public_inputs: public_inputs.clone(),
         })?;
 
+        // verify the last proof of circuit2, inside a new circuit1's proof
         dbg!("proof_1c = c1.prove([proof_1b, proof_2], [verifier_data_c1, verifier_data_c2])");
         let inp = HashOut::<F>::ZERO;
         let inner_inputs = (inp, circuit1_io(inp));
         let proof_1c =
             circuit1.prove(inner_inputs, vec![proof_2], vec![verifier_data_2.clone()])?;
         let public_inputs = RC::<Circuit1>::prepare_public_inputs(vec![], verifier_data_2.clone());
-        // Notice that this is the `verifier_data` of Circuit1:
         verifier_data_1.clone().verify(ProofWithPublicInputs {
             proof: proof_1c.clone(),
             public_inputs: public_inputs.clone(),
         })?;
-
-        // do another final iteration, now with Circuit3
-        // dbg!("circuit3.prove");
-        // let inner_inputs = (inp, circuit3_io(inp));
-        // let proof3 = circuit3.prove(inner_inputs, initial_proofs, vec![verifier_data_3.clone()])?;
-        // let public_inputs = RC::<Circuit3>::prepare_public_inputs(vec![], verifier_data_3.clone());
-        // verifier_data_3.clone().verify(ProofWithPublicInputs {
-        //     proof: proof3.clone(),
-        //     public_inputs: public_inputs.clone(),
-        // })?;
-        //
-        // // verify the last proof
-        // let public_inputs = RC::<Circuit3>::prepare_public_inputs(vec![], verifier_data_3.clone());
-        // let pis = ProofWithPublicInputs {
-        //     proof: proof3.clone(),
-        //     public_inputs: public_inputs.clone(),
-        // };
-        // verifier_data_3.clone().verify(pis.clone())?;
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_recursive_circuit() -> Result<()> {
-        // arity=1, n_steps=4
-        test_recursive_circuit_opt(1, 4)?;
-
-        // arity=2, n_steps=3
-        // test_recursive_circuit_opt(2, 3)?; // commented to be skipped in the CI since it's slower
 
         Ok(())
     }

--- a/src/backends/plonky2/recursion/circuit.rs
+++ b/src/backends/plonky2/recursion/circuit.rs
@@ -1,0 +1,579 @@
+/// This file contains the RecursiveCircuit, the circuit used for recursion.
+///
+/// The RecursiveCircuit verifies N proofs of itself (N=arity), together with
+/// the logic defined at the InnerCircuit (in our case, used for the
+/// MainPodCircuit logic).
+///
+/// The arity defines the maximum amount of proofs of itself that the
+/// RecursiveCircuit verifies. When arity>1, using the RecursiveCircuit has the
+/// shape of a tree of the same arity.
+///                                              
+//
+//                      π_root
+//                        ▲
+//                ┌───────┴────────┐
+//                │RecursiveCircuit│
+//                └─▲───▲───▲────▲─┘
+//          ┌───────┘  ┌┘   └┐   └──────┐
+//          │π''_1     │ ... │     π''_N│
+// ┌────────┴───────┐ ┌┴┐┌─┐┌┴┐ ┌───────┴────────┐
+// │RecursiveCircuit│ │.││.││.│ │RecursiveCircuit│
+// └──▲─────────▲───┘ └─┘└─┘└─┘ └──▲─────────▲───┘
+//    │         │                  │         │
+//   π_1  ...  π_N               π'_1 ...  π'_N
+//
+//
+// where
+// N: arity of the RecursiveCircuit
+// π_i: plonky2 proof of the RecursiveCircuit
+//
+use anyhow::{anyhow, Result};
+use hashbrown::HashMap;
+use plonky2::{
+    self,
+    gates::noop::NoopGate,
+    iop::{
+        target::{BoolTarget, Target},
+        witness::{PartialWitness, WitnessWrite},
+    },
+    plonk::{
+        circuit_builder::CircuitBuilder,
+        circuit_data::{
+            CircuitConfig, CircuitData, ProverCircuitData, VerifierCircuitData,
+            VerifierCircuitTarget,
+        },
+        proof::{ProofWithPublicInputs, ProofWithPublicInputsTarget},
+    },
+    recursion::dummy_circuit::cyclic_base_proof,
+};
+
+use crate::{
+    backends::plonky2::basetypes::{Proof, C, D},
+    middleware::F,
+};
+
+/// InnerCircuit is the trait that is used to define the logic of the circuit
+/// that is used inside the RecursiveCircuit.
+pub trait InnerCircuit: Clone {
+    type Targets;
+    type Input;
+
+    fn build(
+        builder: &mut CircuitBuilder<F, D>,
+        // public_inputs will be used for the recursive proof verification
+        public_inputs: Vec<Target>,
+        selectors: Vec<BoolTarget>,
+    ) -> Result<Self::Targets>;
+
+    fn set_targets(
+        pw: &mut PartialWitness<F>,
+        targets: &Self::Targets,
+        input: &Self::Input,
+    ) -> Result<Vec<F>>;
+}
+
+#[derive(Clone, Debug)]
+pub struct RecursiveParams {
+    /// determines the arity of the RecursiveCircuit
+    arity: usize,
+}
+
+/// RecursiveCircuit defines the circuit that verifies `arity` proofs of itself.
+pub struct RecursiveCircuit<I: InnerCircuit> {
+    params: RecursiveParams,
+    selectors_targ: Vec<BoolTarget>,
+    innercircuit_targ: I::Targets,
+    proofs_targ: Vec<ProofWithPublicInputsTarget<D>>,
+    // cyclic-recursion params:
+    verifier_data_targ: VerifierCircuitTarget,
+    verifier_data: VerifierCircuitData<F, C, D>,
+}
+
+impl<I: InnerCircuit> RecursiveCircuit<I> {
+    pub fn build(
+        builder: &mut CircuitBuilder<F, D>,
+        params: &RecursiveParams,
+        // self's verifier_data
+        verifier_data: VerifierCircuitData<F, C, D>,
+    ) -> Result<Self> {
+        let selectors_targ: Vec<BoolTarget> = (0..params.arity)
+            .map(|_| builder.add_virtual_bool_target_safe())
+            .collect();
+
+        // proof verification
+        let common_data = verifier_data.common.clone();
+        let verifier_data_targ = builder.add_verifier_data_public_inputs();
+        let proofs_targ: Result<Vec<ProofWithPublicInputsTarget<D>>> = (0..params.arity)
+            .map(|i| {
+                let proof_targ = builder.add_virtual_proof_with_pis(&common_data);
+                builder.conditionally_verify_cyclic_proof_or_dummy::<C>(
+                    selectors_targ[i],
+                    &proof_targ,
+                    &common_data,
+                )?;
+                Ok(proof_targ)
+            })
+            .collect();
+        let proofs_targ = proofs_targ?;
+
+        // get the targets of the public inputs used to verify the proofs, to be
+        // used in the InnerCircuit
+        let pub_inp: Vec<Target> = proofs_targ
+            .iter()
+            .flat_map(|proof_pis| proof_pis.public_inputs.clone())
+            .collect();
+
+        // build the InnerCircuits logic
+        let innercircuit_targ: I::Targets = I::build(builder, pub_inp, selectors_targ.clone())?;
+
+        Ok(Self {
+            params: params.clone(),
+            selectors_targ,
+            innercircuit_targ,
+            proofs_targ,
+            verifier_data_targ,
+            verifier_data,
+        })
+    }
+
+    pub fn set_targets(
+        &mut self,
+        pw: &mut PartialWitness<F>,
+        dummy_proof: Proof,
+        innercircuit_input: I::Input,
+        recursive_proofs: Vec<Proof>,
+        non_base_node: bool,
+    ) -> Result<()> {
+        let n = recursive_proofs.len();
+        assert!(n <= self.params.arity);
+
+        // fill the missing proofs with dummy_proofs
+        let dummy_proofs: Vec<Proof> = (n..self.params.arity)
+            .map(|_| dummy_proof.clone())
+            .collect();
+        let recursive_proofs: Vec<Proof> = [recursive_proofs, dummy_proofs].concat();
+
+        // set the first n selectors to `non_base_node`, and the rest to false
+        for i in 0..n {
+            pw.set_bool_target(self.selectors_targ[i], non_base_node)?;
+        }
+        for i in n..self.params.arity {
+            pw.set_bool_target(self.selectors_targ[i], false)?;
+        }
+
+        // set the InnerCircuit related values
+        let innercircuit_pubinp: Vec<F> =
+            I::set_targets(pw, &self.innercircuit_targ, &innercircuit_input)?;
+
+        // recursive proofs verification
+        pw.set_verifier_data_target(&self.verifier_data_targ, &self.verifier_data.verifier_only)?;
+
+        // put together the public inputs with the verifier_data
+        let public_inputs =
+            Self::prepare_public_inputs(innercircuit_pubinp, self.verifier_data.clone());
+        #[allow(clippy::needless_range_loop)]
+        for i in 0..self.params.arity {
+            pw.set_proof_with_pis_target(
+                &self.proofs_targ[i],
+                &ProofWithPublicInputs {
+                    proof: recursive_proofs[i].clone(),
+                    public_inputs: public_inputs.clone(),
+                },
+            )?;
+        }
+
+        Ok(())
+    }
+
+    /// returns the full-recursive CircuitData
+    pub fn circuit_data(params: &RecursiveParams) -> Result<CircuitData<F, C, D>> {
+        let mut data = common_data_for_recursion::<I>(params)?;
+
+        // build the actual RecursiveCircuit circuit data
+        let config = CircuitConfig::standard_recursion_config();
+        let mut builder = CircuitBuilder::new(config);
+
+        let _ = Self::build(&mut builder, params, data.verifier_data())?;
+        dbg!(builder.num_gates());
+        data = builder.build::<C>();
+
+        Ok(data)
+    }
+
+    /// returns ProverCircuitData
+    pub fn build_prover(
+        params: &RecursiveParams,
+        verifier_data: VerifierCircuitData<F, C, D>,
+    ) -> Result<ProverCircuitData<F, C, D>> {
+        let config = CircuitConfig::standard_recursion_config();
+        let mut builder = CircuitBuilder::new(config);
+
+        let _ = Self::build(&mut builder, params, verifier_data.clone())?;
+
+        Ok(builder.build_prover::<C>())
+    }
+
+    pub fn dummy_proof(circuit_data: CircuitData<F, C, D>) -> Proof {
+        let verifier_data = circuit_data.verifier_data();
+        let dummy_proof_pis = cyclic_base_proof(
+            &circuit_data.common,
+            &verifier_data.verifier_only,
+            HashMap::new(),
+        );
+        dummy_proof_pis.proof
+    }
+
+    pub fn prepare_public_inputs(
+        public_inputs: Vec<F>,
+        verifier_data: VerifierCircuitData<F, C, D>,
+    ) -> Vec<F> {
+        [
+            public_inputs,
+            // add verifier_data
+            verifier_data.verifier_only.circuit_digest.elements.to_vec(),
+            verifier_data
+                .verifier_only
+                .constants_sigmas_cap
+                .0
+                .iter()
+                .flat_map(|e| e.elements)
+                .collect(),
+        ]
+        .concat()
+    }
+}
+
+fn common_data_for_recursion<I: InnerCircuit>(
+    params: &RecursiveParams,
+) -> Result<CircuitData<F, C, D>> {
+    // 1st
+    let config = CircuitConfig::standard_recursion_config();
+    let builder = CircuitBuilder::<F, D>::new(config);
+    let data = builder.build::<C>();
+
+    // 2nd
+    let config = CircuitConfig::standard_recursion_config();
+    let mut builder = CircuitBuilder::<F, D>::new(config.clone());
+    let verifier_data = builder.add_virtual_verifier_data(data.common.config.fri_config.cap_height);
+    // proofs
+    for _ in 0..params.arity {
+        let proof = builder.add_virtual_proof_with_pis(&data.common);
+        builder.verify_proof::<C>(&proof, &verifier_data, &data.common);
+    }
+    let data = builder.build::<C>();
+
+    // 3rd
+    let config = CircuitConfig::standard_recursion_config();
+    let mut builder = CircuitBuilder::<F, D>::new(config.clone());
+
+    builder.add_gate(
+        // add a ConstantGate, because without this, when later generating the `dummy_circuit`
+        // (inside the `conditionally_verify_cyclic_proof_or_dummy`), it fails due the
+        // `CommonCircuitData` of the generated circuit not matching the given `CommonCircuitData`
+        // to create it. Without this it fails because it misses a ConstantGate.
+        plonky2::gates::constant::ConstantGate::new(config.num_constants),
+        vec![],
+    );
+
+    // set the targets for the InnerCircuit
+    let _ = I::build(&mut builder, vec![], vec![])?;
+
+    // cyclic_recursion proofs
+    let verifier_data = builder.add_verifier_data_public_inputs();
+    for _ in 0..params.arity {
+        let proof = builder.add_virtual_proof_with_pis(&data.common);
+        builder.verify_proof::<C>(&proof, &verifier_data, &data.common);
+    }
+
+    // pad min gates
+    let n_gates = compute_num_gates(params)?;
+    while builder.num_gates() < n_gates {
+        builder.add_gate(NoopGate, vec![]);
+    }
+    Ok(builder.build::<C>())
+}
+
+fn compute_num_gates(params: &RecursiveParams) -> Result<usize> {
+    // Note: the following numbers are WIP, obtained by trial-error by running different
+    // configurations in the tests.
+    let n_gates = match params.arity {
+        0..=1 => 1 << 12,
+        2 => 1 << 13,
+        3..=5 => 1 << 14,
+        6 => 1 << 15,
+        _ => 0,
+    };
+    if n_gates == 0 {
+        return Err(anyhow!(
+            "arity={} not supported. Currently supported arity from 1 to 6 (both included)",
+            params.arity
+        ));
+    }
+    Ok(n_gates)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{marker::PhantomData, time::Instant};
+
+    use anyhow::Result;
+    use plonky2::hash::{
+        hash_types::{HashOut, HashOutTarget},
+        poseidon::PoseidonHash,
+    };
+
+    use super::*;
+
+    #[derive(Debug, Clone)]
+    pub struct RecursiveTree<I: InnerCircuit> {
+        _i: PhantomData<I>,
+    }
+
+    impl<I: InnerCircuit> RecursiveTree<I> {
+        fn prepare_public_inputs(
+            public_inputs: Vec<F>,
+            verifier_data: VerifierCircuitData<F, C, D>,
+        ) -> Vec<F> {
+            RecursiveCircuit::<I>::prepare_public_inputs(public_inputs, verifier_data)
+        }
+
+        fn prove_node(
+            prover: &ProverCircuitData<F, C, D>,
+            circuit: &mut RecursiveCircuit<I>,
+            dummy_proof: Proof,
+            innercircuit_input: I::Input,
+            recursive_proofs: Vec<Proof>,
+            // this is for the sake of testing, not for real usage
+            non_base_node: bool, // false=skip proof check, true=verify proof
+        ) -> Result<Proof> {
+            // fill the targets
+            let mut pw = PartialWitness::new();
+            circuit.set_targets(
+                &mut pw,
+                dummy_proof,
+                innercircuit_input,
+                recursive_proofs,
+                non_base_node,
+            )?;
+
+            let new_proof = prover.prove(pw)?;
+
+            Ok(new_proof.proof)
+        }
+    }
+
+    pub struct InnerCircuitTargets {
+        input_targ: HashOutTarget,
+        _output_targ: HashOutTarget,
+    }
+
+    #[derive(Clone, Debug)]
+    pub struct Circuit1 {}
+    impl InnerCircuit for Circuit1 {
+        type Targets = InnerCircuitTargets;
+        type Input = HashOut<F>;
+        fn build(
+            builder: &mut CircuitBuilder<F, D>,
+            _public_inputs: Vec<Target>,
+            _selectors: Vec<BoolTarget>,
+        ) -> Result<Self::Targets> {
+            let input_targ = builder.add_virtual_hashes(1)[0];
+
+            let mut output_targ: HashOutTarget = input_targ;
+            for _ in 0..100 {
+                output_targ = builder
+                    .hash_n_to_hash_no_pad::<PoseidonHash>(output_targ.elements.clone().to_vec());
+            }
+
+            Ok(InnerCircuitTargets {
+                input_targ,
+                _output_targ: output_targ,
+            })
+        }
+
+        fn set_targets(
+            pw: &mut PartialWitness<F>,
+            targets: &Self::Targets,
+            input: &Self::Input,
+        ) -> Result<Vec<F>> {
+            pw.set_hash_target(targets.input_targ, *input)?;
+
+            Ok(vec![])
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub struct Circuit2 {}
+    impl InnerCircuit for Circuit2 {
+        type Targets = InnerCircuitTargets;
+        type Input = HashOut<F>;
+        fn build(
+            builder: &mut CircuitBuilder<F, D>,
+            _public_inputs: Vec<Target>,
+            _selectors: Vec<BoolTarget>,
+        ) -> Result<Self::Targets> {
+            let input_targ = builder.add_virtual_hashes(1)[0];
+
+            let mut output_targ: HashOutTarget = input_targ;
+            for _ in 0..2000 {
+                output_targ = builder
+                    .hash_n_to_hash_no_pad::<PoseidonHash>(output_targ.elements.clone().to_vec());
+            }
+
+            Ok(InnerCircuitTargets {
+                input_targ,
+                _output_targ: output_targ,
+            })
+        }
+
+        fn set_targets(
+            pw: &mut PartialWitness<F>,
+            targets: &Self::Targets,
+            input: &Self::Input,
+        ) -> Result<Vec<F>> {
+            pw.set_hash_target(targets.input_targ, *input)?;
+
+            Ok(vec![])
+        }
+    }
+
+    fn test_recursive_circuit_opt(
+        // arity: number of cyclic recursion proofs verified at each node of the
+        // recursion tree
+        arity: usize,
+        // n_steps: determines the number of recursive steps. Notice that when
+        // arity>1, n_steps determines the number of levels of the recursive
+        // tree
+        n_steps: usize,
+    ) -> Result<()> {
+        let params = RecursiveParams { arity };
+
+        type RC<I> = RecursiveCircuit<I>;
+        type RT<I> = RecursiveTree<I>;
+
+        // build the circuit_data & verifier_data for the recursive circuit
+        let start = Instant::now();
+        let circuit_data = RC::<Circuit1>::circuit_data(&params)?;
+        let verifier_data = circuit_data.verifier_data();
+        let prover = RC::<Circuit1>::build_prover(&params, verifier_data.clone())?;
+
+        let dummy_proof = RC::<Circuit1>::dummy_proof(circuit_data);
+        println!("recursive params generated {:?}", start.elapsed());
+
+        // build 1st circuit: circuit1, a RecursiveCircuit which uses as
+        // InnerCircuit the Circuit1
+        let config = CircuitConfig::standard_recursion_config();
+        let mut builder = CircuitBuilder::new(config.clone());
+        let start = Instant::now();
+        let mut circuit = RC::<Circuit1>::build(&mut builder, &params, verifier_data.clone())?;
+        println!("RecursiveCircuit::build(): {:?}", start.elapsed());
+        println!("Circuit1 num_gates {}", builder.num_gates());
+
+        // build 2nd circuit: circuit2, a RecursiveCircuit which uses as
+        // InnerCircuit the Circuit2
+        let mut builder2 = CircuitBuilder::new(config);
+        let mut circuit2 = RC::<Circuit2>::build(&mut builder2, &params, verifier_data.clone())?;
+        println!("Circuit2 num_gates {}", builder2.num_gates());
+
+        // we start with 0 proofs at the first iteration
+        let mut proofs_at_level_i: Vec<Proof> = vec![];
+
+        // loop over the recursion levels
+        for i in 0..n_steps {
+            let mut next_level_proofs: Vec<Proof> = vec![];
+
+            // loop over the nodes of each recursion tree level
+            for j in 0..arity {
+                let innercircuit_input = HashOut::<F>::ZERO;
+
+                let non_base_node: bool = i > 0; // set true/false
+
+                // do the recursive step
+                let start = Instant::now();
+                let new_proof = RT::<Circuit1>::prove_node(
+                    &prover,
+                    &mut circuit,
+                    dummy_proof.clone(),
+                    innercircuit_input,
+                    proofs_at_level_i.clone(),
+                    non_base_node,
+                )?;
+                println!(
+                    "RecursiveTree::prove_node (level: i={}, node: j={}) took: {:?}ms",
+                    i,
+                    j,
+                    start.elapsed()
+                );
+
+                // verify the recursive proof
+                let public_inputs =
+                    RT::<Circuit1>::prepare_public_inputs(vec![], verifier_data.clone());
+                verifier_data.clone().verify(ProofWithPublicInputs {
+                    proof: new_proof.clone(),
+                    public_inputs: public_inputs.clone(),
+                })?;
+
+                // set new_proof for next iteration
+                next_level_proofs.push(new_proof);
+            }
+            proofs_at_level_i = next_level_proofs.clone();
+        }
+
+        // do one more iteration, but now with Circuit2
+        let innercircuit_input = HashOut::<F>::ZERO;
+        let new_proof = RT::<Circuit2>::prove_node(
+            &prover,
+            &mut circuit2,
+            dummy_proof.clone(),
+            innercircuit_input,
+            proofs_at_level_i,
+            true,
+        )?;
+        let public_inputs = RT::<Circuit2>::prepare_public_inputs(vec![], verifier_data.clone());
+        // Notice that this is the `verifier_data` of Circuit1:
+        verifier_data.clone().verify(ProofWithPublicInputs {
+            proof: new_proof.clone(),
+            public_inputs: public_inputs.clone(),
+        })?;
+
+        // do another final iteration, back with Circuit1
+        let innercircuit_input = HashOut::<F>::ZERO;
+        let new_proof = RT::<Circuit1>::prove_node(
+            &prover,
+            &mut circuit,
+            dummy_proof,
+            innercircuit_input,
+            vec![new_proof],
+            true,
+        )?;
+        let public_inputs = RT::<Circuit1>::prepare_public_inputs(vec![], verifier_data.clone());
+        verifier_data.clone().verify(ProofWithPublicInputs {
+            proof: new_proof.clone(),
+            public_inputs: public_inputs.clone(),
+        })?;
+        proofs_at_level_i = vec![new_proof];
+
+        assert_eq!(proofs_at_level_i.len(), 1);
+        let last_proof = proofs_at_level_i[0].clone();
+
+        // verify the last proof
+        let public_inputs = RT::<Circuit1>::prepare_public_inputs(vec![], verifier_data.clone());
+        let pis = ProofWithPublicInputs {
+            proof: last_proof.clone(),
+            public_inputs: public_inputs.clone(),
+        };
+        verifier_data.clone().verify(pis.clone())?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_recursive_circuit() -> Result<()> {
+        // arity=1, n_steps=4
+        test_recursive_circuit_opt(1, 4)?;
+
+        // arity=2, n_steps=3
+        // test_recursive_circuit_opt(2, 3)?; // commented to be skipped in the CI since it's slower
+
+        Ok(())
+    }
+}

--- a/src/backends/plonky2/recursion/circuit.rs
+++ b/src/backends/plonky2/recursion/circuit.rs
@@ -38,7 +38,7 @@ use plonky2::{
     plonk::{
         circuit_builder::CircuitBuilder,
         circuit_data::{
-            CircuitConfig, CircuitData, ProverCircuitData, VerifierCircuitData,
+            CircuitConfig, CircuitData, CommonCircuitData, ProverCircuitData, VerifierCircuitData,
             VerifierCircuitTarget,
         },
         proof::{ProofWithPublicInputs, ProofWithPublicInputsTarget},
@@ -76,41 +76,107 @@ pub trait InnerCircuit: Clone {
 pub struct RecursiveParams {
     /// determines the arity of the RecursiveCircuit
     arity: usize,
+    common_data: CommonCircuitData<F, D>,
+    dummy_proof: Proof,
+    dummy_verifier_data: VerifierCircuitData<F, C, D>,
+}
+
+pub fn new_params<I: InnerCircuit>(
+    arity: usize,
+    inner_params: &I::Params,
+) -> Result<RecursiveParams> {
+    let circuit_data = RecursiveCircuit::<I>::circuit_data(arity, &inner_params)?;
+    let common_data = circuit_data.common.clone();
+    let verifier_data = circuit_data.verifier_data();
+    let dummy_proof = RecursiveCircuit::<I>::dummy_proof(circuit_data);
+    Ok(RecursiveParams {
+        arity,
+        common_data,
+        dummy_proof,
+        dummy_verifier_data: verifier_data,
+    })
 }
 
 /// RecursiveCircuit defines the circuit that verifies `arity` proofs of itself.
 pub struct RecursiveCircuit<I: InnerCircuit> {
     params: RecursiveParams,
+    prover: ProverCircuitData<F, C, D>,
+    targets: RecursiveCircuitTargets<I>,
+    // verifier_data: VerifierCircuitData<F, C, D>,
+}
+#[derive(Clone, Debug)]
+pub struct RecursiveCircuitTargets<I: InnerCircuit> {
     selectors_targ: Vec<BoolTarget>,
     innercircuit_targ: I,
     proofs_targ: Vec<ProofWithPublicInputsTarget<D>>,
     // cyclic-recursion params:
-    verifier_data_targ: VerifierCircuitTarget,
-    verifier_data: VerifierCircuitData<F, C, D>,
+    verifier_data_targ: Vec<VerifierCircuitTarget>,
 }
 
 impl<I: InnerCircuit> RecursiveCircuit<I> {
+    pub fn prove(
+        &mut self,
+        inner_inputs: I::Input,
+        proofs: Vec<Proof>,
+        verifier_datas: Vec<VerifierCircuitData<F, C, D>>,
+    ) -> Result<Proof> {
+        let mut pw = PartialWitness::new();
+        self.set_targets(
+            &mut pw,
+            inner_inputs, // innercircuit_input
+            proofs.clone(),
+            verifier_datas,
+        )?;
+        let proof = self.prover.prove(pw)?.proof;
+        Ok(proof)
+    }
+
     pub fn build(
+        params: &RecursiveParams,
+        inner_params: &I::Params,
+        // self's verifier_data
+        // verifier_data: VerifierCircuitData<F, C, D>, // TODO rm
+        // common_data: CommonCircuitData<F, D>, // TODO wip. TODO move to a RecursiveCircuitBuilder
+    ) -> Result<Self> {
+        let config = CircuitConfig::standard_recursion_config();
+        let mut builder = CircuitBuilder::new(config.clone());
+
+        let targets: RecursiveCircuitTargets<I> =
+            Self::build_opt(&mut builder, params, inner_params)?;
+
+        println!("RecursiveCircuit<I> num_gates {}", builder.num_gates());
+
+        let prover: ProverCircuitData<F, C, D> = builder.build_prover::<C>();
+        Ok(Self {
+            params: params.clone(),
+            prover,
+            targets,
+        })
+    }
+
+    pub fn build_opt(
         builder: &mut CircuitBuilder<F, D>,
         params: &RecursiveParams,
         inner_params: &I::Params,
         // self's verifier_data
-        verifier_data: VerifierCircuitData<F, C, D>,
-    ) -> Result<Self> {
+        // verifier_data: VerifierCircuitData<F, C, D>, // TODO rm
+        // common_data: CommonCircuitData<F, D>, // TODO wip. TODO move to a RecursiveCircuitBuilder
+    ) -> Result<RecursiveCircuitTargets<I>> {
         let selectors_targ: Vec<BoolTarget> = (0..params.arity)
             .map(|_| builder.add_virtual_bool_target_safe())
             .collect();
 
         // proof verification
-        let common_data = verifier_data.common.clone();
-        let verifier_data_targ = builder.add_verifier_data_public_inputs();
+        let verifier_data_targ: Vec<VerifierCircuitTarget> = (0..params.arity)
+            .map(|_| builder.add_verifier_data_public_inputs())
+            .collect();
         let proofs_targ: Result<Vec<ProofWithPublicInputsTarget<D>>> = (0..params.arity)
             .map(|i| {
-                let proof_targ = builder.add_virtual_proof_with_pis(&common_data);
+                let proof_targ = builder.add_virtual_proof_with_pis(&params.common_data);
                 builder.conditionally_verify_cyclic_proof_or_dummy::<C>(
                     selectors_targ[i],
                     &proof_targ,
-                    &common_data,
+                    &params.common_data,
                 )?;
                 Ok(proof_targ)
             })
@@ -128,55 +194,64 @@ impl<I: InnerCircuit> RecursiveCircuit<I> {
         let innercircuit_targ: I =
             I::build(builder, inner_params, pub_inp, selectors_targ.clone())?;
 
-        Ok(Self {
-            params: params.clone(),
+        Ok(RecursiveCircuitTargets {
             selectors_targ,
             innercircuit_targ,
             proofs_targ,
             verifier_data_targ,
-            verifier_data,
         })
     }
 
     pub fn set_targets(
         &mut self,
         pw: &mut PartialWitness<F>,
-        dummy_proof: Proof,
         innercircuit_input: I::Input,
         recursive_proofs: Vec<Proof>,
+        verifier_datas: Vec<VerifierCircuitData<F, C, D>>,
     ) -> Result<()> {
         let n = recursive_proofs.len();
         assert!(n <= self.params.arity);
+        // assert_eq!(recursive_proofs.len(), verifier_datas.len()); // TODO WIP
 
         // fill the missing proofs with dummy_proofs
         let dummy_proofs: Vec<Proof> = (n..self.params.arity)
-            .map(|_| dummy_proof.clone())
+            .map(|_| self.params.dummy_proof.clone())
             .collect();
         let recursive_proofs: Vec<Proof> = [recursive_proofs, dummy_proofs].concat();
 
+        // fill the missing verifier_datas with dummy_verifier_datas
+        let dummy_verifier_datas: Vec<VerifierCircuitData<F, C, D>> = (n..self.params.arity)
+            .map(|_| self.params.dummy_verifier_data.clone())
+            .collect();
+        let verifier_datas: Vec<VerifierCircuitData<F, C, D>> =
+            [verifier_datas, dummy_verifier_datas].concat();
+
         // set the first n selectors to true, and the rest to false
         for i in 0..n {
-            pw.set_bool_target(self.selectors_targ[i], true)?;
+            pw.set_bool_target(self.targets.selectors_targ[i], true)?;
         }
         for i in n..self.params.arity {
-            pw.set_bool_target(self.selectors_targ[i], false)?;
+            pw.set_bool_target(self.targets.selectors_targ[i], false)?;
         }
 
         // set the InnerCircuit related values
-        self.innercircuit_targ
+        self.targets
+            .innercircuit_targ
             .set_targets(pw, &innercircuit_input)?;
-
-        // recursive proofs verification
-        pw.set_verifier_data_target(&self.verifier_data_targ, &self.verifier_data.verifier_only)?;
 
         #[allow(clippy::needless_range_loop)]
         for i in 0..self.params.arity {
+            pw.set_verifier_data_target(
+                &self.targets.verifier_data_targ[i],
+                &verifier_datas[i].verifier_only,
+            )?; // TODO WIP
+
             // put together the public inputs with the verifier_data. Note:
             // current version doesn't use InnerCircuit's public inputs (vec![])
-            let public_inputs = Self::prepare_public_inputs(vec![], self.verifier_data.clone());
+            let public_inputs = Self::prepare_public_inputs(vec![], verifier_datas[0].clone());
 
             pw.set_proof_with_pis_target(
-                &self.proofs_targ[i],
+                &self.targets.proofs_targ[i],
                 &ProofWithPublicInputs {
                     proof: recursive_proofs[i].clone(),
                     public_inputs: public_inputs.clone(),
@@ -189,33 +264,29 @@ impl<I: InnerCircuit> RecursiveCircuit<I> {
 
     /// returns the full-recursive CircuitData
     pub fn circuit_data(
-        params: &RecursiveParams,
+        // params: &RecursiveParams,
+        arity: usize,
         inner_params: &I::Params,
     ) -> Result<CircuitData<F, C, D>> {
-        let mut data = common_data_for_recursion::<I>(params, inner_params)?;
+        let data: CircuitData<F, C, D> = common_data_for_recursion::<I>(arity, inner_params)?;
+        let common_data = data.common.clone();
+        let verifier_data = data.verifier_data();
+        let dummy_proof = Self::dummy_proof(data);
+        let params = RecursiveParams {
+            arity,
+            common_data,
+            dummy_proof,
+            dummy_verifier_data: verifier_data,
+        };
 
         // build the actual RecursiveCircuit circuit data
         let config = CircuitConfig::standard_recursion_config();
         let mut builder = CircuitBuilder::new(config);
 
-        let _ = Self::build(&mut builder, params, inner_params, data.verifier_data())?;
-        data = builder.build::<C>();
+        let _ = Self::build_opt(&mut builder, &params, inner_params)?;
+        let data = builder.build::<C>();
 
         Ok(data)
-    }
-
-    /// returns ProverCircuitData
-    pub fn build_prover(
-        params: &RecursiveParams,
-        inner_params: &I::Params,
-        verifier_data: VerifierCircuitData<F, C, D>,
-    ) -> Result<ProverCircuitData<F, C, D>> {
-        let config = CircuitConfig::standard_recursion_config();
-        let mut builder = CircuitBuilder::new(config);
-
-        let _ = Self::build(&mut builder, params, inner_params, verifier_data.clone())?;
-
-        Ok(builder.build_prover::<C>())
     }
 
     pub fn dummy_proof(circuit_data: CircuitData<F, C, D>) -> Proof {
@@ -249,7 +320,7 @@ impl<I: InnerCircuit> RecursiveCircuit<I> {
 }
 
 fn common_data_for_recursion<I: InnerCircuit>(
-    params: &RecursiveParams,
+    arity: usize,
     inner_params: &I::Params,
 ) -> Result<CircuitData<F, C, D>> {
     // 1st
@@ -262,7 +333,7 @@ fn common_data_for_recursion<I: InnerCircuit>(
     let mut builder = CircuitBuilder::<F, D>::new(config.clone());
     let verifier_data = builder.add_virtual_verifier_data(data.common.config.fri_config.cap_height);
     // proofs
-    for _ in 0..params.arity {
+    for _ in 0..arity {
         let proof = builder.add_virtual_proof_with_pis(&data.common);
         builder.verify_proof::<C>(&proof, &verifier_data, &data.common);
     }
@@ -286,23 +357,23 @@ fn common_data_for_recursion<I: InnerCircuit>(
 
     // cyclic_recursion proofs
     let verifier_data = builder.add_verifier_data_public_inputs();
-    for _ in 0..params.arity {
+    for _ in 0..arity {
         let proof = builder.add_virtual_proof_with_pis(&data.common);
         builder.verify_proof::<C>(&proof, &verifier_data, &data.common);
     }
 
     // pad min gates
-    let n_gates = compute_num_gates(params)?;
+    let n_gates = compute_num_gates(arity)?;
     while builder.num_gates() < n_gates {
         builder.add_gate(NoopGate, vec![]);
     }
     Ok(builder.build::<C>())
 }
 
-fn compute_num_gates(params: &RecursiveParams) -> Result<usize> {
+fn compute_num_gates(arity: usize) -> Result<usize> {
     // Note: the following numbers are WIP, obtained by trial-error by running different
     // configurations in the tests.
-    let n_gates = match params.arity {
+    let n_gates = match arity {
         0..=1 => 1 << 12,
         2 => 1 << 13,
         3..=5 => 1 << 14,
@@ -312,7 +383,7 @@ fn compute_num_gates(params: &RecursiveParams) -> Result<usize> {
     if n_gates == 0 {
         return Err(Error::custom(format!(
             "arity={} not supported. Currently supported arity from 1 to 6 (both included)",
-            params.arity
+            arity
         )));
     }
     Ok(n_gates)
@@ -336,7 +407,7 @@ mod tests {
     // out-of-circuit input-output computation for Circuit1
     fn circuit1_io(inp: HashOut<F>) -> HashOut<F> {
         let mut out: HashOut<F> = inp;
-        for _ in 0..100 {
+        for _ in 0..2000 {
             out = PoseidonHash::hash_no_pad(&out.elements)
         }
         out
@@ -344,7 +415,7 @@ mod tests {
     // out-of-circuit input-output computation for Circuit2
     fn circuit2_io(inp: HashOut<F>) -> HashOut<F> {
         let mut out: HashOut<F> = inp;
-        for _ in 0..2000 {
+        for _ in 0..100 {
             out = PoseidonHash::hash_no_pad(&out.elements)
         }
         out
@@ -375,7 +446,7 @@ mod tests {
             let input_targ = builder.add_virtual_hash();
 
             let mut output_targ: HashOutTarget = input_targ.clone();
-            for _ in 0..100 {
+            for _ in 0..2000 {
                 output_targ = builder
                     .hash_n_to_hash_no_pad::<PoseidonHash>(output_targ.elements.clone().to_vec());
             }
@@ -408,7 +479,7 @@ mod tests {
             let input_targ = builder.add_virtual_hash();
 
             let mut output_targ: HashOutTarget = input_targ.clone();
-            for _ in 0..2000 {
+            for _ in 0..100 {
                 output_targ = builder
                     .hash_n_to_hash_no_pad::<PoseidonHash>(output_targ.elements.clone().to_vec());
             }
@@ -495,6 +566,20 @@ mod tests {
         Ok(())
     }
 
+    /*
+    - c1 = RecursiveCircuit<Circuit1>
+    - c2 = Circuit2
+    // c1 & c2
+
+    - proof_1a = c1.prove([null, null], [null, null])
+    - proof_1b = c1.prove([proof_1a, null], [verifier_data_c1, null])
+    - proof_2 = c2.prove(c2_inputs)
+
+    - proof_1c = c1.prove([proof_1b, proof_2], [verifier_data_c1, verifier_data_c2])
+
+
+    */
+
     fn test_recursive_circuit_opt(
         // arity: number of cyclic recursion proofs verified at each node of the
         // recursion tree
@@ -504,17 +589,23 @@ mod tests {
         // tree
         n_steps: usize,
     ) -> Result<()> {
-        let params = RecursiveParams { arity };
-
         type RC<I> = RecursiveCircuit<I>;
         let inner_params = ();
 
+        let params: RecursiveParams = new_params::<Circuit1>(arity, &inner_params)?;
+
         // build the circuit_data & verifier_data for the recursive circuit
         let start = Instant::now();
-        let circuit_data = RC::<Circuit1>::circuit_data(&params, &inner_params)?;
-        let verifier_data = circuit_data.verifier_data();
-        let prover = RC::<Circuit1>::build_prover(&params, &inner_params, verifier_data.clone())?;
-        let dummy_proof = RC::<Circuit1>::dummy_proof(circuit_data);
+        let circuit_data_1 = RC::<Circuit1>::circuit_data(arity, &inner_params)?;
+        let verifier_data_1 = circuit_data_1.verifier_data();
+
+        let circuit_data_2 = RC::<Circuit2>::circuit_data(arity, &inner_params)?;
+        let verifier_data_2 = circuit_data_2.verifier_data();
+
+        // let circuit_data_3 = RC::<Circuit3>::circuit_data(arity, &inner_params)?;
+        // let verifier_data_3 = circuit_data_3.verifier_data();
+
+        // let dummy_proof = RC::<Circuit1>::dummy_proof(circuit_data_1);
         println!(
             "circuit_data,prover,dummy_proof generated {:?}",
             start.elapsed()
@@ -522,110 +613,94 @@ mod tests {
 
         // build 1st circuit: circuit1, a RecursiveCircuit which uses as
         // InnerCircuit the Circuit1
-        let config = CircuitConfig::standard_recursion_config();
-        let mut builder = CircuitBuilder::new(config.clone());
-        let mut circuit = RC::<Circuit1>::build(&mut builder, &params, &(), verifier_data.clone())?;
-        println!("Circuit1 num_gates {}", builder.num_gates());
+        let mut circuit1 = RC::<Circuit1>::build(&params, &())?;
 
         // build 2nd circuit: circuit2, a RecursiveCircuit which uses as
         // InnerCircuit the Circuit2
-        let mut builder2 = CircuitBuilder::new(config.clone());
-        let mut circuit2 =
-            RC::<Circuit2>::build(&mut builder2, &params, &(), verifier_data.clone())?;
-        println!("Circuit2 num_gates {}", builder2.num_gates());
+        let mut circuit2 = RC::<Circuit2>::build(&params, &())?;
 
         // build 3rd circuit: circuit3, a RecursiveCircuit which uses as
         // InnerCircuit the Circuit3
-        let mut builder3 = CircuitBuilder::new(config);
-        let mut circuit3 =
-            RC::<Circuit3>::build(&mut builder3, &params, &(), verifier_data.clone())?;
-        println!("Circuit3 num_gates {}", builder3.num_gates());
+        // let circuit3 = RC::<Circuit3>::build(&params, &())?;
+
+        // TODO use circuit4 in the test
+        // circuit4 is the Circuit3 without the RecursiveCircuit wrapper
+        // let mut builder4 = CircuitBuilder::new(config);
+        // let mut circuit4 = Circuit3::build(&mut builder4, &(), vec![], vec![])?;
+        // println!("Circuit4 num_gates {}", builder4.num_gates());
 
         // we start with 0 proofs at the first iteration, which means that
         // internally at RecursiveCircuit.set_targets, it will use all
         // dummy_proofs
-        let mut proofs_at_level_i: Vec<Proof> = vec![];
 
+        dbg!("circuit1.prove");
         let inp = HashOut::<F>::ZERO;
         let inner_inputs = (inp, circuit1_io(inp));
+        let proof_1a =
+            // circuit1.prove(inner_inputs, vec![], vec![verifier_data_1.clone()])?;
+            circuit1.prove(inner_inputs, vec![], vec![])?;
+        let public_inputs = RC::<Circuit1>::prepare_public_inputs(vec![], verifier_data_1.clone());
+        // Notice that this is the `verifier_data` of Circuit1:
+        verifier_data_1.clone().verify(ProofWithPublicInputs {
+            proof: proof_1a.clone(),
+            public_inputs: public_inputs.clone(),
+        })?;
 
-        // loop over the recursion steps
-        for i in 0..n_steps {
-            let mut next_level_proofs: Vec<Proof> = vec![];
-
-            // loop over the nodes of each recursion tree level
-            for j in 0..arity {
-                // do the recursive step
-                let start = Instant::now();
-                let mut pw = PartialWitness::new();
-                circuit.set_targets(
-                    &mut pw,
-                    dummy_proof.clone(),
-                    inner_inputs,              // innercircuit_input
-                    proofs_at_level_i.clone(), // recursive_proofs
-                )?;
-                let new_proof = prover.prove(pw)?.proof;
-                println!(
-                    "RecursiveTree::prove_node (level: i={}, node: j={}) took: {:?}ms",
-                    i,
-                    j,
-                    start.elapsed()
-                );
-
-                // verify the recursive proof
-                let public_inputs =
-                    RC::<Circuit1>::prepare_public_inputs(vec![], verifier_data.clone());
-                verifier_data.clone().verify(ProofWithPublicInputs {
-                    proof: new_proof.clone(),
-                    public_inputs: public_inputs.clone(),
-                })?;
-
-                // set new_proof for next iteration
-                next_level_proofs.push(new_proof);
-            }
-            proofs_at_level_i = next_level_proofs.clone();
-        }
+        dbg!("circuit1.prove (2nd iteration), verifies the proof of 1st iteration with circuit1");
+        let inp = HashOut::<F>::ZERO;
+        let inner_inputs = (inp, circuit1_io(inp));
+        let proof_1b = circuit1.prove(
+            inner_inputs,
+            vec![proof_1a.clone()],
+            vec![verifier_data_1.clone()],
+        )?;
+        let public_inputs = RC::<Circuit1>::prepare_public_inputs(vec![], verifier_data_1.clone());
+        // Notice that this is the `verifier_data` of Circuit1:
+        verifier_data_1.clone().verify(ProofWithPublicInputs {
+            proof: proof_1b.clone(),
+            public_inputs: public_inputs.clone(),
+        })?;
 
         // do one more iteration, but now with Circuit2
+        dbg!("circuit2.prove");
         let inner_inputs = (inp, circuit2_io(inp));
-        let mut pw = PartialWitness::new();
-        circuit2.set_targets(
-            &mut pw,
-            dummy_proof.clone(),
-            inner_inputs,              // innercircuit_input
-            proofs_at_level_i.clone(), // recursive_proofs
-        )?;
-        let new_proof = prover.prove(pw)?.proof;
-        let public_inputs = RC::<Circuit2>::prepare_public_inputs(vec![], verifier_data.clone());
+        let proof_2 = circuit2.prove(inner_inputs, vec![], vec![verifier_data_2.clone()])?;
+        let public_inputs = RC::<Circuit2>::prepare_public_inputs(vec![], verifier_data_2.clone());
         // Notice that this is the `verifier_data` of Circuit1:
-        verifier_data.clone().verify(ProofWithPublicInputs {
-            proof: new_proof.clone(),
+        verifier_data_2.clone().verify(ProofWithPublicInputs {
+            proof: proof_2.clone(),
+            public_inputs: public_inputs.clone(),
+        })?;
+
+        dbg!("proof_1c = c1.prove([proof_1b, proof_2], [verifier_data_c1, verifier_data_c2])");
+        let inp = HashOut::<F>::ZERO;
+        let inner_inputs = (inp, circuit1_io(inp));
+        let proof_1c =
+            circuit1.prove(inner_inputs, vec![proof_2], vec![verifier_data_2.clone()])?;
+        let public_inputs = RC::<Circuit1>::prepare_public_inputs(vec![], verifier_data_2.clone());
+        // Notice that this is the `verifier_data` of Circuit1:
+        verifier_data_1.clone().verify(ProofWithPublicInputs {
+            proof: proof_1c.clone(),
             public_inputs: public_inputs.clone(),
         })?;
 
         // do another final iteration, now with Circuit3
-        let inner_inputs = (inp, circuit3_io(inp));
-        let mut pw = PartialWitness::new();
-        circuit3.set_targets(
-            &mut pw,
-            dummy_proof.clone(),
-            inner_inputs,    // innercircuit_input
-            vec![new_proof], // recursive_proofs
-        )?;
-        let new_proof = prover.prove(pw)?.proof;
-        let public_inputs = RC::<Circuit3>::prepare_public_inputs(vec![], verifier_data.clone());
-        verifier_data.clone().verify(ProofWithPublicInputs {
-            proof: new_proof.clone(),
-            public_inputs: public_inputs.clone(),
-        })?;
-
-        // verify the last proof
-        let public_inputs = RC::<Circuit3>::prepare_public_inputs(vec![], verifier_data.clone());
-        let pis = ProofWithPublicInputs {
-            proof: new_proof.clone(),
-            public_inputs: public_inputs.clone(),
-        };
-        verifier_data.clone().verify(pis.clone())?;
+        // dbg!("circuit3.prove");
+        // let inner_inputs = (inp, circuit3_io(inp));
+        // let proof3 = circuit3.prove(inner_inputs, initial_proofs, vec![verifier_data_3.clone()])?;
+        // let public_inputs = RC::<Circuit3>::prepare_public_inputs(vec![], verifier_data_3.clone());
+        // verifier_data_3.clone().verify(ProofWithPublicInputs {
+        //     proof: proof3.clone(),
+        //     public_inputs: public_inputs.clone(),
+        // })?;
+        //
+        // // verify the last proof
+        // let public_inputs = RC::<Circuit3>::prepare_public_inputs(vec![], verifier_data_3.clone());
+        // let pis = ProofWithPublicInputs {
+        //     proof: proof3.clone(),
+        //     public_inputs: public_inputs.clone(),
+        // };
+        // verifier_data_3.clone().verify(pis.clone())?;
 
         Ok(())
     }
@@ -633,10 +708,10 @@ mod tests {
     #[test]
     fn test_recursive_circuit() -> Result<()> {
         // arity=1, n_steps=4
-        // test_recursive_circuit_opt(1, 4)?;
+        test_recursive_circuit_opt(1, 4)?;
 
         // arity=2, n_steps=3
-        test_recursive_circuit_opt(2, 3)?; // commented to be skipped in the CI since it's slower
+        // test_recursive_circuit_opt(2, 3)?; // commented to be skipped in the CI since it's slower
 
         Ok(())
     }

--- a/src/backends/plonky2/recursion/circuit.rs
+++ b/src/backends/plonky2/recursion/circuit.rs
@@ -144,7 +144,6 @@ impl<I: InnerCircuit> RecursiveCircuit<I> {
         dummy_proof: Proof,
         innercircuit_input: I::Input,
         recursive_proofs: Vec<Proof>,
-        non_base_node: bool,
     ) -> Result<()> {
         let n = recursive_proofs.len();
         assert!(n <= self.params.arity);
@@ -155,9 +154,9 @@ impl<I: InnerCircuit> RecursiveCircuit<I> {
             .collect();
         let recursive_proofs: Vec<Proof> = [recursive_proofs, dummy_proofs].concat();
 
-        // set the first n selectors to `non_base_node`, and the rest to false
+        // set the first n selectors to true, and the rest to false
         for i in 0..n {
-            pw.set_bool_target(self.selectors_targ[i], non_base_node)?;
+            pw.set_bool_target(self.selectors_targ[i], true)?;
         }
         for i in n..self.params.arity {
             pw.set_bool_target(self.selectors_targ[i], false)?;
@@ -556,8 +555,6 @@ mod tests {
 
             // loop over the nodes of each recursion tree level
             for j in 0..arity {
-                let non_base_node: bool = i > 0;
-
                 // do the recursive step
                 let start = Instant::now();
                 let mut pw = PartialWitness::new();
@@ -566,7 +563,6 @@ mod tests {
                     dummy_proof.clone(),
                     inner_inputs,              // innercircuit_input
                     proofs_at_level_i.clone(), // recursive_proofs
-                    non_base_node,
                 )?;
                 let new_proof = prover.prove(pw)?.proof;
                 println!(
@@ -598,7 +594,6 @@ mod tests {
             dummy_proof.clone(),
             inner_inputs,              // innercircuit_input
             proofs_at_level_i.clone(), // recursive_proofs
-            true,
         )?;
         let new_proof = prover.prove(pw)?.proof;
         let public_inputs = RC::<Circuit2>::prepare_public_inputs(vec![], verifier_data.clone());
@@ -616,7 +611,6 @@ mod tests {
             dummy_proof.clone(),
             inner_inputs,    // innercircuit_input
             vec![new_proof], // recursive_proofs
-            true,
         )?;
         let new_proof = prover.prove(pw)?.proof;
         let public_inputs = RC::<Circuit3>::prepare_public_inputs(vec![], verifier_data.clone());

--- a/src/backends/plonky2/recursion/mod.rs
+++ b/src/backends/plonky2/recursion/mod.rs
@@ -1,0 +1,2 @@
+pub mod circuit;
+pub use circuit::{InnerCircuit, RecursiveCircuit, RecursiveParams};


### PR DESCRIPTION
The RecursiveCircuit verifies N proofs (N=arity), together with the logic defined at the InnerCircuit (in our case, used for the MainPodCircuit logic).
The arity defines the maximum amount of proofs that the RecursiveCircuit verifies. When arity>1, using the RecursiveCircuit has the shape of a tree of the same arity.

The recursive circuit can verify proofs of other circuits other than itself, as long as the common_data & config are the same.

resolves #174