### PR TITLE
apply new circuit naming convention

### DIFF
--- a/src/backends/plonky2/circuits/mainpod.rs
+++ b/src/backends/plonky2/circuits/mainpod.rs
@@ -378,7 +378,7 @@ impl MainPodVerifyTarget {
             for _statement in 0..params.max_public_statements {
                 statements.push(StatementTarget::new_native(
                     builder,
-                    &params,
+                    params,
                     NativePredicate::None,
                     &[],
                 ))

--- a/src/backends/plonky2/mainpod/mod.rs
+++ b/src/backends/plonky2/mainpod/mod.rs
@@ -17,7 +17,7 @@ pub use statement::*;
 use crate::{
     backends::plonky2::{
         basetypes::{C, D},
-        circuits::mainpod::{MainPodVerifyCircuit, MainPodVerifyInput},
+        circuits::mainpod::{MainPodVerifyInput, MainPodVerifyTarget},
         error::{Error, Result},
         primitives::merkletree::MerkleClaimAndProof,
         signedpod::SignedPod,
@@ -283,10 +283,7 @@ impl Prover {
     fn _prove(&mut self, params: &Params, inputs: MainPodInputs) -> Result<MainPod> {
         let config = CircuitConfig::standard_recursion_config();
         let mut builder = CircuitBuilder::<F, D>::new(config);
-        let main_pod = MainPodVerifyCircuit {
-            params: params.clone(),
-        }
-        .eval(&mut builder)?;
+        let main_pod = MainPodVerifyTarget::build_circuit(&mut builder, params)?;
 
         let mut pw = PartialWitness::<F>::new();
         let signed_pods_input: Vec<SignedPod> = inputs
@@ -386,10 +383,7 @@ impl MainPod {
         // TODO: cache these artefacts
         let config = CircuitConfig::standard_recursion_config();
         let mut builder = CircuitBuilder::<F, D>::new(config);
-        let _main_pod = MainPodVerifyCircuit {
-            params: self.params.clone(),
-        }
-        .eval(&mut builder)?;
+        let _main_pod = MainPodVerifyTarget::build_circuit(&mut builder, &self.params)?;
 
         let data = builder.build::<C>();
         data.verify(self.proof.clone())

--- a/src/backends/plonky2/primitives/signature/circuit.rs
+++ b/src/backends/plonky2/primitives/signature/circuit.rs
@@ -35,10 +35,9 @@ use crate::{
 
 lazy_static! {
     /// SignatureVerifyGadget VerifierCircuitData
-    pub static ref S_VD: VerifierCircuitData<F,C,D> = SignatureVerifyGadget::verifier_data().unwrap();
+    pub static ref S_VD: VerifierCircuitData<F,C,D> = SignatureVerifyTarget::verifier_data().unwrap();
 }
 
-pub struct SignatureVerifyGadget {}
 pub struct SignatureVerifyTarget {
     // verifier_data of the SignatureInternalCircuit
     verifier_data_targ: VerifierCircuitTarget,
@@ -50,21 +49,19 @@ pub struct SignatureVerifyTarget {
     proof: ProofWithPublicInputsTarget<D>,
 }
 
-impl SignatureVerifyGadget {
+impl SignatureVerifyTarget {
     pub fn verifier_data() -> Result<VerifierCircuitData<F, C, D>> {
         // notice that we use the 'zk' config
         let config = CircuitConfig::standard_recursion_zk_config();
         let mut builder = CircuitBuilder::<F, D>::new(config);
-        let circuit = SignatureVerifyGadget {}.eval(&mut builder)?;
+        let circuit = SignatureVerifyTarget::build(&mut builder)?;
 
         let circuit_data = builder.build::<C>();
         Ok(circuit_data.verifier_data())
     }
-}
 
-impl SignatureVerifyGadget {
     /// creates the targets and defines the logic of the circuit
-    pub fn eval(&self, builder: &mut CircuitBuilder<F, D>) -> Result<SignatureVerifyTarget> {
+    pub fn build(builder: &mut CircuitBuilder<F, D>) -> Result<SignatureVerifyTarget> {
         let enabled = builder.add_virtual_bool_target_safe();
 
         let common_data = VP.0.common.clone();
@@ -123,9 +120,7 @@ impl SignatureVerifyGadget {
             proof: proof_targ,
         })
     }
-}
 
-impl SignatureVerifyTarget {
     /// assigns the given values to the targets
     pub fn set_targets(
         &self,
@@ -186,7 +181,7 @@ pub mod tests {
         let mut builder = CircuitBuilder::<F, D>::new(config);
         let mut pw = PartialWitness::<F>::new();
 
-        let targets = SignatureVerifyGadget {}.eval(&mut builder)?;
+        let targets = SignatureVerifyTarget::build(&mut builder)?;
         targets.set_targets(&mut pw, true, pk, msg, sig)?;
 
         // generate & verify proof
@@ -223,7 +218,7 @@ pub mod tests {
         let config = CircuitConfig::standard_recursion_zk_config();
         let mut builder = CircuitBuilder::<F, D>::new(config);
         let mut pw = PartialWitness::<F>::new();
-        let targets = SignatureVerifyGadget {}.eval(&mut builder)?;
+        let targets = SignatureVerifyTarget::build(&mut builder)?;
         targets.set_targets(&mut pw, true, pk.clone(), msg, sig.clone())?; // enabled=true
 
         // generate proof, and expect it to fail
@@ -237,7 +232,7 @@ pub mod tests {
         let mut builder = CircuitBuilder::<F, D>::new(config);
         let mut pw = PartialWitness::<F>::new();
 
-        let targets = SignatureVerifyGadget {}.eval(&mut builder)?;
+        let targets = SignatureVerifyTarget::build(&mut builder)?;
         targets.set_targets(&mut pw, false, pk, msg, sig)?; // enabled=false
 
         // generate & verify proof


### PR DESCRIPTION
Resolve #181 
I'm setting this as a draft because some parts of this change don't feel right to me.

Things that don't feel right:
- In the MainPod circuit there were two methods that return a `MainPodVerifyTarget` one was for the `MainPodVerifyGadget` (internall unit) and the other one was for `MainPodVerifyCircuit` (external unit, which contains the gadget and makes some targets public).  But now we got rid of the Gadget and Circuit types.  I named the second method `build_circuit` but I don't know if it's very clear
- We had OperationVerifyGadget which added constraints but didn't return any target, just a `Result<()>`.  Now we have an empty `OperationVerifyTarget` which is weird because it doesn't contain any target.