### PR TITLE
Desugar statement templates

### DIFF
--- a/book/src/values.md
+++ b/book/src/values.md
@@ -40,9 +40,9 @@ The array, set and dictionary types are similar types. While all of them use [a 
 - **array**: the elements are placed at the value field of each leaf, and the key field is just the array index (integer)
     - `leaf.key=i` 
     - `leaf.value=original_value` 
-- **set**: the value field of the leaf is unused, and the key contains the hash of the element
-    -  `leaf.key=hash(original_value)`
-    - `leaf.value=0`
+- **set**: both the key and the value are set to the hash of the value.
+    - `leaf.key=hash(original_value)`
+    - `leaf.value=hash(original_value)`
 
 In the three types, the merkletree under the hood allows to prove inclusion & non-inclusion of the particular entry of the {dictionary/array/set} element.
 

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -251,8 +251,11 @@ impl MainPodBuilder {
             }
             Native(SetContainsFromEntries) => {
                 let [set, value] = op.1.try_into().unwrap(); // TODO: Error handling
-                let empty = OperationArg::Literal(Value::from(EMPTY_VALUE));
-                Operation(Native(ContainsFromEntries), vec![set, value, empty], op.2)
+                Operation(
+                    Native(ContainsFromEntries),
+                    vec![set, value.clone(), value],
+                    op.2,
+                )
             }
             Native(SetNotContainsFromEntries) => {
                 let [set, value] = op.1.try_into().unwrap(); // TODO: Error handling

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -9,8 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::middleware::{
     self, check_st_tmpl, hash_str, hash_values, AnchoredKey, Hash, Key, MainPodInputs,
     NativeOperation, NativePredicate, OperationAux, OperationType, Params, PodId, PodProver,
-    PodSigner, Predicate, Statement, StatementArg, Value, WildcardValue, EMPTY_VALUE, KEY_TYPE,
-    SELF,
+    PodSigner, Predicate, Statement, StatementArg, Value, WildcardValue, KEY_TYPE, SELF,
 };
 
 mod custom;

--- a/src/middleware/containers.rs
+++ b/src/middleware/containers.rs
@@ -11,7 +11,7 @@ use super::serialization::{ordered_map, ordered_set};
 use crate::backends::plonky2::primitives::merkletree::{MerkleProof, MerkleTree};
 use crate::{
     constants::MAX_DEPTH,
-    middleware::{hash_value, Error, Hash, Key, RawValue, Result, Value, EMPTY_VALUE},
+    middleware::{hash_value, Error, Hash, Key, RawValue, Result, Value},
 };
 
 /// Dictionary: the user original keys and values are hashed to be used in the leaf.
@@ -129,7 +129,7 @@ impl Set {
             .iter()
             .map(|e| {
                 let h = hash_value(&e.raw());
-                (RawValue::from(h), EMPTY_VALUE)
+                (RawValue::from(h), RawValue::from(h))
             })
             .collect();
         Ok(Self {
@@ -159,7 +159,7 @@ impl Set {
             root,
             proof,
             &RawValue::from(h),
-            &EMPTY_VALUE,
+            &RawValue::from(h),
         )?)
     }
     pub fn verify_nonexistence(root: Hash, proof: &MerkleProof, value: &Value) -> Result<()> {


### PR DESCRIPTION
Closes #224 

This adds desugaring of statement templates during the building of a custom predicate. `Gt` and `GtEq` are replaced by `Lt` and `LtEq` respectively, `DictContains`/`ArrayContains` are replaced by `Contains`, and `DictNotContains`/`SetNotContains` are replaced by `NotContains`.

~~`SetContains` is TODO because it's not immediately obvious how the third argument to `Contains` should be generated.~~ EDIT: `SetContains` is now implemented, including a change in the Set implementation: instead of building the Set Merkle tree from pairs of `value` and `EMPTY_VALUE`, we now duplicate the `value`. This makes the `Contains` statement derived from `SetContains` deterministic.