### PR TITLE
make Pod derive from Any

### DIFF
--- a/src/backends/plonky2/circuits/signedpod.rs
+++ b/src/backends/plonky2/circuits/signedpod.rs
@@ -188,6 +188,8 @@ impl SignedPodVerifyTarget {
 
 #[cfg(test)]
 pub mod tests {
+    use std::any::Any;
+
     use plonky2::plonk::{circuit_builder::CircuitBuilder, circuit_data::CircuitConfig};
 
     use super::*;
@@ -218,7 +220,7 @@ pub mod tests {
         let sk = SecretKey::new_rand();
         let mut signer = Signer(sk);
         let pod = pod.sign(&mut signer).unwrap();
-        let signed_pod = pod.pod.into_any().downcast::<SignedPod>().unwrap();
+        let signed_pod = (pod.pod as Box<dyn Any>).downcast::<SignedPod>().unwrap();
 
         // use the pod in the circuit
         let config = CircuitConfig::standard_recursion_config();

--- a/src/backends/plonky2/mainpod/mod.rs
+++ b/src/backends/plonky2/mainpod/mod.rs
@@ -293,8 +293,7 @@ impl PodProver for Prover {
             .signed_pods
             .iter()
             .map(|p| {
-                let p = p
-                    .as_any()
+                let p = (*p as &dyn Any)
                     .downcast_ref::<SignedPod>()
                     .expect("type SignedPod");
                 p.clone()
@@ -404,13 +403,6 @@ impl Pod for MainPod {
             .collect()
     }
 
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn serialized_proof(&self) -> String {
         todo!()
     }
@@ -453,7 +445,7 @@ pub mod tests {
 
         let mut prover = Prover {};
         let kyc_pod = kyc_builder.prove(&mut prover, &params)?;
-        let pod = kyc_pod.pod.into_any().downcast::<MainPod>().unwrap();
+        let pod = (kyc_pod.pod as Box<dyn Any>).downcast::<MainPod>().unwrap();
 
         pod.verify()
     }
@@ -488,14 +480,16 @@ pub mod tests {
         // Mock
         let mut prover = MockProver {};
         let kyc_pod = kyc_builder.prove(&mut prover, &params).unwrap();
-        let pod = kyc_pod.pod.into_any().downcast::<MockMainPod>().unwrap();
+        let pod = (kyc_pod.pod as Box<dyn Any>)
+            .downcast::<MockMainPod>()
+            .unwrap();
         pod.verify().unwrap();
         println!("{:#}", pod);
 
         // Real
         let mut prover = Prover {};
         let kyc_pod = kyc_builder.prove(&mut prover, &params).unwrap();
-        let pod = kyc_pod.pod.into_any().downcast::<MainPod>().unwrap();
+        let pod = (kyc_pod.pod as Box<dyn Any>).downcast::<MainPod>().unwrap();
         pod.verify().unwrap()
     }
 }

--- a/src/backends/plonky2/mock/mainpod.rs
+++ b/src/backends/plonky2/mock/mainpod.rs
@@ -2,7 +2,7 @@
 // MainPod
 //
 
-use std::{any::Any, fmt};
+use std::fmt;
 
 use anyhow::{anyhow, Result};
 
@@ -274,13 +274,6 @@ impl Pod for MockMainPod {
             .collect()
     }
 
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn serialized_proof(&self) -> String {
         todo!()
         // BASE64_STANDARD.encode(serde_json::to_string(self).unwrap())
@@ -289,6 +282,8 @@ impl Pod for MockMainPod {
 
 #[cfg(test)]
 pub mod tests {
+    use std::any::Any;
+
     use super::*;
     use crate::{
         backends::plonky2::mock::signedpod::MockSigner,
@@ -321,7 +316,9 @@ pub mod tests {
 
         let mut prover = MockProver {};
         let kyc_pod = kyc_builder.prove(&mut prover, &params)?;
-        let pod = kyc_pod.pod.into_any().downcast::<MockMainPod>().unwrap();
+        let pod = (kyc_pod.pod as Box<dyn Any>)
+            .downcast::<MockMainPod>()
+            .unwrap();
 
         println!("{:#}", pod);
 
@@ -338,9 +335,7 @@ pub mod tests {
 
         let mut prover = MockProver {};
         let great_boy_pod = great_boy_builder.prove(&mut prover, &params)?;
-        let pod = great_boy_pod
-            .pod
-            .into_any()
+        let pod = (great_boy_pod.pod as Box<dyn Any>)
             .downcast::<MockMainPod>()
             .unwrap();
 
@@ -357,7 +352,9 @@ pub mod tests {
         let tickets_builder = tickets_pod_full_flow()?;
         let mut prover = MockProver {};
         let proof_pod = tickets_builder.prove(&mut prover, &params)?;
-        let pod = proof_pod.pod.into_any().downcast::<MockMainPod>().unwrap();
+        let pod = (proof_pod.pod as Box<dyn Any>)
+            .downcast::<MockMainPod>()
+            .unwrap();
 
         println!("{}", pod);
         pod.verify()?;

--- a/src/backends/plonky2/mock/signedpod.rs
+++ b/src/backends/plonky2/mock/signedpod.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, collections::HashMap};
+use std::collections::HashMap;
 
 use anyhow::{anyhow, Result};
 use itertools::Itertools;
@@ -122,13 +122,6 @@ impl Pod for MockSignedPod {
             .collect()
     }
 
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn serialized_proof(&self) -> String {
         self.signature.to_string()
     }
@@ -136,7 +129,7 @@ impl Pod for MockSignedPod {
 
 #[cfg(test)]
 pub mod tests {
-    use std::iter;
+    use std::{any::Any, iter};
 
     use plonky2::field::types::Field;
 
@@ -156,7 +149,9 @@ pub mod tests {
 
         let mut signer = MockSigner { pk: "Molly".into() };
         let pod = pod.sign(&mut signer).unwrap();
-        let pod = pod.pod.into_any().downcast::<MockSignedPod>().unwrap();
+        let pod = (pod.pod as Box<dyn Any>)
+            .downcast::<MockSignedPod>()
+            .unwrap();
 
         pod.verify()?;
         println!("id: {}", pod.id());

--- a/src/backends/plonky2/signedpod.rs
+++ b/src/backends/plonky2/signedpod.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, collections::HashMap};
+use std::collections::HashMap;
 
 use anyhow::{anyhow, Result};
 use itertools::Itertools;
@@ -101,13 +101,6 @@ impl Pod for SignedPod {
             .collect()
     }
 
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn serialized_proof(&self) -> String {
         let mut buffer = Vec::new();
         use plonky2::util::serialization::Write;
@@ -118,7 +111,7 @@ impl Pod for SignedPod {
 
 #[cfg(test)]
 pub mod tests {
-    use std::iter;
+    use std::{any::Any, iter};
 
     use plonky2::field::types::Field;
 
@@ -140,7 +133,7 @@ pub mod tests {
         let sk = SecretKey::new_rand();
         let mut signer = Signer(sk);
         let pod = pod.sign(&mut signer).unwrap();
-        let pod = pod.pod.into_any().downcast::<SignedPod>().unwrap();
+        let pod = (pod.pod as Box<dyn Any>).downcast::<SignedPod>().unwrap();
 
         pod.verify()?;
         println!("id: {}", pod.id());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::get_first)]
+#![feature(trait_upcasting)]
 
 pub mod backends;
 pub mod constants;

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -487,7 +487,7 @@ impl Params {
     }
 }
 
-pub trait Pod: fmt::Debug + DynClone {
+pub trait Pod: fmt::Debug + DynClone + Any {
     fn verify(&self) -> Result<()>;
     fn id(&self) -> PodId;
     fn pub_statements(&self) -> Vec<Statement>;
@@ -501,9 +501,6 @@ pub trait Pod: fmt::Debug + DynClone {
             })
             .collect()
     }
-    // Used for downcasting
-    fn into_any(self: Box<Self>) -> Box<dyn Any>;
-    fn as_any(&self) -> &dyn Any;
     // Front-end Pods keep references to middleware Pods. Most of the
     // middleware data can be derived directly from front-end data, but the
     // "proof" data is only created at the point of proving/signing, and
@@ -536,12 +533,6 @@ impl Pod for NonePod {
     }
     fn pub_statements(&self) -> Vec<Statement> {
         Vec::new()
-    }
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-    fn as_any(&self) -> &dyn Any {
-        self
     }
     fn serialized_proof(&self) -> String {
         "".to_string()


### PR DESCRIPTION
This commit makes Pod inherit Any, which removes the need for the as_any and into_any functions.

It requires the `trait_upcasting` feature, which was considered experimental in the `nightly-2025-01-20` toolchain, but has since been stabilized: https://github.com/rust-lang/rust/issues/65991