### PR TITLE
Serialization for Plonky2 Signed and Main PODs

### DIFF
--- a/src/backends/plonky2/mainpod/mod.rs
+++ b/src/backends/plonky2/mainpod/mod.rs
@@ -446,12 +446,14 @@ impl PodProver for Prover {
     }
 }
 
+pub type MainPodProof = Proof<F, C, D>;
+
 #[derive(Clone, Debug)]
 pub struct MainPod {
     params: Params,
     id: PodId,
     public_statements: Vec<Statement>,
-    proof: Proof<F, C, D>,
+    proof: MainPodProof,
 }
 
 /// Convert a Statement into middleware::Statement and replace references to SELF by `self_id`.
@@ -497,6 +499,28 @@ impl MainPod {
         })
         .map_err(|e| Error::custom(format!("MainPod proof verification failure: {:?}", e)))
     }
+
+    pub fn proof(&self) -> MainPodProof {
+        self.proof.clone()
+    }
+
+    pub fn params(&self) -> &Params {
+        &self.params
+    }
+
+    pub fn new(
+        proof: MainPodProof,
+        public_statements: Vec<Statement>,
+        id: PodId,
+        params: Params,
+    ) -> Self {
+        Self {
+            params,
+            id,
+            public_statements,
+            proof,
+        }
+    }
 }
 
 impl Pod for MainPod {
@@ -515,10 +539,6 @@ impl Pod for MainPod {
             .cloned()
             .map(|statement| normalize_statement(&statement, self.id()))
             .collect()
-    }
-
-    fn serialized_proof(&self) -> String {
-        todo!()
     }
 }
 

--- a/src/backends/plonky2/mainpod/mod.rs
+++ b/src/backends/plonky2/mainpod/mod.rs
@@ -452,7 +452,8 @@ pub type MainPodProof = Proof<F, C, D>;
 pub struct MainPod {
     params: Params,
     id: PodId,
-    public_statements: Vec<Statement>,
+    // TODO remove pub
+    pub public_statements: Vec<Statement>,
     proof: MainPodProof,
 }
 

--- a/src/backends/plonky2/mainpod/mod.rs
+++ b/src/backends/plonky2/mainpod/mod.rs
@@ -542,7 +542,10 @@ impl Pod for MainPod {
     }
 
     fn serialized_proof(&self) -> String {
-        serde_json::to_string(&self.proof).unwrap()
+        let mut buffer = Vec::new();
+        use plonky2::util::serialization::Write;
+        buffer.write_proof_with_public_inputs(&self.proof).unwrap();
+        hex::encode(buffer)
     }
 }
 

--- a/src/backends/plonky2/mainpod/mod.rs
+++ b/src/backends/plonky2/mainpod/mod.rs
@@ -215,7 +215,7 @@ fn fill_pad<T: Clone>(v: &mut Vec<T>, pad_value: T, len: usize) {
     }
 }
 
-fn pad_statement(params: &Params, s: &mut Statement) {
+pub fn pad_statement(params: &Params, s: &mut Statement) {
     fill_pad(&mut s.1, StatementArg::None, params.max_statement_args)
 }
 
@@ -452,8 +452,7 @@ pub type MainPodProof = Proof<F, C, D>;
 pub struct MainPod {
     params: Params,
     id: PodId,
-    // TODO remove pub
-    pub public_statements: Vec<Statement>,
+    public_statements: Vec<Statement>,
     proof: MainPodProof,
 }
 
@@ -540,6 +539,10 @@ impl Pod for MainPod {
             .cloned()
             .map(|statement| normalize_statement(&statement, self.id()))
             .collect()
+    }
+
+    fn serialized_proof(&self) -> String {
+        serde_json::to_string(&self.proof).unwrap()
     }
 }
 

--- a/src/backends/plonky2/mock/mainpod.rs
+++ b/src/backends/plonky2/mock/mainpod.rs
@@ -265,10 +265,6 @@ impl MockMainPod {
         Ok(())
     }
 
-    pub fn serialized_proof(&self) -> String {
-        BASE64_STANDARD.encode(serde_json::to_string(self).unwrap())
-    }
-
     pub fn params(&self) -> &Params {
         &self.params
     }
@@ -290,6 +286,10 @@ impl Pod for MockMainPod {
             .cloned()
             .map(|statement| normalize_statement(&statement, self.id()))
             .collect()
+    }
+
+    fn serialized_proof(&self) -> String {
+        BASE64_STANDARD.encode(serde_json::to_string(self).unwrap())
     }
 }
 

--- a/src/backends/plonky2/mock/mainpod.rs
+++ b/src/backends/plonky2/mock/mainpod.rs
@@ -264,6 +264,14 @@ impl MockMainPod {
         }
         Ok(())
     }
+
+    pub fn serialized_proof(&self) -> String {
+        BASE64_STANDARD.encode(serde_json::to_string(self).unwrap())
+    }
+
+    pub fn params(&self) -> &Params {
+        &self.params
+    }
 }
 
 impl Pod for MockMainPod {
@@ -282,10 +290,6 @@ impl Pod for MockMainPod {
             .cloned()
             .map(|statement| normalize_statement(&statement, self.id()))
             .collect()
-    }
-
-    fn serialized_proof(&self) -> String {
-        BASE64_STANDARD.encode(serde_json::to_string(self).unwrap())
     }
 }
 

--- a/src/backends/plonky2/mock/signedpod.rs
+++ b/src/backends/plonky2/mock/signedpod.rs
@@ -133,6 +133,10 @@ impl Pod for MockSignedPod {
             .map(|(k, v)| Statement::ValueOf(AnchoredKey::from((id, k)), v))
             .collect()
     }
