### PR TITLE
chore(backend): make Plonky2 config more explicit

### DIFF
--- a/src/backends/plonky2/basetypes.rs
+++ b/src/backends/plonky2/basetypes.rs
@@ -2,14 +2,30 @@
 //! `backend_plonky2` feature is enabled.
 //! See src/middleware/basetypes.rs for more details.
 
-use plonky2::plonk::{config::PoseidonGoldilocksConfig, proof::Proof as Plonky2Proof};
+use plonky2::{
+    field::extension::quadratic::QuadraticExtension,
+    hash::poseidon::PoseidonHash,
+    plonk::{config::GenericConfig, proof::Proof as Plonky2Proof},
+};
+use serde::Serialize;
 
 use crate::middleware::F;
 
-/// C is the Plonky2 config used in POD2 to work with Plonky2 recursion.
-pub type C = PoseidonGoldilocksConfig;
 /// D defines the extension degree of the field used in the Plonky2 proofs (quadratic extension).
 pub const D: usize = 2;
 
+/// FE is the degree D field extension used in Plonky2 proofs.
+pub type FE = QuadraticExtension<F>;
+
+/// C is the Plonky2 config used in POD2 to work with Plonky2 recursion.
+#[derive(Debug, Copy, Clone, Default, Eq, PartialEq, Serialize)]
+pub struct C;
+impl GenericConfig<D> for C {
+    type F = F;
+    type FE = FE;
+    type Hasher = PoseidonHash;
+    type InnerHasher = PoseidonHash;
+}
+
 /// proof system proof
-pub type Proof = Plonky2Proof<F, PoseidonGoldilocksConfig, D>;
+pub type Proof = Plonky2Proof<F, C, D>;

--- a/src/backends/plonky2/mainpod/mod.rs
+++ b/src/backends/plonky2/mainpod/mod.rs
@@ -352,7 +352,7 @@ pub struct MainPod {
     params: Params,
     id: PodId,
     public_statements: Vec<Statement>,
-    proof: ProofWithPublicInputs<F, C, 2>,
+    proof: ProofWithPublicInputs<F, C, D>,
 }
 
 /// Convert a Statement into middleware::Statement and replace references to SELF by `self_id`.


### PR DESCRIPTION
This PR makes the Plonky2 config in use more explicit, making it easier to swap out the extension degree and field for another in testing.