+
+    fn serialized_proof(&self) -> String {
+        serde_json::to_string(&self.signature).unwrap()
+    }
 }
 
 #[cfg(test)]

--- a/src/backends/plonky2/mock/signedpod.rs
+++ b/src/backends/plonky2/mock/signedpod.rs
@@ -59,6 +59,10 @@ impl MockSignedPod {
     pub(crate) fn new(id: PodId, signature: String, kvs: HashMap<Key, Value>) -> Self {
         Self { id, signature, kvs }
     }
+
+    pub fn signature(&self) -> String {
+        self.signature.clone()
+    }
 }
 
 impl MockSignedPod {
@@ -128,10 +132,6 @@ impl Pod for MockSignedPod {
             .chain(kvs.into_iter().sorted_by_key(|kv| kv.0.hash()))
             .map(|(k, v)| Statement::ValueOf(AnchoredKey::from((id, k)), v))
             .collect()
-    }
-
-    fn serialized_proof(&self) -> String {
-        self.signature.to_string()
     }
 }
 

--- a/src/backends/plonky2/primitives/signature/mod.rs
+++ b/src/backends/plonky2/primitives/signature/mod.rs
@@ -21,6 +21,7 @@ use plonky2::{
 
 pub mod circuit;
 pub use circuit::*;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     backends::plonky2::{
@@ -57,7 +58,8 @@ pub struct SecretKey(pub(crate) RawValue);
 #[derive(Clone, Debug)]
 pub struct PublicKey(pub(crate) RawValue);
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct Signature(pub(crate) Proof);
 
 /// Implements the key generation and the computation of proof-based signatures.

--- a/src/backends/plonky2/signedpod.rs
+++ b/src/backends/plonky2/signedpod.rs
@@ -115,7 +115,10 @@ impl Pod for SignedPod {
     }
 
     fn serialized_proof(&self) -> String {
-        serde_json::to_string(&self.signature).unwrap()
+        let mut buffer = Vec::new();
+        use plonky2::util::serialization::Write;
+        buffer.write_proof(&self.signature.0).unwrap();
+        hex::encode(buffer)
     }
 }
 

--- a/src/backends/plonky2/signedpod.rs
+++ b/src/backends/plonky2/signedpod.rs
@@ -113,6 +113,10 @@ impl Pod for SignedPod {
             .map(|(k, v)| Statement::ValueOf(AnchoredKey::from((id, k)), v))
             .collect()
     }
+
+    fn serialized_proof(&self) -> String {
+        serde_json::to_string(&self.signature).unwrap()
+    }
 }
 
 #[cfg(test)]

--- a/src/backends/plonky2/signedpod.rs
+++ b/src/backends/plonky2/signedpod.rs
@@ -1,13 +1,15 @@
 use std::collections::HashMap;
 
+use base64::{prelude::BASE64_STANDARD, Engine};
 use itertools::Itertools;
+use plonky2::util::serialization::Buffer;
 
 use crate::{
     backends::plonky2::{
         error::{Error, Result},
         primitives::{
             merkletree::MerkleTree,
-            signature::{PublicKey, SecretKey, Signature},
+            signature::{PublicKey, SecretKey, Signature, VP},
         },
     },
     constants::MAX_DEPTH,
@@ -88,6 +90,29 @@ impl SignedPod {
 
         Ok(())
     }
+
+    pub fn decode_signature(signature: &str) -> Result<Signature, Error> {
+        use plonky2::util::serialization::Read;
+
+        let decoded = BASE64_STANDARD.decode(signature).map_err(|e| {
+            Error::custom(format!(
+                "Failed to decode signature from base64: {}. Value: {}",
+                e, signature
+            ))
+        })?;
+        let mut buf = Buffer::new(&decoded);
+
+        let proof = buf.read_proof(&VP.0.common).map_err(|e| {
+            Error::custom(format!(
+                "Failed to read signature from buffer: {}. Value: {}",
+                e, signature
+            ))
+        })?;
+
+        let sig = Signature(proof);
+
+        Ok(sig)
+    }
 }
 
 impl Pod for SignedPod {
@@ -118,7 +143,7 @@ impl Pod for SignedPod {
         let mut buffer = Vec::new();
         use plonky2::util::serialization::Write;
         buffer.write_proof(&self.signature.0).unwrap();
-        hex::encode(buffer)
+        BASE64_STANDARD.encode(buffer)
     }
 }
 

--- a/src/backends/plonky2/signedpod.rs
+++ b/src/backends/plonky2/signedpod.rs
@@ -113,13 +113,6 @@ impl Pod for SignedPod {
             .map(|(k, v)| Statement::ValueOf(AnchoredKey::from((id, k)), v))
             .collect()
     }
-
-    fn serialized_proof(&self) -> String {
-        let mut buffer = Vec::new();
-        use plonky2::util::serialization::Write;
-        buffer.write_proof(&self.signature.0).unwrap();
-        hex::encode(buffer)
-    }
 }
 
 #[cfg(test)]

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -4,7 +4,6 @@
 use std::{collections::HashMap, convert::From, fmt};
 
 use itertools::Itertools;
-use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serialization::{SerializedMainPod, SerializedSignedPod};
 
@@ -21,7 +20,6 @@ mod serialization;
 pub use custom::*;
 pub use error::*;
 pub use operation::*;
-use serialization::*;
 
 #[derive(Clone, Debug)]
 pub struct SignedPodBuilder {

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -4,7 +4,9 @@
 use std::{collections::HashMap, convert::From, fmt};
 
 use itertools::Itertools;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use serialization::{SerializedMainPod, SerializedSignedPod};
 
 use crate::middleware::{
     self, check_st_tmpl, hash_str, hash_values, AnchoredKey, Hash, Key, MainPodInputs,
@@ -59,8 +61,8 @@ impl SignedPodBuilder {
 
 /// SignedPod is a wrapper on top of backend::SignedPod, which additionally stores the
 /// string<-->hash relation of the keys.
-#[derive(Debug, Clone)]
-//#[serde(try_from = "SignedPodHelper", into = "SignedPodHelper")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(from = "SerializedSignedPod", into = "SerializedSignedPod")]
 pub struct SignedPod {
     pub pod: Box<dyn middleware::Pod>,
     // We store a copy of the key values for quick access
@@ -609,16 +611,18 @@ impl MainPodBuilder {
 
         Ok(MainPod {
             pod,
+            params: self.params.clone(),
             public_statements,
         })
     }
 }
 
-#[derive(Debug, Clone)]
-//#[serde(try_from = "MainPodHelper", into = "MainPodHelper")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(try_from = "SerializedMainPod", into = "SerializedMainPod")]
 pub struct MainPod {
     pub pod: Box<dyn middleware::Pod>,
     pub public_statements: Vec<Statement>,
+    pub params: Params,
 }
 
 impl fmt::Display for MainPod {

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -21,14 +21,6 @@ pub use error::*;
 pub use operation::*;
 use serialization::*;
 
-/// This type is just for presentation purposes.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub enum PodClass {
-    #[default]
-    Signed,
-    Main,
-}
-
 #[derive(Clone, Debug)]
 pub struct SignedPodBuilder {
     pub params: Params,
@@ -67,8 +59,8 @@ impl SignedPodBuilder {
 
 /// SignedPod is a wrapper on top of backend::SignedPod, which additionally stores the
 /// string<-->hash relation of the keys.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(try_from = "SignedPodHelper", into = "SignedPodHelper")]
+#[derive(Debug, Clone)]
+//#[serde(try_from = "SignedPodHelper", into = "SignedPodHelper")]
 pub struct SignedPod {
     pub pod: Box<dyn middleware::Pod>,
     // We store a copy of the key values for quick access
@@ -622,8 +614,8 @@ impl MainPodBuilder {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(try_from = "MainPodHelper", into = "MainPodHelper")]
+#[derive(Debug, Clone)]
+//#[serde(try_from = "MainPodHelper", into = "MainPodHelper")]
 pub struct MainPod {
     pub pod: Box<dyn middleware::Pod>,
     pub public_statements: Vec<Statement>,

--- a/src/frontend/serialization.rs
+++ b/src/frontend/serialization.rs
@@ -633,10 +633,19 @@ mod tests {
     fn test_plonky2_main_pod_serialization() -> Result<()> {
         let kyc_pod = build_plonky2_zukyc_pod()?;
         println!("id: {}", kyc_pod.pod.id());
+        let pod = (kyc_pod.pod.clone() as Box<dyn Any>)
+            .downcast::<Plonky2MainPod>()
+            .unwrap();
+        let stmts = pod.public_statements.clone();
         let serialized = serde_json::to_string_pretty(&kyc_pod).unwrap();
         // println!("serialized: {}", serialized);
         let deserialized: MainPod = serde_json::from_str(&serialized).unwrap();
         println!("deserialized id: {}", deserialized.pod.id());
+        let dpod = (deserialized.pod.clone() as Box<dyn Any>)
+            .downcast::<Plonky2MainPod>()
+            .unwrap();
+        let dstmts = dpod.public_statements.clone();
+        assert_eq!(stmts, dstmts);
 
         assert_eq!(kyc_pod.public_statements, deserialized.public_statements);
         assert_eq!(kyc_pod.pod.id(), deserialized.pod.id());

--- a/src/frontend/serialization.rs
+++ b/src/frontend/serialization.rs
@@ -34,6 +34,7 @@ pub enum SignedPodType {
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
+#[schemars(rename = "SignedPod")]
 pub struct SerializedSignedPod {
     id: PodId,
     #[serde(serialize_with = "ordered_map")]
@@ -50,6 +51,7 @@ pub enum MainPodType {
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
+#[schemars(rename = "MainPod")]
 pub struct SerializedMainPod {
     id: PodId,
     public_statements: Vec<Statement>,

--- a/src/frontend/serialization.rs
+++ b/src/frontend/serialization.rs
@@ -1,444 +1,185 @@
-use std::{any::Any, collections::BTreeMap, fmt};
+use std::{any::Any, collections::HashMap};
 
 use schemars::JsonSchema;
-use serde::{
-    de::{self, MapAccess, Visitor},
-    ser::SerializeStruct,
-    Deserialize, Serialize,
-};
+use serde::{Deserialize, Serialize};
 
+use super::Error;
 use crate::{
     backends::plonky2::{
-        mainpod::{MainPod as Plonky2MainPod, MainPodProof, Statement as BackendStatement},
+        mainpod::{pad_statement, MainPod as Plonky2MainPod, Statement as BackendStatement},
         mock::{mainpod::MockMainPod, signedpod::MockSignedPod},
         signedpod::SignedPod as Plonky2SignedPod,
     },
     frontend::{MainPod, SignedPod},
     middleware::{
-        containers::Dictionary, AnchoredKey, Params, Pod, PodId, PodType, Statement, StatementArg,
-        Value, SELF,
+        self, containers::Dictionary, serialization::ordered_map, AnchoredKey, Key, Params, PodId,
+        Statement, StatementArg, Value, SELF,
     },
 };
 
-impl Serialize for SignedPod {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut state = serializer.serialize_struct("SignedPod", 4)?;
-        //  state.serialize_field("pod", &self.pod)?;
-        // Force sorting by keys using a BTreeMap
-        let kvs_btree: BTreeMap<String, Value> = self
-            .kvs
+#[derive(Serialize, Deserialize, JsonSchema)]
+pub enum SignedPodType {
+    Signed,
+    MockSigned,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SerializedSignedPod {
+    id: PodId,
+    #[serde(serialize_with = "ordered_map")]
+    entries: HashMap<Key, Value>,
+    proof: String,
+    pod_type: SignedPodType,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+pub enum MainPodType {
+    Main,
+    MockMain,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SerializedMainPod {
+    id: PodId,
+    public_statements: Vec<Statement>,
+    proof: String,
+    params: Params,
+    pod_type: MainPodType,
+}
+
+impl From<SignedPod> for SerializedSignedPod {
+    fn from(pod: SignedPod) -> Self {
+        SerializedSignedPod {
+            id: pod.id(),
+            entries: pod.kvs,
+            proof: pod.pod.serialized_proof(),
+            pod_type: if (&*pod.pod as &dyn Any)
+                .downcast_ref::<Plonky2SignedPod>()
+                .is_some()
+            {
+                SignedPodType::Signed
+            } else {
+                SignedPodType::MockSigned
+            },
+        }
+    }
+}
+
+impl From<SerializedSignedPod> for SignedPod {
+    fn from(serialized: SerializedSignedPod) -> Self {
+        match serialized.pod_type {
+            SignedPodType::Signed => SignedPod {
+                pod: Box::new(Plonky2SignedPod {
+                    id: serialized.id,
+                    signature: serde_json::from_str(&serialized.proof).unwrap(),
+                    dict: Dictionary::new(serialized.entries.clone()).unwrap(),
+                }),
+                kvs: serialized.entries,
+            },
+            SignedPodType::MockSigned => SignedPod {
+                pod: Box::new(MockSignedPod::new(
+                    serialized.id,
+                    serde_json::from_str(&serialized.proof).unwrap(),
+                    serialized.entries.clone(),
+                )),
+                kvs: serialized.entries,
+            },
+        }
+    }
+}
+
+impl From<MainPod> for SerializedMainPod {
+    fn from(pod: MainPod) -> Self {
+        SerializedMainPod {
+            id: pod.id(),
+            proof: pod.pod.serialized_proof(),
+            params: pod.params.clone(),
+            pod_type: if (&*pod.pod as &dyn Any)
+                .downcast_ref::<Plonky2MainPod>()
+                .is_some()
+            {
+                MainPodType::Main
+            } else {
+                MainPodType::MockMain
+            },
+            public_statements: pod.public_statements.clone(),
+        }
+    }
+}
+
+impl TryFrom<SerializedMainPod> for MainPod {
+    type Error = Error;
+
+    fn try_from(serialized: SerializedMainPod) -> Result<Self, Self::Error> {
+        match serialized.pod_type {
+            MainPodType::Main => Ok(MainPod {
+                pod: Box::new(Plonky2MainPod::new(
+                    serde_json::from_str(&serialized.proof).map_err(|e| {
+                        Error::custom(format!(
+                            "Failed to deserialize MainPod proof: {}. Value: {}",
+                            e, serialized.proof
+                        ))
+                    })?,
+                    middleware_statements_to_backend(
+                        serialized.public_statements.clone(),
+                        &serialized.params,
+                        serialized.id,
+                    ),
+                    serialized.id,
+                    serialized.params.clone(),
+                )),
+                public_statements: serialized.public_statements,
+                params: serialized.params,
+            }),
+            MainPodType::MockMain => Ok(MainPod {
+                pod: Box::new(
+                    MockMainPod::deserialize(serialized.proof.clone()).map_err(|e| {
+                        Error::custom(format!(
+                            "Failed to deserialize MockMainPod: {}. Value: {}",
+                            e, serialized.proof
+                        ))
+                    })?,
+                ),
+                public_statements: serialized.public_statements,
+                params: serialized.params,
+            }),
+        }
+    }
+}
+
+fn middleware_statements_to_backend(
+    mid_statements: Vec<Statement>,
+    params: &Params,
+    id: PodId,
+) -> Vec<BackendStatement> {
+    let mut statements = Vec::new();
+    for i in 0..(params.max_public_statements) {
+        let mut st: BackendStatement = mid_statements
+            .get(i)
+            .unwrap_or(&middleware::Statement::None)
             .clone()
-            .into_iter()
-            .map(|(k, v)| (k.name().to_string(), v))
-            .collect();
-        state.serialize_field("entries", &kvs_btree)?;
-        state.serialize_field("id", &self.id())?;
+            .into();
 
-        if let Ok(pod) = (self.pod.clone() as Box<dyn Any>).downcast::<MockSignedPod>() {
-            state.serialize_field("podType", &PodType::MockSigned)?;
-            state.serialize_field("proof", &pod.signature())?;
-        } else if let Ok(pod) = (self.pod.clone() as Box<dyn Any>).downcast::<Plonky2SignedPod>() {
-            state.serialize_field("podType", &PodType::Signed)?;
-            state.serialize_field("proof", &pod.signature)?;
-        }
-
-        state.end()
-    }
-}
-
-impl<'de> Deserialize<'de> for SignedPod {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        enum Field {
-            Entries,
-            Id,
-            Proof,
-            PodType,
-        }
-
-        impl<'de> Deserialize<'de> for Field {
-            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
-            where
-                D: serde::Deserializer<'de>,
-            {
-                struct FieldVisitor;
-
-                impl Visitor<'_> for FieldVisitor {
-                    type Value = Field;
-
-                    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                        formatter.write_str("`entries`, `id`, `proof`, or `podType`")
+        st = BackendStatement(
+            st.0.clone(),
+            st.1.iter()
+                .map(|sa| match &sa {
+                    StatementArg::Key(AnchoredKey { pod_id, key }) if *pod_id == id => {
+                        StatementArg::Key(AnchoredKey::new(SELF, key.clone()))
                     }
-
-                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
-                    where
-                        E: de::Error,
-                    {
-                        match value {
-                            "entries" => Ok(Field::Entries),
-                            "id" => Ok(Field::Id),
-                            "proof" => Ok(Field::Proof),
-                            "podType" => Ok(Field::PodType),
-                            _ => Err(de::Error::unknown_field(value, FIELDS)),
-                        }
-                    }
-                }
-                deserializer.deserialize_identifier(FieldVisitor)
-            }
-        }
-
-        struct SignedPodVisitor;
-
-        impl<'de> Visitor<'de> for SignedPodVisitor {
-            type Value = SignedPod;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("struct SignedPod")
-            }
-
-            fn visit_map<V>(self, mut map: V) -> Result<SignedPod, V::Error>
-            where
-                V: MapAccess<'de>,
-            {
-                let mut entries: Option<Dictionary> = None;
-                let mut id: Option<PodId> = None;
-                let mut proof_value: Option<serde_json::Value> = None;
-                let mut pod_type: Option<PodType> = None;
-
-                while let Some(key) = map.next_key()? {
-                    match key {
-                        Field::Entries => {
-                            if entries.is_some() {
-                                return Err(de::Error::duplicate_field("entries"));
-                            }
-                            entries = Some(map.next_value()?);
-                        }
-                        Field::Id => {
-                            if id.is_some() {
-                                return Err(de::Error::duplicate_field("id"));
-                            }
-                            id = Some(map.next_value()?);
-                        }
-                        Field::Proof => {
-                            if proof_value.is_some() {
-                                return Err(de::Error::duplicate_field("proof"));
-                            }
-                            proof_value = Some(map.next_value()?);
-                        }
-                        Field::PodType => {
-                            if pod_type.is_some() {
-                                return Err(de::Error::duplicate_field("podType"));
-                            }
-                            pod_type = Some(map.next_value()?);
-                        }
-                    }
-                }
-
-                let entries = entries.ok_or_else(|| de::Error::missing_field("entries"))?;
-                let _id = id.ok_or_else(|| de::Error::missing_field("id"))?;
-                let proof_value = proof_value.ok_or_else(|| de::Error::missing_field("proof"))?;
-                let pod_type = pod_type.ok_or_else(|| de::Error::missing_field("podType"))?;
-
-                let kvs = entries.kvs().clone();
-                let pod: Box<dyn Pod> = match pod_type {
-                    PodType::MockSigned => {
-                        let proof_string: String = serde_json::from_value(proof_value.clone())
-                            .map_err(|e| {
-                                de::Error::custom(format!(
-                                    "Proof for MockSigned is not a string: {}. Value: {}",
-                                    e, proof_value
-                                ))
-                            })?;
-                        Box::new(MockSignedPod::new(
-                            PodId(entries.commitment()),
-                            proof_string,
-                            kvs.clone(),
-                        ))
-                    }
-                    PodType::Signed => {
-                        let signature_obj: crate::backends::plonky2::primitives::signature::Signature =
-                            serde_json::from_value(proof_value.clone()).map_err(|e| {
-                                de::Error::custom(format!(
-                                    "Proof for Signed is not a Plonky2 Signature object: {}. Value: {}",
-                                    e, proof_value
-                                ))
-                            })?;
-                        Box::new(Plonky2SignedPod {
-                            id: PodId(entries.commitment()), // Use derived ID
-                            signature: signature_obj,
-                            dict: entries,
-                        })
-                    }
-                    _ => {
-                        return Err(de::Error::custom(format!(
-                            "Unsupported pod_type for SignedPod: {:?}",
-                            pod_type
-                        )))
-                    }
-                };
-
-                Ok(SignedPod { pod, kvs })
-            }
-        }
-
-        const FIELDS: &[&str] = &["entries", "id", "proof", "podType"];
-        deserializer.deserialize_struct("SignedPod", FIELDS, SignedPodVisitor)
-    }
-}
-
-impl Serialize for MainPod {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut state = serializer.serialize_struct("MainPod", 5)?;
-        state.serialize_field("id", &self.pod.id())?;
-        state.serialize_field("public_statements", &self.public_statements)?;
-
-        if let Ok(pod) = (self.pod.clone() as Box<dyn Any>).downcast::<MockMainPod>() {
-            state.serialize_field("params", &pod.params())?;
-            state.serialize_field("podType", &PodType::MockMain)?;
-            state.serialize_field("proof", &pod.serialized_proof())?;
-        } else if let Ok(pod) = (self.pod.clone() as Box<dyn Any>).downcast::<Plonky2MainPod>() {
-            state.serialize_field("params", &pod.params())?;
-            state.serialize_field("podType", &PodType::Main)?;
-            state.serialize_field("proof", &pod.proof())?;
-        }
-
-        state.end()
-    }
-}
-
-impl<'de> Deserialize<'de> for MainPod {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        enum Field {
-            Id,
-            PublicStatements,
-            PodType,
-            Proof,
-            Params,
-        }
-
-        impl<'de> Deserialize<'de> for Field {
-            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
-            where
-                D: serde::Deserializer<'de>,
-            {
-                struct FieldVisitor;
-
-                impl Visitor<'_> for FieldVisitor {
-                    type Value = Field;
-
-                    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                        formatter
-                            .write_str("`id`, `public_statements`, `podType`, `proof`, or `params`")
-                    }
-
-                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
-                    where
-                        E: de::Error,
-                    {
-                        match value {
-                            "id" => Ok(Field::Id),
-                            "public_statements" => Ok(Field::PublicStatements),
-                            "podType" => Ok(Field::PodType),
-                            "proof" => Ok(Field::Proof),
-                            "params" => Ok(Field::Params),
-                            _ => Err(de::Error::unknown_field(value, FIELDS)),
-                        }
-                    }
-                }
-                deserializer.deserialize_identifier(FieldVisitor)
-            }
-        }
-
-        struct MainPodVisitor;
-
-        impl<'de> Visitor<'de> for MainPodVisitor {
-            type Value = MainPod;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("struct MainPod")
-            }
-
-            fn visit_map<V>(self, mut map: V) -> Result<MainPod, V::Error>
-            where
-                V: MapAccess<'de>,
-            {
-                let mut id: Option<PodId> = None;
-                let mut public_statements: Option<Vec<Statement>> = None;
-                let mut pod_type: Option<PodType> = None;
-                let mut proof_value: Option<serde_json::Value> = None;
-                let mut params: Option<Params> = None;
-
-                while let Some(key) = map.next_key()? {
-                    match key {
-                        Field::Id => {
-                            if id.is_some() {
-                                return Err(de::Error::duplicate_field("id"));
-                            }
-                            id = Some(map.next_value()?);
-                        }
-                        Field::PublicStatements => {
-                            if public_statements.is_some() {
-                                return Err(de::Error::duplicate_field("public_statements"));
-                            }
-                            public_statements = Some(map.next_value()?);
-                        }
-                        Field::PodType => {
-                            if pod_type.is_some() {
-                                return Err(de::Error::duplicate_field("podType"));
-                            }
-                            pod_type = Some(map.next_value()?);
-                        }
-                        Field::Proof => {
-                            if proof_value.is_some() {
-                                return Err(de::Error::duplicate_field("proof"));
-                            }
-                            proof_value = Some(map.next_value()?);
-                        }
-                        Field::Params => {
-                            if params.is_some() {
-                                return Err(de::Error::duplicate_field("params"));
-                            }
-                            params = Some(map.next_value()?);
-                        }
-                    }
-                }
-
-                let id = id.ok_or_else(|| de::Error::missing_field("id"))?;
-                let public_statements = public_statements
-                    .ok_or_else(|| de::Error::missing_field("public_statements"))?;
-                let pod_type = pod_type.ok_or_else(|| de::Error::missing_field("podType"))?;
-                let proof_value = proof_value.ok_or_else(|| de::Error::missing_field("proof"))?;
-                let params = params.ok_or_else(|| de::Error::missing_field("params"))?;
-
-                let pod: Box<dyn Pod> = match pod_type {
-                    PodType::MockMain => {
-                        let proof_string: String = serde_json::from_value(proof_value.clone())
-                            .map_err(|e| {
-                                de::Error::custom(format!(
-                                    "Proof for MockMainPod is not a string: {}. Value: {}",
-                                    e, proof_value
-                                ))
-                            })?;
-                        Box::new(MockMainPod::deserialize(proof_string).map_err(|e| {
-                            de::Error::custom(format!("Failed to deserialize MockMainPod: {}", e))
-                        })?)
-                    }
-                    PodType::Main => {
-                        let actual_proof: MainPodProof =
-                            serde_json::from_value(proof_value.clone()).map_err(|e| {
-                                de::Error::custom(format!(
-                                    "Proof for Plonky2MainPod is not a valid Plonky2Proof structure: {}. Value: {}",
-                                    e, proof_value
-                                ))
-                            })?;
-                        Box::new(Plonky2MainPod::new(
-                            actual_proof,
-                            public_statements
-                                .clone()
-                                .into_iter()
-                                .map(|s| {
-                                    // We need to turn the middleware::Statement into a backend statement
-                                    let bs: BackendStatement = s.into();
-                                    BackendStatement(
-                                        bs.0.clone(),
-                                        bs.1.iter()
-                                            .map(|sa| match &sa {
-                                                // Reverse the normalization step by restoring the SELF PodId in places
-                                                // where the current Pod's ID has been used in an anchored key.
-                                                StatementArg::Key(AnchoredKey { pod_id, key })
-                                                    if *pod_id == id =>
-                                                {
-                                                    println!(
-                                                        "Replacing {:?} with {:?}",
-                                                        pod_id, SELF
-                                                    );
-                                                    StatementArg::Key(AnchoredKey::new(
-                                                        SELF,
-                                                        key.clone(),
-                                                    ))
-                                                }
-                                                _ => sa.clone(),
-                                            })
-                                            .collect(),
-                                    )
-                                })
-                                .collect(),
-                            id,
-                            params,
-                        ))
-                    }
-                    _ => {
-                        return Err(de::Error::custom(format!(
-                            "Unsupported pod_type for MainPod: {:?}",
-                            pod_type
-                        )))
-                    }
-                };
-
-                Ok(MainPod {
-                    pod,
-                    public_statements,
+                    _ => sa.clone(),
                 })
-            }
-        }
+                .collect(),
+        );
 
-        const FIELDS: &[&str] = &["id", "public_statements", "podType", "proof", "params"];
-        deserializer.deserialize_struct("MainPod", FIELDS, MainPodVisitor)
+        pad_statement(params, &mut st);
+        statements.push(st);
     }
+
+    statements
 }
-
-// #[derive(Serialize, Deserialize, JsonSchema)]
-// #[schemars(title = "MainPod")]
-// #[serde(rename_all = "camelCase")]
-// pub struct MainPodHelper {
-//     public_statements: Vec<Statement>,
-//     proof: String,
-//     pod_class: String,
-//     pod_type: String,
-// }
-
-// impl TryFrom<MainPodHelper> for MainPod {
-//     type Error = Error; // or you can create a custom error type
-
-//     fn try_from(helper: MainPodHelper) -> Result<Self, Self::Error> {
-//         if helper.pod_class != "Main" {
-//             return Err(Error::custom("pod_class is not Main"));
-//         }
-//         if helper.pod_type != "Mock" {
-//             return Err(Error::custom("pod_type is not Mock"));
-//         }
-
-//         let pod = MockMainPod::deserialize(helper.proof)
-//             .map_err(|e| Error::custom(format!("Failed to deserialize proof: {}", e)))?;
-
-//         Ok(MainPod {
-//             pod: Box::new(pod),
-//             public_statements: helper.public_statements,
-//         })
-//     }
-// }
-
-// impl From<MainPod> for MainPodHelper {
-//     fn from(pod: MainPod) -> Self {
-//         MainPodHelper {
-//             public_statements: pod.public_statements,
-//             proof: pod.pod.serialized_proof(),
-//             pod_class: "Main".to_string(),
-//             pod_type: "Mock".to_string(),
-//         }
-//     }
-// }
 
 #[cfg(test)]
 mod tests {
@@ -519,8 +260,7 @@ mod tests {
         }
     }
 
-    fn build_signed_pod() -> Result<SignedPod> {
-        let mut signer = MockSigner { pk: "test".into() };
+    fn signed_pod_builder() -> SignedPodBuilder {
         let mut builder = SignedPodBuilder::new(&Params::default());
         builder.insert("name", "test");
         builder.insert("age", 30);
@@ -547,19 +287,40 @@ mod tests {
             ]))
             .unwrap(),
         );
-
-        let pod = builder.sign(&mut signer).unwrap();
-        Ok(pod)
+        builder
     }
 
     #[test]
     fn test_signed_pod_serialization() {
-        let pod = build_signed_pod().unwrap();
+        let builder = signed_pod_builder();
+        let mut signer = Signer(SecretKey(RawValue::from(1)));
+        let pod = builder.sign(&mut signer).unwrap();
 
         let serialized = serde_json::to_string_pretty(&pod).unwrap();
         println!("serialized: {}", serialized);
         let deserialized: SignedPod = serde_json::from_str(&serialized).unwrap();
+        println!(
+            "deserialized: {}",
+            serde_json::to_string_pretty(&deserialized).unwrap()
+        );
+        assert_eq!(pod.kvs, deserialized.kvs);
+        assert_eq!(pod.verify().is_ok(), deserialized.verify().is_ok());
+        assert_eq!(pod.id(), deserialized.id())
+    }
 
+    #[test]
+    fn test_mock_signed_pod_serialization() {
+        let builder = signed_pod_builder();
+        let mut signer = MockSigner { pk: "test".into() };
+        let pod = builder.sign(&mut signer).unwrap();
+
+        let serialized = serde_json::to_string_pretty(&pod).unwrap();
+        println!("serialized: {}", serialized);
+        let deserialized: SignedPod = serde_json::from_str(&serialized).unwrap();
+        println!(
+            "deserialized: {}",
+            serde_json::to_string_pretty(&deserialized).unwrap()
+        );
         assert_eq!(pod.kvs, deserialized.kvs);
         assert_eq!(pod.verify().is_ok(), deserialized.verify().is_ok());
         assert_eq!(pod.id(), deserialized.id())
@@ -632,20 +393,8 @@ mod tests {
     #[test]
     fn test_plonky2_main_pod_serialization() -> Result<()> {
         let kyc_pod = build_plonky2_zukyc_pod()?;
-        println!("id: {}", kyc_pod.pod.id());
-        let pod = (kyc_pod.pod.clone() as Box<dyn Any>)
-            .downcast::<Plonky2MainPod>()
-            .unwrap();
-        let stmts = pod.public_statements.clone();
         let serialized = serde_json::to_string_pretty(&kyc_pod).unwrap();
-        // println!("serialized: {}", serialized);
         let deserialized: MainPod = serde_json::from_str(&serialized).unwrap();
-        println!("deserialized id: {}", deserialized.pod.id());
-        let dpod = (deserialized.pod.clone() as Box<dyn Any>)
-            .downcast::<Plonky2MainPod>()
-            .unwrap();
-        let dstmts = dpod.public_statements.clone();
-        assert_eq!(stmts, dstmts);
 
         assert_eq!(kyc_pod.public_statements, deserialized.public_statements);
         assert_eq!(kyc_pod.pod.id(), deserialized.pod.id());
@@ -694,30 +443,32 @@ mod tests {
         Ok(alice_bob_ethdos)
     }
 
-    // #[test]
-    // // This tests that we can generate JSON Schemas for the MainPod and
-    // // SignedPod types, and that we can validate real Signed and Main Pods
-    // // against the schemas.
-    // fn test_schema() {
-    //     let mainpod_schema = schema_for!(MainPodHelper);
-    //     let signedpod_schema = schema_for!(SignedPodHelper);
+    #[test]
+    // This tests that we can generate JSON Schemas for the MainPod and
+    // SignedPod types, and that we can validate real Signed and Main Pods
+    // against the schemas.
+    fn test_schema() {
+        let mainpod_schema = schema_for!(SerializedMainPod);
+        let signedpod_schema = schema_for!(SerializedSignedPod);
 
-    //     let kyc_pod = build_zukyc_pod().unwrap();
-    //     let signed_pod = build_signed_pod().unwrap();
-    //     let ethdos_pod = build_ethdos_pod().unwrap();
-    //     let mainpod_schema_value = serde_json::to_value(&mainpod_schema).unwrap();
-    //     let signedpod_schema_value = serde_json::to_value(&signedpod_schema).unwrap();
+        let kyc_pod = build_mock_zukyc_pod().unwrap();
+        let signed_pod = signed_pod_builder()
+            .sign(&mut MockSigner { pk: "test".into() })
+            .unwrap();
+        let ethdos_pod = build_ethdos_pod().unwrap();
+        let mainpod_schema_value = serde_json::to_value(&mainpod_schema).unwrap();
+        let signedpod_schema_value = serde_json::to_value(&signedpod_schema).unwrap();
 
-    //     let kyc_pod_value = serde_json::to_value(&kyc_pod).unwrap();
-    //     let mainpod_valid = jsonschema::validate(&mainpod_schema_value, &kyc_pod_value);
-    //     assert!(mainpod_valid.is_ok(), "{:#?}", mainpod_valid);
+        let kyc_pod_value = serde_json::to_value(&kyc_pod).unwrap();
+        let mainpod_valid = jsonschema::validate(&mainpod_schema_value, &kyc_pod_value);
+        assert!(mainpod_valid.is_ok(), "{:#?}", mainpod_valid);
 
-    //     let signed_pod_value = serde_json::to_value(&signed_pod).unwrap();
-    //     let signedpod_valid = jsonschema::validate(&signedpod_schema_value, &signed_pod_value);
-    //     assert!(signedpod_valid.is_ok(), "{:#?}", signedpod_valid);
+        let signed_pod_value = serde_json::to_value(&signed_pod).unwrap();
+        let signedpod_valid = jsonschema::validate(&signedpod_schema_value, &signed_pod_value);
+        assert!(signedpod_valid.is_ok(), "{:#?}", signedpod_valid);
 
-    //     let ethdos_pod_value = serde_json::to_value(&ethdos_pod).unwrap();
-    //     let ethdos_pod_valid = jsonschema::validate(&mainpod_schema_value, &ethdos_pod_value);
-    //     assert!(ethdos_pod_valid.is_ok(), "{:#?}", ethdos_pod_valid);
-    // }
+        let ethdos_pod_value = serde_json::to_value(&ethdos_pod).unwrap();
+        let ethdos_pod_valid = jsonschema::validate(&mainpod_schema_value, &ethdos_pod_value);
+        assert!(ethdos_pod_valid.is_ok(), "{:#?}", ethdos_pod_valid);
+    }
 }

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -692,6 +692,16 @@ pub trait Pod: fmt::Debug + DynClone + Any {
             .collect()
     }
 
+    // Front-end Pods keep references to middleware Pods. Most of the
+    // middleware data can be derived directly from front-end data, but the
+    // "proof" data is only created at the point of proving/signing, and
+    // cannot be reconstructed. As such, we need to serialize it whenever
+    // we serialize a front-end Pod. Since the front-end does not understand
+    // the implementation details of the middleware, this method allows the
+    // middleware to provide some serialized data that can be used to
+    // reconstruct the proof.
+    // It is an important principle that this data is opaque to the front-end
+    // and any third-party code.
     fn serialized_proof(&self) -> String;
 }
 

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -673,10 +673,6 @@ impl Params {
         );
         println!();
     }
-
-    fn serialized_proof(&self) -> String {
-        BASE64_STANDARD.encode(serde_json::to_string(self).unwrap())
-    }
 }
 
 pub type DynError = dyn std::error::Error + Send + Sync;
@@ -695,6 +691,8 @@ pub trait Pod: fmt::Debug + DynClone + Any {
             })
             .collect()
     }
+
+    fn serialized_proof(&self) -> String;
 }
 
 // impl Clone for Box<dyn SignedPod>
@@ -722,6 +720,9 @@ impl Pod for NonePod {
     }
     fn pub_statements(&self) -> Vec<Statement> {
         Vec::new()
+    }
+    fn serialized_proof(&self) -> String {
+        "".to_string()
     }
 }
 

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -8,7 +8,6 @@ use std::{
     hash,
 };
 
-use base64::{prelude::BASE64_STANDARD, Engine};
 use containers::{Array, Dictionary, Set};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -8,6 +8,7 @@ use std::{
     hash,
 };
 
+use base64::{prelude::BASE64_STANDARD, Engine};
 use containers::{Array, Dictionary, Set};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -553,7 +554,7 @@ impl ToFields for PodId {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub enum PodType {
     None = 0,
     MockSigned = 1,
@@ -574,7 +575,7 @@ impl fmt::Display for PodType {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Params {
     pub max_input_signed_pods: usize,
@@ -672,6 +673,10 @@ impl Params {
         );
         println!();
     }
+
+    fn serialized_proof(&self) -> String {
+        BASE64_STANDARD.encode(serde_json::to_string(self).unwrap())
+    }
 }
 
 pub type DynError = dyn std::error::Error + Send + Sync;
@@ -690,15 +695,6 @@ pub trait Pod: fmt::Debug + DynClone + Any {
             })
             .collect()
     }
-    // Front-end Pods keep references to middleware Pods. Most of the
-    // middleware data can be derived directly from front-end data, but the
-    // "proof" data is only created at the point of proving/signing, and
-    // cannot be reconstructed. As such, we need to serialize it whenever
-    // we serialize a front-end Pod. Since the front-end does not understand
-    // the implementation details of the middleware, this method allows the
-    // middleware to provide some serialized data that can be used to
-    // reconstruct the proof.
-    fn serialized_proof(&self) -> String;
 }
 
 // impl Clone for Box<dyn SignedPod>
@@ -726,9 +722,6 @@ impl Pod for NonePod {
     }
     fn pub_statements(&self) -> Vec<Statement> {
         Vec::new()
-    }
-    fn serialized_proof(&self) -> String {
-        "".to_string()
     }
 }
 


### PR DESCRIPTION
This PR adds serialization for the plonky2 variants of Signed and Main PODs.

Both mock and plonky2 PODs have identical signed representations. In Signed PODs, the `signature` field is an opaque string, and in Main PODs the `proof` field is an opaque string. External applications should not rely on this string having any particular contents or structure.

See the `SerializedSignedPod` and `SerializedMainPod` types - these are intermediate types used to standardize the representation before serialization.