### PR TITLE
Add verifier-datas tree (set) & in-circuit verification

### DIFF
--- a/src/backends/plonky2/basetypes.rs
+++ b/src/backends/plonky2/basetypes.rs
@@ -37,7 +37,6 @@ pub type CircuitBuilder = circuit_builder::CircuitBuilder<F, D>;
 pub type Proof = proof::Proof<F, C, D>;
 pub type ProofWithPublicInputs = proof::ProofWithPublicInputs<F, C, D>;
 
-// TODO decide where to place struct VDSTree and the DEFAULT_VD_TREE
 use std::{collections::HashMap, sync::LazyLock};
 
 use plonky2::hash::hash_types::HashOut;
@@ -60,19 +59,17 @@ pub static DEFAULT_VD_TREE: LazyLock<VDTree> = LazyLock::new(|| {
     VDTree::new(params.max_depth_mt_vds, &vds).unwrap()
 });
 
-// TODO: Note: I've used `containers::Array`, but I think that using the `Set`
-// would make. With `Array` we save 1 hash per each verifier_data entry, but
-// with `Set` we don't need to keep track of which verifier_data is stored at
-// which position, and can just get the merkleproof for the given
-// `verifier_data` (without first getting its `i`).
 /// Struct that allows to get the specific merkle proofs for the given verifier_data
+#[derive(Clone, Debug)]
 pub struct VDTree {
     root: Hash,
+    // (verifier_data, merkleproof)
     proofs_map: HashMap<HashOut<F>, MerkleClaimAndProof>,
 }
 impl VDTree {
     /// builds the verifier_datas tree, and returns the root and the proofs
     pub fn new(tree_depth: usize, vds: &[VerifierOnlyCircuitData]) -> Result<Self> {
+        // TODO sort vds
         let array = Array::new_with_depth(
             tree_depth,
             vds.iter()

--- a/src/backends/plonky2/basetypes.rs
+++ b/src/backends/plonky2/basetypes.rs
@@ -60,7 +60,11 @@ pub static DEFAULT_VD_SET: LazyLock<VDSet> = LazyLock::new(|| {
     VDSet::new(params.max_depth_mt_vds, &vds).unwrap()
 });
 
-/// Struct that allows to get the specific merkle proofs for the given verifier_data
+/// VDSet is the set of the allowed verifier_data hashes. When proving a
+/// MainPod, the circuit will enforce that all the used verifier_datas for
+/// verifying the recursive proofs of previous PODs appears in the VDSet.
+/// The VDSet struct that allows to get the specific merkle proofs for the given
+/// verifier_data.
 #[derive(Clone, Debug)]
 pub struct VDSet {
     root: Hash,

--- a/src/backends/plonky2/basetypes.rs
+++ b/src/backends/plonky2/basetypes.rs
@@ -49,24 +49,24 @@ use crate::{
     middleware::{containers::Array, Hash, RawValue, Result, Value},
 };
 
-pub static DEFAULT_VD_TREE: LazyLock<VDTree> = LazyLock::new(|| {
+pub static DEFAULT_VD_SET: LazyLock<VDSet> = LazyLock::new(|| {
     let params = &*DEFAULT_PARAMS;
 
     let vds = vec![
         STANDARD_REC_MAIN_POD_CIRCUIT_DATA.verifier_only.clone(),
         STANDARD_EMPTY_POD_DATA.1.verifier_only.clone(),
     ];
-    VDTree::new(params.max_depth_mt_vds, &vds).unwrap()
+    VDSet::new(params.max_depth_mt_vds, &vds).unwrap()
 });
 
 /// Struct that allows to get the specific merkle proofs for the given verifier_data
 #[derive(Clone, Debug)]
-pub struct VDTree {
+pub struct VDSet {
     root: Hash,
     // (verifier_data, merkleproof)
     proofs_map: HashMap<HashOut<F>, MerkleClaimAndProof>,
 }
-impl VDTree {
+impl VDSet {
     /// builds the verifier_datas tree, and returns the root and the proofs
     pub fn new(tree_depth: usize, vds: &[VerifierOnlyCircuitData]) -> Result<Self> {
         // TODO sort vds
@@ -106,7 +106,7 @@ impl VDTree {
                 self.proofs_map
                     .get(&vd.circuit_digest)
                     .ok_or(crate::middleware::Error::custom(
-                        "verifier_data not found in VDTree".to_string(),
+                        "verifier_data not found in VDSet".to_string(),
                     ))?;
             proofs.push(p.clone());
         }

--- a/src/backends/plonky2/basetypes.rs
+++ b/src/backends/plonky2/basetypes.rs
@@ -36,3 +36,83 @@ pub type VerifierCircuitData = circuit_data::VerifierCircuitData<F, C, D>;
 pub type CircuitBuilder = circuit_builder::CircuitBuilder<F, D>;
 pub type Proof = proof::Proof<F, C, D>;
 pub type ProofWithPublicInputs = proof::ProofWithPublicInputs<F, C, D>;
+
+// TODO decide where to place struct VDSTree and the DEFAULT_VD_TREE
+use std::{collections::HashMap, sync::LazyLock};
+
+use plonky2::hash::hash_types::HashOut;
+
+use crate::{
+    backends::plonky2::{
+        emptypod::STANDARD_EMPTY_POD_DATA, primitives::merkletree::MerkleClaimAndProof,
+        DEFAULT_PARAMS, STANDARD_REC_MAIN_POD_CIRCUIT_DATA,
+    },
+    middleware::{containers::Array, Hash, RawValue, Result, Value},
+};
+
+pub static DEFAULT_VD_TREE: LazyLock<VDTree> = LazyLock::new(|| {
+    let params = &*DEFAULT_PARAMS;
+
+    let vds = vec![
+        STANDARD_REC_MAIN_POD_CIRCUIT_DATA.verifier_only.clone(),
+        STANDARD_EMPTY_POD_DATA.1.verifier_only.clone(),
+    ];
+    VDTree::new(params.max_depth_mt_vds, &vds).unwrap()
+});
+
+// TODO: Note: I've used `containers::Array`, but I think that using the `Set`
+// would make. With `Array` we save 1 hash per each verifier_data entry, but
+// with `Set` we don't need to keep track of which verifier_data is stored at
+// which position, and can just get the merkleproof for the given
+// `verifier_data` (without first getting its `i`).
+/// Struct that allows to get the specific merkle proofs for the given verifier_data
+pub struct VDTree {
+    root: Hash,
+    proofs_map: HashMap<HashOut<F>, MerkleClaimAndProof>,
+}
+impl VDTree {
+    /// builds the verifier_datas tree, and returns the root and the proofs
+    pub fn new(tree_depth: usize, vds: &[VerifierOnlyCircuitData]) -> Result<Self> {
+        let array = Array::new_with_depth(
+            tree_depth,
+            vds.iter()
+                .map(|vd| Value::from(RawValue(vd.circuit_digest.elements)))
+                .collect(),
+        )?;
+
+        let root = array.commitment();
+        let mut proofs_map = HashMap::<HashOut<F>, MerkleClaimAndProof>::new();
+
+        for (i, vd) in vds.iter().enumerate() {
+            let (value, proof) = array.prove(i)?;
+            let p = MerkleClaimAndProof {
+                root,
+                key: RawValue::from(i as i64),
+                value: value.raw(),
+                proof,
+            };
+            proofs_map.insert(vd.circuit_digest, p);
+        }
+        Ok(Self { root, proofs_map })
+    }
+    pub fn root(&self) -> Hash {
+        self.root
+    }
+    /// returns the vector of merkle proofs corresponding to the given verifier_datas
+    pub fn get_vds_proofs(
+        &self,
+        vds: &[VerifierOnlyCircuitData],
+    ) -> Result<Vec<MerkleClaimAndProof>> {
+        let mut proofs: Vec<MerkleClaimAndProof> = vec![];
+        for vd in vds {
+            let p =
+                self.proofs_map
+                    .get(&vd.circuit_digest)
+                    .ok_or(crate::middleware::Error::custom(
+                        "verifier_data not found in VDTree".to_string(),
+                    ))?;
+            proofs.push(p.clone());
+        }
+        Ok(proofs)
+    }
+}

--- a/src/backends/plonky2/circuits/common.rs
+++ b/src/backends/plonky2/circuits/common.rs
@@ -40,7 +40,7 @@ use crate::{
 pub const CODE_SIZE: usize = HASH_SIZE + 2;
 const NUM_BITS: usize = 32;
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct ValueTarget {
     pub elements: [Target; VALUE_SIZE],
 }

--- a/src/backends/plonky2/circuits/mainpod.rs
+++ b/src/backends/plonky2/circuits/mainpod.rs
@@ -1406,7 +1406,7 @@ impl MainPodVerifyTarget {
         pw.set_target_arr(&self.vds_root.elements, &input.vds_root.0)?;
 
         for (i, vd_mt_proof) in input.vd_mt_proofs.iter().enumerate() {
-            self.vd_mt_proofs[i].set_targets(pw, true, &vd_mt_proof)?;
+            self.vd_mt_proofs[i].set_targets(pw, true, vd_mt_proof)?;
         }
         // TODO review if disable, or if to put emtpy_pod related vd
         for i in input.vd_mt_proofs.len()..self.vd_mt_proofs.len() {

--- a/src/backends/plonky2/circuits/mainpod.rs
+++ b/src/backends/plonky2/circuits/mainpod.rs
@@ -1231,6 +1231,9 @@ impl MainPodVerifyGadget {
             }
             .eval(builder);
 
+            // ensure that mt_proof is enabled
+            let true_targ = builder._true();
+            builder.connect(vd_mt_proof.enabled.target, true_targ.target);
             // connect the vd_mt_proof's root to the actual vds_root, to ensure that the mt proof
             // verifies against the vds_root
             builder.connect_hashes(vds_root, vd_mt_proof.root);

--- a/src/backends/plonky2/circuits/mainpod.rs
+++ b/src/backends/plonky2/circuits/mainpod.rs
@@ -1221,9 +1221,8 @@ impl MainPodVerifyGadget {
 
         let vds_root = builder.add_virtual_hash();
 
-        // TODO: verify that all input pod proofs use verifier data from the public input VD array
-        // This requires merkle proofs
-        // https://github.com/0xPARC/pod2/issues/250
+        // verify that all input pod proofs use verifier data from the public input VD array This
+        // requires merkle proofs
         let mut vd_mt_proofs: Vec<MerkleClaimAndProofTarget> = vec![];
         for verified_proof in verified_proofs {
             // add target for the vd_mt_proof
@@ -1235,7 +1234,11 @@ impl MainPodVerifyGadget {
             // connect the vd_mt_proof's root to the actual vds_root, to ensure that the mt proof
             // verifies against the vds_root
             builder.connect_hashes(vds_root, vd_mt_proof.root);
-            // TODO connect vd_mt_proof.key == verified_proof.verifier_data_hash
+            // connect vd_mt_proof's value with the verified_proof.verifier_data_hash
+            builder.connect_hashes(
+                verified_proof.verifier_data_hash,
+                HashOutTarget::from_vec(vd_mt_proof.value.elements.to_vec()),
+            );
 
             vd_mt_proofs.push(vd_mt_proof);
         }

--- a/src/backends/plonky2/circuits/mainpod.rs
+++ b/src/backends/plonky2/circuits/mainpod.rs
@@ -1411,7 +1411,6 @@ impl MainPodVerifyTarget {
         for (i, vd_mt_proof) in input.vd_mt_proofs.iter().enumerate() {
             self.vd_mt_proofs[i].set_targets(pw, true, vd_mt_proof)?;
         }
-        // TODO review if disable, or if to put emtpy_pod related vd
         for i in input.vd_mt_proofs.len()..self.vd_mt_proofs.len() {
             self.vd_mt_proofs[i].set_targets(pw, false, &input.vd_mt_proofs[i])?;
         }

--- a/src/backends/plonky2/circuits/signedpod.rs
+++ b/src/backends/plonky2/circuits/signedpod.rs
@@ -41,7 +41,7 @@ impl SignedPodVerifyGadget {
         let mut mt_proofs = Vec::new();
         for _ in 0..self.params.max_signed_pod_values {
             let mt_proof = MerkleProofExistenceGadget {
-                max_depth: self.params.max_depth_mt_gadget,
+                max_depth: self.params.max_depth_mt_containers,
             }
             .eval(builder)?;
             builder.connect_hashes(id, mt_proof.root);

--- a/src/backends/plonky2/emptypod.rs
+++ b/src/backends/plonky2/emptypod.rs
@@ -27,7 +27,7 @@ use crate::{
     },
     middleware::{
         self, AnchoredKey, DynError, Hash, Params, Pod, PodId, PodType, RecursivePod, Statement,
-        ToFields, Value, VerifierOnlyCircuitData, EMPTY_HASH, F, HASH_SIZE, KEY_TYPE, SELF,
+        ToFields, Value, VerifierOnlyCircuitData, F, HASH_SIZE, KEY_TYPE, SELF,
     },
     timed,
 };
@@ -80,7 +80,7 @@ pub struct EmptyPod {
 
 type CircuitData = circuit_data::CircuitData<F, C, D>;
 
-static STANDARD_EMPTY_POD_DATA: LazyLock<(EmptyPodVerifyTarget, CircuitData)> =
+pub static STANDARD_EMPTY_POD_DATA: LazyLock<(EmptyPodVerifyTarget, CircuitData)> =
     LazyLock::new(|| build().expect("successful build"));
 
 fn build() -> Result<(EmptyPodVerifyTarget, CircuitData)> {
@@ -144,7 +144,7 @@ impl EmptyPod {
         let public_inputs = id
             .to_fields(&self.params)
             .iter()
-            .chain(EMPTY_HASH.0.iter()) // slot for the unused vds root
+            .chain(self.vds_root.0.iter())
             .cloned()
             .collect_vec();
 
@@ -222,6 +222,7 @@ impl RecursivePod for EmptyPod {
 #[cfg(test)]
 pub mod tests {
     use super::*;
+    use crate::middleware::EMPTY_HASH;
 
     #[test]
     fn test_empty_pod() {

--- a/src/backends/plonky2/mainpod/mod.rs
+++ b/src/backends/plonky2/mainpod/mod.rs
@@ -701,7 +701,7 @@ pub mod tests {
             {self},
         },
         middleware,
-        middleware::{CustomPredicateRef, NativePredicate as NP, RawValue, DEFAULT_VD_SET},
+        middleware::{CustomPredicateRef, NativePredicate as NP, DEFAULT_VD_SET},
         op,
     };
 

--- a/src/backends/plonky2/mainpod/mod.rs
+++ b/src/backends/plonky2/mainpod/mod.rs
@@ -545,6 +545,11 @@ impl PodProver for Prover {
 pub struct MainPod {
     params: Params,
     id: PodId,
+    /// vds_root is the merkle-root of the `VDSet`, which contains the
+    /// verifier_data hashes of the allowed set of VerifierOnlyCircuitData, for
+    /// the succession of recursive MainPods, which when proving the POD, it is
+    /// proven that all the recursive proofs that are being verified in-circuit
+    /// use one of the verifier_data's contained in the VDSet.
     vds_root: Hash,
     public_statements: Vec<Statement>,
     proof: Proof,

--- a/src/backends/plonky2/mainpod/mod.rs
+++ b/src/backends/plonky2/mainpod/mod.rs
@@ -13,10 +13,8 @@ pub use statement::*;
 
 use crate::{
     backends::plonky2::{
-        basetypes::{Proof, ProofWithPublicInputs, VerifierOnlyCircuitData, D, DEFAULT_VD_TREE},
-        circuits::mainpod::{
-            CustomPredicateVerification, MainPodVerifyInput, MainPodVerifyTarget, NUM_PUBLIC_INPUTS,
-        },
+        basetypes::{Proof, ProofWithPublicInputs, VerifierOnlyCircuitData, D},
+        circuits::mainpod::{CustomPredicateVerification, MainPodVerifyInput, MainPodVerifyTarget},
         deserialize_proof,
         emptypod::EmptyPod,
         error::{Error, Result},

--- a/src/backends/plonky2/mainpod/mod.rs
+++ b/src/backends/plonky2/mainpod/mod.rs
@@ -283,7 +283,7 @@ pub(crate) fn layout_statements(
             // We mocking or we don't need padding so we skip creating an EmptyPod
             MockEmptyPod::new_boxed(params)
         } else {
-            EmptyPod::new_boxed(params, inputs.vds_root)
+            EmptyPod::new_boxed(params, inputs.vds_set.root())
         };
     let empty_pod = empty_pod_box.as_ref();
     assert!(inputs.recursive_pods.len() <= params.max_input_recursive_pods);
@@ -445,7 +445,7 @@ impl Prover {
             // We don't need padding so we skip creating an EmptyPod
             MockEmptyPod::new_boxed(params)
         } else {
-            EmptyPod::new_boxed(params, inputs.vds_root)
+            EmptyPod::new_boxed(params, inputs.vds_set.root())
         };
         let inputs = MainPodInputs {
             recursive_pods: &inputs
@@ -492,10 +492,10 @@ impl Prover {
             .recursive_pods
             .iter()
             .map(|pod| {
-                assert_eq!(inputs.vds_root, pod.vds_root());
+                assert_eq!(inputs.vds_set.root(), pod.vds_root());
                 ProofWithPublicInputs {
                     proof: pod.proof(),
-                    public_inputs: [pod.id().0 .0, inputs.vds_root.0].concat(),
+                    public_inputs: [pod.id().0 .0, inputs.vds_set.root().0].concat(),
                 }
             })
             .collect_vec();
@@ -508,7 +508,7 @@ impl Prover {
         let vd_mt_proofs = vd_set.get_vds_proofs(&verifier_datas)?;
 
         let input = MainPodVerifyInput {
-            vds_root: inputs.vds_root,
+            vds_set: inputs.vds_set.clone(),
             vd_mt_proofs,
             signed_pods: signed_pods_input,
             recursive_pods_pub_self_statements,
@@ -523,7 +523,7 @@ impl Prover {
         Ok(MainPod {
             params: params.clone(),
             id,
-            vds_root: inputs.vds_root,
+            vds_root: inputs.vds_set.root(),
             public_statements,
             proof: proof_with_pis.proof,
         })

--- a/src/backends/plonky2/mainpod/mod.rs
+++ b/src/backends/plonky2/mainpod/mod.rs
@@ -26,9 +26,10 @@ use crate::{
         STANDARD_REC_MAIN_POD_CIRCUIT_DATA,
     },
     middleware::{
-        self, resolve_wildcard_values, AnchoredKey, CustomPredicateBatch, DynError, Hash,
-        MainPodInputs, NativeOperation, NonePod, OperationType, Params, Pod, PodId, PodProver,
-        PodType, RecursivePod, StatementArg, ToFields, F, KEY_TYPE, SELF,
+        self, containers::Array, resolve_wildcard_values, AnchoredKey, CustomPredicateBatch,
+        DynError, Hash, MainPodInputs, NativeOperation, NonePod, OperationType, Params, Pod, PodId,
+        PodProver, PodType, RawValue, RecursivePod, StatementArg, ToFields, Value, F, KEY_TYPE,
+        SELF,
     },
 };
 
@@ -153,11 +154,11 @@ pub(crate) fn extract_merkle_proofs(
             _ => None,
         })
         .collect();
-    if merkle_proofs.len() > params.max_merkle_proofs {
+    if merkle_proofs.len() > params.max_merkle_proofs_containers {
         return Err(Error::custom(format!(
             "The number of required Merkle proofs ({}) exceeds the maximum number ({}).",
             merkle_proofs.len(),
-            params.max_merkle_proofs
+            params.max_merkle_proofs_containers
         )));
     }
     Ok(merkle_proofs)
@@ -504,8 +505,13 @@ impl Prover {
             .iter()
             .map(|pod| pod.verifier_data())
             .collect_vec();
+
+        let (root, vd_mt_proofs) = vds_tree(params.max_depth_mt_vds, &verifier_datas)?;
+        assert_eq!(inputs.vds_root, root);
+
         let input = MainPodVerifyInput {
             vds_root: inputs.vds_root,
+            vd_mt_proofs,
             signed_pods: signed_pods_input,
             recursive_pods_pub_self_statements,
             statements: statements[statements.len() - params.max_statements..].to_vec(),
@@ -676,6 +682,33 @@ impl RecursivePod for MainPod {
     }
 }
 
+/// builds the verifier_datas tree, and returns the root and the proofs
+fn vds_tree(
+    tree_depth: usize,
+    vds: &[VerifierOnlyCircuitData],
+) -> Result<(Hash, Vec<MerkleClaimAndProof>)> {
+    let array = Array::new_with_depth(
+        tree_depth,
+        vds.iter()
+            .map(|vd| Value::from(RawValue(vd.circuit_digest.elements)))
+            .collect(),
+    )?;
+
+    let root = array.commitment();
+    let mut proofs = vec![];
+    for i in 0..vds.len() {
+        let (value, proof) = array.prove(i)?;
+        let p = MerkleClaimAndProof {
+            root,
+            key: RawValue::from(i as i64),
+            value: value.raw(),
+            proof,
+        };
+        proofs.push(p);
+    }
+    Ok((root, proofs))
+}
+
 #[cfg(test)]
 pub mod tests {
     use num::{BigUint, One};
@@ -792,8 +825,9 @@ pub mod tests {
             max_custom_predicate_arity: 2,
             max_custom_predicate_wildcards: 2,
             max_custom_batch_size: 2,
-            max_merkle_proofs: 2,
-            max_depth_mt_gadget: 4,
+            max_merkle_proofs_containers: 2,
+            max_depth_mt_containers: 4,
+            max_depth_mt_vds: 6,
         };
 
         let pod_builder = frontend::MainPodBuilder::new(&params);

--- a/src/backends/plonky2/mainpod/mod.rs
+++ b/src/backends/plonky2/mainpod/mod.rs
@@ -30,7 +30,7 @@ use crate::{
     middleware::{
         self, resolve_wildcard_values, AnchoredKey, CustomPredicateBatch, DynError, Hash,
         MainPodInputs, NativeOperation, NonePod, OperationType, Params, Pod, PodId, PodProver,
-        PodType, RecursivePod, StatementArg, ToFields, VDTree, F, KEY_TYPE, SELF,
+        PodType, RecursivePod, StatementArg, ToFields, VDSet, F, KEY_TYPE, SELF,
     },
 };
 
@@ -412,7 +412,7 @@ pub(crate) fn process_public_statements_operations(
 pub struct Prover {}
 
 impl Prover {
-    fn _prove(&self, params: &Params, vd_tree: &VDTree, inputs: MainPodInputs) -> Result<MainPod> {
+    fn _prove(&self, params: &Params, vd_set: &VDSet, inputs: MainPodInputs) -> Result<MainPod> {
         let rec_circuit_data = &*STANDARD_REC_MAIN_POD_CIRCUIT_DATA;
         let (main_pod_target, circuit_data) =
             RecursiveCircuit::<MainPodVerifyTarget>::target_and_circuit_data_padded(
@@ -507,7 +507,7 @@ impl Prover {
             .map(|pod| pod.verifier_data())
             .collect_vec();
 
-        let vd_mt_proofs = vd_tree.get_vds_proofs(&verifier_datas)?;
+        let vd_mt_proofs = vd_set.get_vds_proofs(&verifier_datas)?;
 
         let input = MainPodVerifyInput {
             vds_root: inputs.vds_root,
@@ -536,10 +536,10 @@ impl PodProver for Prover {
     fn prove(
         &self,
         params: &Params,
-        vd_tree: &VDTree,
+        vd_set: &VDSet,
         inputs: MainPodInputs,
     ) -> Result<Box<dyn RecursivePod>, Box<DynError>> {
-        Ok(self._prove(params, vd_tree, inputs).map(Box::new)?)
+        Ok(self._prove(params, vd_set, inputs).map(Box::new)?)
     }
 }
 
@@ -703,7 +703,7 @@ pub mod tests {
             {self},
         },
         middleware,
-        middleware::{CustomPredicateRef, NativePredicate as NP, RawValue, DEFAULT_VD_TREE},
+        middleware::{CustomPredicateRef, NativePredicate as NP, RawValue, DEFAULT_VD_SET},
         op,
     };
 
@@ -718,7 +718,7 @@ pub mod tests {
             ..Default::default()
         };
         println!("{:#?}", params);
-        let vd_tree = &*DEFAULT_VD_TREE;
+        let vd_set = &*DEFAULT_VD_SET;
 
         let (gov_id_builder, pay_stub_builder, sanction_list_builder) =
             zu_kyc_sign_pod_builders(&params);
@@ -730,7 +730,7 @@ pub mod tests {
         let sanction_list_pod = sanction_list_builder.sign(&mut signer)?;
         let kyc_builder = zu_kyc_pod_builder(
             &params,
-            &vd_tree,
+            &vd_set,
             &gov_id_pod,
             &pay_stub_pod,
             &sanction_list_pod,
@@ -755,7 +755,7 @@ pub mod tests {
             max_input_pods_public_statements: 10,
             ..Default::default()
         };
-        let vd_tree = &*DEFAULT_VD_TREE;
+        let vd_set = &*DEFAULT_VD_SET;
 
         let mut gov_id_builder = frontend::SignedPodBuilder::new(&params);
         gov_id_builder.insert("idNumber", "4242424242");
@@ -764,7 +764,7 @@ pub mod tests {
         let mut signer = Signer(SecretKey(42u64.into()));
         let gov_id = gov_id_builder.sign(&mut signer).unwrap();
         let now_minus_18y: i64 = 1169909388;
-        let mut kyc_builder = frontend::MainPodBuilder::new(&params, &vd_tree);
+        let mut kyc_builder = frontend::MainPodBuilder::new(&params, &vd_set);
         kyc_builder.add_signed_pod(&gov_id);
         kyc_builder
             .pub_op(op!(lt, (&gov_id, "dateOfBirth"), now_minus_18y))
@@ -810,9 +810,9 @@ pub mod tests {
             max_depth_mt_containers: 4,
             max_depth_mt_vds: 6,
         };
-        let vd_tree = &*DEFAULT_VD_TREE;
+        let vd_set = &*DEFAULT_VD_SET;
 
-        let pod_builder = frontend::MainPodBuilder::new(&params, &vd_tree);
+        let pod_builder = frontend::MainPodBuilder::new(&params, &vd_set);
 
         // Mock
         let mut prover = MockProver {};
@@ -844,7 +844,7 @@ pub mod tests {
             ..Default::default()
         };
         println!("{:#?}", params);
-        let vd_tree = &*DEFAULT_VD_TREE;
+        let vd_set = &*DEFAULT_VD_SET;
 
         let mut alice = Signer(SecretKey(1u32.into()));
         let bob = Signer(SecretKey(2u32.into()));
@@ -859,7 +859,7 @@ pub mod tests {
 
         let alice_bob_ethdos_builder = eth_dos_pod_builder(
             &params,
-            &vd_tree,
+            &vd_set,
             false,
             &alice_attestation,
             &charlie_attestation,
@@ -896,7 +896,7 @@ pub mod tests {
             ..Default::default()
         };
         println!("{:#?}", params);
-        let vd_tree = &*DEFAULT_VD_TREE;
+        let vd_set = &*DEFAULT_VD_SET;
 
         let mut cpb_builder = CustomPredicateBatchBuilder::new(params.clone(), "cpb".into());
         let stb0 = STB::new(NP::ValueOf)
@@ -917,7 +917,7 @@ pub mod tests {
         let cpb_and = CustomPredicateRef::new(cpb.clone(), 0);
         let _cpb_or = CustomPredicateRef::new(cpb.clone(), 1);
 
-        let mut pod_builder = MainPodBuilder::new(&params, &vd_tree);
+        let mut pod_builder = MainPodBuilder::new(&params, &vd_set);
 
         let st0 = pod_builder.priv_op(op!(new_entry, ("score", 42)))?;
         let st1 = pod_builder.priv_op(op!(new_entry, ("foo", 42)))?;

--- a/src/backends/plonky2/mock/mainpod.rs
+++ b/src/backends/plonky2/mock/mainpod.rs
@@ -177,7 +177,7 @@ impl MockMainPod {
         Ok(Self {
             params: params.clone(),
             id,
-            vds_root: inputs.vds_root,
+            vds_root: inputs.vds_set.root(),
             //  input_signed_pods,
             //  input_main_pods,
             //  input_statements,

--- a/src/backends/plonky2/mock/mainpod.rs
+++ b/src/backends/plonky2/mock/mainpod.rs
@@ -19,8 +19,7 @@ use crate::{
     },
     middleware::{
         self, hash_str, AnchoredKey, DynError, Hash, MainPodInputs, NativePredicate, Params, Pod,
-        PodId, PodProver, PodType, Predicate, RecursivePod, StatementArg, VDSet, VDTree, KEY_TYPE,
-        SELF,
+        PodId, PodProver, PodType, Predicate, RecursivePod, StatementArg, VDSet, KEY_TYPE, SELF,
     },
 };
 

--- a/src/backends/plonky2/mock/mainpod.rs
+++ b/src/backends/plonky2/mock/mainpod.rs
@@ -19,7 +19,8 @@ use crate::{
     },
     middleware::{
         self, hash_str, AnchoredKey, DynError, Hash, MainPodInputs, NativePredicate, Params, Pod,
-        PodId, PodProver, PodType, Predicate, RecursivePod, StatementArg, VDTree, KEY_TYPE, SELF,
+        PodId, PodProver, PodType, Predicate, RecursivePod, StatementArg, VDSet, VDTree, KEY_TYPE,
+        SELF,
     },
 };
 
@@ -29,7 +30,7 @@ impl PodProver for MockProver {
     fn prove(
         &self,
         params: &Params,
-        _vd_tree: &VDTree,
+        _vd_set: &VDSet,
         inputs: MainPodInputs,
     ) -> Result<Box<dyn RecursivePod>, Box<DynError>> {
         Ok(Box::new(MockMainPod::new(params, inputs)?))
@@ -357,13 +358,13 @@ pub mod tests {
             zu_kyc_sign_pod_builders,
         },
         frontend,
-        middleware::{self, DEFAULT_VD_TREE},
+        middleware::{self, DEFAULT_VD_SET},
     };
 
     #[test]
     fn test_mock_main_zu_kyc() -> frontend::Result<()> {
         let params = middleware::Params::default();
-        let vd_tree = &*DEFAULT_VD_TREE;
+        let vd_set = &*DEFAULT_VD_SET;
         let (gov_id_builder, pay_stub_builder, sanction_list_builder) =
             zu_kyc_sign_pod_builders(&params);
         let mut signer = MockSigner {
@@ -380,7 +381,7 @@ pub mod tests {
         let sanction_list_pod = sanction_list_builder.sign(&mut signer)?;
         let kyc_builder = zu_kyc_pod_builder(
             &params,
-            &vd_tree,
+            &vd_set,
             &gov_id_pod,
             &pay_stub_pod,
             &sanction_list_pod,

--- a/src/backends/plonky2/mock/signedpod.rs
+++ b/src/backends/plonky2/mock/signedpod.rs
@@ -27,13 +27,13 @@ impl MockSigner {
 }
 
 impl MockSigner {
-    fn _sign(&mut self, _params: &Params, kvs: &HashMap<Key, Value>) -> Result<MockSignedPod> {
+    fn _sign(&mut self, params: &Params, kvs: &HashMap<Key, Value>) -> Result<MockSignedPod> {
         let mut kvs = kvs.clone();
         let pubkey = self.public_key();
         kvs.insert(Key::from(KEY_SIGNER), Value::from(pubkey));
         kvs.insert(Key::from(KEY_TYPE), Value::from(PodType::MockSigned));
 
-        let dict = Dictionary::new(kvs.clone())?;
+        let dict = Dictionary::new(params.max_depth_mt_containers, kvs.clone())?;
         let id = PodId(dict.commitment());
         let signature = format!("{}_signed_by_{}", id, pubkey);
         Ok(MockSignedPod { id, signature, kvs })

--- a/src/backends/plonky2/signedpod.rs
+++ b/src/backends/plonky2/signedpod.rs
@@ -28,13 +28,13 @@ use crate::{
 pub struct Signer(pub SecretKey);
 
 impl Signer {
-    fn _sign(&mut self, _params: &Params, kvs: &HashMap<Key, Value>) -> Result<SignedPod> {
+    fn _sign(&mut self, params: &Params, kvs: &HashMap<Key, Value>) -> Result<SignedPod> {
         let mut kvs = kvs.clone();
         let pubkey = self.0.public_key();
         kvs.insert(Key::from(KEY_SIGNER), Value::from(pubkey));
         kvs.insert(Key::from(KEY_TYPE), Value::from(PodType::Signed));
 
-        let dict = Dictionary::new(kvs)?;
+        let dict = Dictionary::new(params.max_depth_mt_containers, kvs)?;
         let id = RawValue::from(dict.commitment()); // PodId as Value
 
         let nonce = OsRng.gen_biguint_below(&GROUP_ORDER);
@@ -232,7 +232,7 @@ pub mod tests {
             .into_iter()
             .chain(iter::once(bad_kv))
             .collect::<HashMap<Key, Value>>();
-        bad_pod.dict = Dictionary::new(bad_kvs).unwrap();
+        bad_pod.dict = Dictionary::new(params.max_depth_mt_containers, bad_kvs).unwrap();
         assert!(bad_pod.verify().is_err());
 
         let mut bad_pod = pod.clone();
@@ -244,7 +244,7 @@ pub mod tests {
             .into_iter()
             .chain(iter::once(bad_kv))
             .collect::<HashMap<Key, Value>>();
-        bad_pod.dict = Dictionary::new(bad_kvs).unwrap();
+        bad_pod.dict = Dictionary::new(params.max_depth_mt_containers, bad_kvs).unwrap();
         assert!(bad_pod.verify().is_err());
 
         Ok(())

--- a/src/examples/mod.rs
+++ b/src/examples/mod.rs
@@ -20,7 +20,8 @@ pub fn zu_kyc_sign_pod_builders(
     params: &Params,
 ) -> (SignedPodBuilder, SignedPodBuilder, SignedPodBuilder) {
     let sanctions_values: HashSet<Value> = ["A343434340"].iter().map(|s| Value::from(*s)).collect();
-    let sanction_set = Value::from(Set::new(sanctions_values).unwrap());
+    let sanction_set =
+        Value::from(Set::new(params.max_depth_mt_containers, sanctions_values).unwrap());
 
     let mut gov_id = SignedPodBuilder::new(params);
     gov_id.insert("idNumber", "4242424242");
@@ -352,6 +353,7 @@ pub fn great_boy_pod_full_flow() -> Result<(Params, MainPodBuilder)> {
     alice_friend_pods.push(friend.sign(&mut charlie_signer).unwrap());
 
     let good_boy_issuers = Value::from(Set::new(
+        params.max_depth_mt_containers,
         good_boy_issuers.into_iter().map(Value::from).collect(),
     )?);
 
@@ -420,6 +422,6 @@ pub fn tickets_pod_full_flow() -> Result<MainPodBuilder> {
         &signed_pod,
         123,
         true,
-        &Set::new(HashSet::new())?,
+        &Set::new(params.max_depth_mt_containers, HashSet::new())?,
     )
 }

--- a/src/examples/mod.rs
+++ b/src/examples/mod.rs
@@ -8,8 +8,8 @@ use crate::{
     backends::plonky2::mock::signedpod::MockSigner,
     frontend::{MainPodBuilder, Result, SignedPod, SignedPodBuilder},
     middleware::{
-        containers::Set, CustomPredicateRef, Params, PodType, Statement, TypedValue, Value,
-        KEY_SIGNER, KEY_TYPE,
+        containers::Set, CustomPredicateRef, Params, PodType, Statement, TypedValue, VDTree, Value,
+        DEFAULT_VD_TREE, KEY_SIGNER, KEY_TYPE,
     },
     op,
 };
@@ -40,6 +40,7 @@ pub fn zu_kyc_sign_pod_builders(
 
 pub fn zu_kyc_pod_builder(
     params: &Params,
+    vd_tree: &VDTree,
     gov_id: &SignedPod,
     pay_stub: &SignedPod,
     sanction_list: &SignedPod,
@@ -47,7 +48,7 @@ pub fn zu_kyc_pod_builder(
     let now_minus_18y: i64 = 1169909388;
     let now_minus_1y: i64 = 1706367566;
 
-    let mut kyc = MainPodBuilder::new(params);
+    let mut kyc = MainPodBuilder::new(params, vd_tree);
     kyc.add_signed_pod(gov_id);
     kyc.add_signed_pod(pay_stub);
     kyc.add_signed_pod(sanction_list);
@@ -78,6 +79,7 @@ pub fn eth_friend_signed_pod_builder(params: &Params, friend_pubkey: Value) -> S
 
 pub fn eth_dos_pod_builder(
     params: &Params,
+    vd_tree: &VDTree,
     mock: bool,
     alice_attestation: &SignedPod,
     charlie_attestation: &SignedPod,
@@ -91,7 +93,7 @@ pub fn eth_dos_pod_builder(
     let eth_dos = CustomPredicateRef::new(eth_dos_batch.clone(), 2);
 
     // ETHDoS POD builder
-    let mut alice_bob_ethdos = MainPodBuilder::new(params);
+    let mut alice_bob_ethdos = MainPodBuilder::new(params, vd_tree);
     alice_bob_ethdos.add_signed_pod(alice_attestation);
     alice_bob_ethdos.add_signed_pod(charlie_attestation);
 
@@ -229,6 +231,7 @@ pub fn friend_sign_pod_builder(params: &Params, friend: &str) -> SignedPodBuilde
 
 pub fn great_boy_pod_builder(
     params: &Params,
+    vd_tree: &VDTree,
     good_boy_pods: [&SignedPod; 4],
     friend_pods: [&SignedPod; 2],
     good_boy_issuers: &Value,
@@ -242,7 +245,7 @@ pub fn great_boy_pod_builder(
     // good boy 0 -> friend_pods[0] => receiver
     // good boy 1 -> friend_pods[1] => receiver
 
-    let mut great_boy = MainPodBuilder::new(params);
+    let mut great_boy = MainPodBuilder::new(params, vd_tree);
     for i in 0..4 {
         great_boy.add_signed_pod(good_boy_pods[i]);
     }
@@ -305,6 +308,7 @@ pub fn great_boy_pod_full_flow() -> Result<(Params, MainPodBuilder)> {
         num_public_statements_id: 50,
         ..Default::default()
     };
+    let vd_tree = &*DEFAULT_VD_TREE;
 
     let good_boy_issuers = ["Giggles", "Macrosoft", "FaeBook"];
     let mut giggles_signer = MockSigner {
@@ -353,6 +357,7 @@ pub fn great_boy_pod_full_flow() -> Result<(Params, MainPodBuilder)> {
 
     let builder = great_boy_pod_builder(
         &params,
+        &vd_tree,
         [
             &bob_good_boys[0],
             &bob_good_boys[1],
@@ -383,6 +388,7 @@ pub fn tickets_sign_pod_builder(params: &Params) -> SignedPodBuilder {
 
 pub fn tickets_pod_builder(
     params: &Params,
+    vd_tree: &VDTree,
     signed_pod: &SignedPod,
     expected_event_id: i64,
     expect_consumed: bool,
@@ -390,7 +396,7 @@ pub fn tickets_pod_builder(
 ) -> Result<MainPodBuilder> {
     let blacklisted_email_set_value = Value::from(TypedValue::Set(blacklisted_emails.clone()));
     // Create a main pod referencing this signed pod with some statements
-    let mut builder = MainPodBuilder::new(params);
+    let mut builder = MainPodBuilder::new(params, vd_tree);
     builder.add_signed_pod(signed_pod);
     builder.pub_op(op!(eq, (signed_pod, "eventId"), expected_event_id))?;
     builder.pub_op(op!(eq, (signed_pod, "isConsumed"), expect_consumed))?;
@@ -405,7 +411,15 @@ pub fn tickets_pod_builder(
 
 pub fn tickets_pod_full_flow() -> Result<MainPodBuilder> {
     let params = Params::default();
+    let vd_tree = &*DEFAULT_VD_TREE;
     let builder = tickets_sign_pod_builder(&params);
     let signed_pod = builder.sign(&mut MockSigner { pk: "test".into() }).unwrap();
-    tickets_pod_builder(&params, &signed_pod, 123, true, &Set::new(HashSet::new())?)
+    tickets_pod_builder(
+        &params,
+        vd_tree,
+        &signed_pod,
+        123,
+        true,
+        &Set::new(HashSet::new())?,
+    )
 }

--- a/src/examples/mod.rs
+++ b/src/examples/mod.rs
@@ -8,8 +8,8 @@ use crate::{
     backends::plonky2::mock::signedpod::MockSigner,
     frontend::{MainPodBuilder, Result, SignedPod, SignedPodBuilder},
     middleware::{
-        containers::Set, CustomPredicateRef, Params, PodType, Statement, TypedValue, VDTree, Value,
-        DEFAULT_VD_TREE, KEY_SIGNER, KEY_TYPE,
+        containers::Set, CustomPredicateRef, Params, PodType, Statement, TypedValue, VDSet, Value,
+        DEFAULT_VD_SET, KEY_SIGNER, KEY_TYPE,
     },
     op,
 };
@@ -40,7 +40,7 @@ pub fn zu_kyc_sign_pod_builders(
 
 pub fn zu_kyc_pod_builder(
     params: &Params,
-    vd_tree: &VDTree,
+    vd_set: &VDSet,
     gov_id: &SignedPod,
     pay_stub: &SignedPod,
     sanction_list: &SignedPod,
@@ -48,7 +48,7 @@ pub fn zu_kyc_pod_builder(
     let now_minus_18y: i64 = 1169909388;
     let now_minus_1y: i64 = 1706367566;
 
-    let mut kyc = MainPodBuilder::new(params, vd_tree);
+    let mut kyc = MainPodBuilder::new(params, vd_set);
     kyc.add_signed_pod(gov_id);
     kyc.add_signed_pod(pay_stub);
     kyc.add_signed_pod(sanction_list);
@@ -79,7 +79,7 @@ pub fn eth_friend_signed_pod_builder(params: &Params, friend_pubkey: Value) -> S
 
 pub fn eth_dos_pod_builder(
     params: &Params,
-    vd_tree: &VDTree,
+    vd_set: &VDSet,
     mock: bool,
     alice_attestation: &SignedPod,
     charlie_attestation: &SignedPod,
@@ -93,7 +93,7 @@ pub fn eth_dos_pod_builder(
     let eth_dos = CustomPredicateRef::new(eth_dos_batch.clone(), 2);
 
     // ETHDoS POD builder
-    let mut alice_bob_ethdos = MainPodBuilder::new(params, vd_tree);
+    let mut alice_bob_ethdos = MainPodBuilder::new(params, vd_set);
     alice_bob_ethdos.add_signed_pod(alice_attestation);
     alice_bob_ethdos.add_signed_pod(charlie_attestation);
 
@@ -231,7 +231,7 @@ pub fn friend_sign_pod_builder(params: &Params, friend: &str) -> SignedPodBuilde
 
 pub fn great_boy_pod_builder(
     params: &Params,
-    vd_tree: &VDTree,
+    vd_set: &VDSet,
     good_boy_pods: [&SignedPod; 4],
     friend_pods: [&SignedPod; 2],
     good_boy_issuers: &Value,
@@ -245,7 +245,7 @@ pub fn great_boy_pod_builder(
     // good boy 0 -> friend_pods[0] => receiver
     // good boy 1 -> friend_pods[1] => receiver
 
-    let mut great_boy = MainPodBuilder::new(params, vd_tree);
+    let mut great_boy = MainPodBuilder::new(params, vd_set);
     for i in 0..4 {
         great_boy.add_signed_pod(good_boy_pods[i]);
     }
@@ -308,7 +308,7 @@ pub fn great_boy_pod_full_flow() -> Result<(Params, MainPodBuilder)> {
         num_public_statements_id: 50,
         ..Default::default()
     };
-    let vd_tree = &*DEFAULT_VD_TREE;
+    let vd_set = &*DEFAULT_VD_SET;
 
     let good_boy_issuers = ["Giggles", "Macrosoft", "FaeBook"];
     let mut giggles_signer = MockSigner {
@@ -357,7 +357,7 @@ pub fn great_boy_pod_full_flow() -> Result<(Params, MainPodBuilder)> {
 
     let builder = great_boy_pod_builder(
         &params,
-        &vd_tree,
+        &vd_set,
         [
             &bob_good_boys[0],
             &bob_good_boys[1],
@@ -388,7 +388,7 @@ pub fn tickets_sign_pod_builder(params: &Params) -> SignedPodBuilder {
 
 pub fn tickets_pod_builder(
     params: &Params,
-    vd_tree: &VDTree,
+    vd_set: &VDSet,
     signed_pod: &SignedPod,
     expected_event_id: i64,
     expect_consumed: bool,
@@ -396,7 +396,7 @@ pub fn tickets_pod_builder(
 ) -> Result<MainPodBuilder> {
     let blacklisted_email_set_value = Value::from(TypedValue::Set(blacklisted_emails.clone()));
     // Create a main pod referencing this signed pod with some statements
-    let mut builder = MainPodBuilder::new(params, vd_tree);
+    let mut builder = MainPodBuilder::new(params, vd_set);
     builder.add_signed_pod(signed_pod);
     builder.pub_op(op!(eq, (signed_pod, "eventId"), expected_event_id))?;
     builder.pub_op(op!(eq, (signed_pod, "isConsumed"), expect_consumed))?;
@@ -411,12 +411,12 @@ pub fn tickets_pod_builder(
 
 pub fn tickets_pod_full_flow() -> Result<MainPodBuilder> {
     let params = Params::default();
-    let vd_tree = &*DEFAULT_VD_TREE;
+    let vd_set = &*DEFAULT_VD_SET;
     let builder = tickets_sign_pod_builder(&params);
     let signed_pod = builder.sign(&mut MockSigner { pk: "test".into() }).unwrap();
     tickets_pod_builder(
         &params,
-        vd_tree,
+        vd_set,
         &signed_pod,
         123,
         true,

--- a/src/frontend/custom.rs
+++ b/src/frontend/custom.rs
@@ -290,7 +290,7 @@ mod tests {
         backends::plonky2::mock::mainpod::MockProver,
         examples::custom::{eth_dos_batch, eth_friend_batch},
         frontend::MainPodBuilder,
-        middleware::{self, containers::Set, CustomPredicateRef, Params, PodType, DEFAULT_VD_TREE},
+        middleware::{self, containers::Set, CustomPredicateRef, Params, PodType, DEFAULT_VD_SET},
         op,
     };
 
@@ -324,7 +324,7 @@ mod tests {
     #[test]
     fn test_desugared_gt_custom_pred() -> Result<()> {
         let params = Params::default();
-        let vd_tree = &*DEFAULT_VD_TREE;
+        let vd_set = &*DEFAULT_VD_SET;
         let mut builder = CustomPredicateBatchBuilder::new(params.clone(), "gt_custom_pred".into());
 
         let gt_stb = StatementTmplBuilder::new(NativePredicate::Gt)
@@ -341,7 +341,7 @@ mod tests {
         let batch_clone = batch.clone();
         let gt_custom_pred = CustomPredicateRef::new(batch, 0);
 
-        let mut mp_builder = MainPodBuilder::new(&params, &vd_tree);
+        let mut mp_builder = MainPodBuilder::new(&params, &vd_set);
 
         // 2 > 1
         let s1 = mp_builder.literal(true, Value::from(2))?;
@@ -373,7 +373,7 @@ mod tests {
     #[test]
     fn test_desugared_set_contains_custom_pred() -> Result<()> {
         let params = Params::default();
-        let vd_tree = &*DEFAULT_VD_TREE;
+        let vd_set = &*DEFAULT_VD_SET;
         let mut builder =
             CustomPredicateBatchBuilder::new(params.clone(), "set_contains_custom_pred".into());
 
@@ -390,7 +390,7 @@ mod tests {
         let batch = builder.finish();
         let batch_clone = batch.clone();
 
-        let mut mp_builder = MainPodBuilder::new(&params, &vd_tree);
+        let mut mp_builder = MainPodBuilder::new(&params, &vd_set);
 
         let set_values: HashSet<Value> = [1, 2, 3].iter().map(|i| Value::from(*i)).collect();
         let s1 = mp_builder.literal(true, Value::from(Set::new(set_values)?))?;

--- a/src/frontend/custom.rs
+++ b/src/frontend/custom.rs
@@ -290,7 +290,7 @@ mod tests {
         backends::plonky2::mock::mainpod::MockProver,
         examples::custom::{eth_dos_batch, eth_friend_batch},
         frontend::MainPodBuilder,
-        middleware::{self, containers::Set, CustomPredicateRef, Params, PodType},
+        middleware::{self, containers::Set, CustomPredicateRef, Params, PodType, DEFAULT_VD_TREE},
         op,
     };
 
@@ -324,6 +324,7 @@ mod tests {
     #[test]
     fn test_desugared_gt_custom_pred() -> Result<()> {
         let params = Params::default();
+        let vd_tree = &*DEFAULT_VD_TREE;
         let mut builder = CustomPredicateBatchBuilder::new(params.clone(), "gt_custom_pred".into());
 
         let gt_stb = StatementTmplBuilder::new(NativePredicate::Gt)
@@ -340,7 +341,7 @@ mod tests {
         let batch_clone = batch.clone();
         let gt_custom_pred = CustomPredicateRef::new(batch, 0);
 
-        let mut mp_builder = MainPodBuilder::new(&params);
+        let mut mp_builder = MainPodBuilder::new(&params, &vd_tree);
 
         // 2 > 1
         let s1 = mp_builder.literal(true, Value::from(2))?;
@@ -372,6 +373,7 @@ mod tests {
     #[test]
     fn test_desugared_set_contains_custom_pred() -> Result<()> {
         let params = Params::default();
+        let vd_tree = &*DEFAULT_VD_TREE;
         let mut builder =
             CustomPredicateBatchBuilder::new(params.clone(), "set_contains_custom_pred".into());
 
@@ -388,7 +390,7 @@ mod tests {
         let batch = builder.finish();
         let batch_clone = batch.clone();
 
-        let mut mp_builder = MainPodBuilder::new(&params);
+        let mut mp_builder = MainPodBuilder::new(&params, &vd_tree);
 
         let set_values: HashSet<Value> = [1, 2, 3].iter().map(|i| Value::from(*i)).collect();
         let s1 = mp_builder.literal(true, Value::from(Set::new(set_values)?))?;

--- a/src/frontend/custom.rs
+++ b/src/frontend/custom.rs
@@ -393,7 +393,10 @@ mod tests {
         let mut mp_builder = MainPodBuilder::new(&params, &vd_set);
 
         let set_values: HashSet<Value> = [1, 2, 3].iter().map(|i| Value::from(*i)).collect();
-        let s1 = mp_builder.literal(true, Value::from(Set::new(set_values)?))?;
+        let s1 = mp_builder.literal(
+            true,
+            Value::from(Set::new(params.max_depth_mt_containers, set_values)?),
+        )?;
         let s2 = mp_builder.literal(true, Value::from(1))?;
 
         let set_contains = mp_builder.pub_op(op!(set_contains, s1, s2))?;

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -564,7 +564,7 @@ impl MainPodBuilder {
             statements: &statements,
             operations: &operations,
             public_statements: &public_statements,
-            vds_root: self.vd_set.root(),
+            vds_set: self.vd_set.clone(),
         };
         let pod = prover.prove(&self.params, &self.vd_set, inputs)?;
 

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -1071,7 +1071,7 @@ pub mod tests {
         my_dict_kvs.insert(Key::from("c"), Value::from(3));
         //        let my_dict_as_mt = MerkleTree::new(5, &my_dict_kvs).unwrap();
         //        let dict = Dictionary { mt: my_dict_as_mt };
-        let dict = Dictionary::new(my_dict_kvs)?;
+        let dict = Dictionary::new(params.max_depth_mt_containers, my_dict_kvs)?;
         let dict_root = Value::from(dict.clone());
         builder.insert("dict", dict_root);
 

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -10,8 +10,7 @@ use serialization::{SerializedMainPod, SerializedSignedPod};
 use crate::middleware::{
     self, check_st_tmpl, hash_str, hash_values, AnchoredKey, Hash, Key, MainPodInputs,
     NativeOperation, NativePredicate, OperationAux, OperationType, Params, PodId, PodProver,
-    PodSigner, Predicate, Statement, StatementArg, VDSet, Value, WildcardValue, DEFAULT_VD_SET,
-    KEY_TYPE, SELF,
+    PodSigner, Predicate, Statement, StatementArg, VDSet, Value, WildcardValue, KEY_TYPE, SELF,
 };
 
 mod custom;
@@ -565,7 +564,7 @@ impl MainPodBuilder {
             statements: &statements,
             operations: &operations,
             public_statements: &public_statements,
-            vds_root: DEFAULT_VD_SET.root(),
+            vds_root: self.vd_set.root(),
         };
         let pod = prover.prove(&self.params, &self.vd_set, inputs)?;
 
@@ -841,7 +840,7 @@ pub mod tests {
             eth_dos_pod_builder, eth_friend_signed_pod_builder, great_boy_pod_full_flow,
             tickets_pod_full_flow, zu_kyc_pod_builder, zu_kyc_sign_pod_builders,
         },
-        middleware::{containers::Dictionary, Value},
+        middleware::{containers::Dictionary, Value, DEFAULT_VD_SET},
     };
 
     // Check that frontend public statements agree with those

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -10,7 +10,7 @@ use serialization::{SerializedMainPod, SerializedSignedPod};
 use crate::middleware::{
     self, check_st_tmpl, hash_str, hash_values, AnchoredKey, Hash, Key, MainPodInputs,
     NativeOperation, NativePredicate, OperationAux, OperationType, Params, PodId, PodProver,
-    PodSigner, Predicate, Statement, StatementArg, Value, WildcardValue, EMPTY_HASH, KEY_TYPE,
+    PodSigner, Predicate, Statement, StatementArg, Value, WildcardValue, DEFAULT_VD_TREE, KEY_TYPE,
     SELF,
 };
 
@@ -548,6 +548,7 @@ impl MainPodBuilder {
         };
 
         let (statements, operations, public_statements) = compiler.compile(inputs, params)?;
+
         let inputs = MainPodInputs {
             signed_pods: &self
                 .input_signed_pods
@@ -562,7 +563,7 @@ impl MainPodBuilder {
             statements: &statements,
             operations: &operations,
             public_statements: &public_statements,
-            vds_root: EMPTY_HASH, // TODO https://github.com/0xPARC/pod2/issues/249
+            vds_root: DEFAULT_VD_TREE.root(),
         };
         let pod = prover.prove(&self.params, inputs)?;
 

--- a/src/frontend/serialization.rs
+++ b/src/frontend/serialization.rs
@@ -118,18 +118,19 @@ mod tests {
 
     #[test]
     fn test_value_serialization() {
+        let params = &Params::default();
         // Pairs of values and their expected serialized representations
         let values = vec![
             (TypedValue::String("hello".to_string()), "\"hello\""),
             (TypedValue::Int(42), "{\"Int\":\"42\"}"),
             (TypedValue::Bool(true), "true"),
             (
-                TypedValue::Array(Array::new(vec!["foo".into(), false.into()]).unwrap()),
+                TypedValue::Array(Array::new(params.max_depth_mt_containers, vec!["foo".into(), false.into()]).unwrap()),
                 "{\"max_depth\":32,\"array\":[\"foo\",false]}",
             ),
             (
                 TypedValue::Dictionary(
-                    Dictionary::new(HashMap::from([
+                    Dictionary::new(params.max_depth_mt_containers, HashMap::from([
                         // The set of valid keys is equal to the set of valid JSON keys
                         ("foo".into(), 123.into()),
                         // Empty strings are valid JSON keys
@@ -148,7 +149,7 @@ mod tests {
                 "{\"Dictionary\":{\"max_depth\":32,\"kvs\":{\"\":\"baz\",\"\\u0000\":\"\",\"    hi\":false,\"!@£$%^&&*()\":\"\",\"foo\":{\"Int\":\"123\"},\"🥳\":\"party time!\"}}}",
             ),
             (
-                TypedValue::Set(Set::new(HashSet::from(["foo".into(), "bar".into()])).unwrap()),
+                TypedValue::Set(Set::new(params.max_depth_mt_containers, HashSet::from(["foo".into(), "bar".into()])).unwrap()),
                 "{\"Set\":{\"max_depth\":32,\"set\":[\"bar\",\"foo\"]}}",
             ),
         ];
@@ -168,30 +169,45 @@ mod tests {
     }
 
     fn signed_pod_builder() -> SignedPodBuilder {
-        let mut builder = SignedPodBuilder::new(&Params::default());
+        let params = &Params::default();
+        let mut builder = SignedPodBuilder::new(params);
         builder.insert("name", "test");
         builder.insert("age", 30);
         builder.insert("very_large_int", 1152921504606846976);
         builder.insert(
             "a_dict_containing_one_key",
-            Dictionary::new(HashMap::from([
-                ("foo".into(), 123.into()),
-                (
-                    "an_array_containing_three_ints".into(),
-                    Array::new(vec![1.into(), 2.into(), 3.into()])
+            Dictionary::new(
+                params.max_depth_mt_containers,
+                HashMap::from([
+                    ("foo".into(), 123.into()),
+                    (
+                        "an_array_containing_three_ints".into(),
+                        Array::new(
+                            params.max_depth_mt_containers,
+                            vec![1.into(), 2.into(), 3.into()],
+                        )
                         .unwrap()
                         .into(),
-                ),
-                (
-                    "a_set_containing_two_strings".into(),
-                    Set::new(HashSet::from([
-                        Array::new(vec!["foo".into(), "bar".into()]).unwrap().into(),
-                        "baz".into(),
-                    ]))
-                    .unwrap()
-                    .into(),
-                ),
-            ]))
+                    ),
+                    (
+                        "a_set_containing_two_strings".into(),
+                        Set::new(
+                            params.max_depth_mt_containers,
+                            HashSet::from([
+                                Array::new(
+                                    params.max_depth_mt_containers,
+                                    vec!["foo".into(), "bar".into()],
+                                )
+                                .unwrap()
+                                .into(),
+                                "baz".into(),
+                            ]),
+                        )
+                        .unwrap()
+                        .into(),
+                    ),
+                ]),
+            )
             .unwrap(),
         );
         builder

--- a/src/frontend/serialization.rs
+++ b/src/frontend/serialization.rs
@@ -125,7 +125,7 @@ mod tests {
             (TypedValue::Bool(true), "true"),
             (
                 TypedValue::Array(Array::new(vec!["foo".into(), false.into()]).unwrap()),
-                "[\"foo\",false]",
+                "{\"max_depth\":32,\"array\":[\"foo\",false]}",
             ),
             (
                 TypedValue::Dictionary(
@@ -145,11 +145,11 @@ mod tests {
                     ]))
                     .unwrap(),
                 ),
-                "{\"Dictionary\":{\"\":\"baz\",\"\\u0000\":\"\",\"    hi\":false,\"!@£$%^&&*()\":\"\",\"foo\":{\"Int\":\"123\"},\"🥳\":\"party time!\"}}",
+                "{\"Dictionary\":{\"max_depth\":32,\"kvs\":{\"\":\"baz\",\"\\u0000\":\"\",\"    hi\":false,\"!@£$%^&&*()\":\"\",\"foo\":{\"Int\":\"123\"},\"🥳\":\"party time!\"}}}",
             ),
             (
                 TypedValue::Set(Set::new(HashSet::from(["foo".into(), "bar".into()])).unwrap()),
-                "{\"Set\":[\"bar\",\"foo\"]}",
+                "{\"Set\":{\"max_depth\":32,\"set\":[\"bar\",\"foo\"]}}",
             ),
         ];
 

--- a/src/frontend/serialization.rs
+++ b/src/frontend/serialization.rs
@@ -112,7 +112,7 @@ mod tests {
         middleware::{
             self,
             containers::{Array, Dictionary, Set},
-            Params, TypedValue,
+            Params, TypedValue, DEFAULT_VD_TREE,
         },
     };
 
@@ -235,6 +235,7 @@ mod tests {
 
     fn build_mock_zukyc_pod() -> Result<MainPod> {
         let params = middleware::Params::default();
+        let vd_tree = &*DEFAULT_VD_TREE;
 
         let (gov_id_builder, pay_stub_builder, sanction_list_builder) =
             zu_kyc_sign_pod_builders(&params);
@@ -250,8 +251,14 @@ mod tests {
             pk: "ZooOFAC".into(),
         };
         let sanction_list_pod = sanction_list_builder.sign(&mut signer).unwrap();
-        let kyc_builder =
-            zu_kyc_pod_builder(&params, &gov_id_pod, &pay_stub_pod, &sanction_list_pod).unwrap();
+        let kyc_builder = zu_kyc_pod_builder(
+            &params,
+            &vd_tree,
+            &gov_id_pod,
+            &pay_stub_pod,
+            &sanction_list_pod,
+        )
+        .unwrap();
 
         let mut prover = MockProver {};
         let kyc_pod = kyc_builder.prove(&mut prover, &params).unwrap();
@@ -265,6 +272,7 @@ mod tests {
             max_input_recursive_pods: 1,
             ..Default::default()
         };
+        let vd_tree = &*DEFAULT_VD_TREE;
 
         let (gov_id_builder, pay_stub_builder, sanction_list_builder) =
             zu_kyc_sign_pod_builders(&params);
@@ -274,8 +282,13 @@ mod tests {
         let pay_stub_pod = pay_stub_builder.sign(&mut signer)?;
         let mut signer = Signer(SecretKey(3u32.into()));
         let sanction_list_pod = sanction_list_builder.sign(&mut signer)?;
-        let kyc_builder =
-            zu_kyc_pod_builder(&params, &gov_id_pod, &pay_stub_pod, &sanction_list_pod)?;
+        let kyc_builder = zu_kyc_pod_builder(
+            &params,
+            &vd_tree,
+            &gov_id_pod,
+            &pay_stub_pod,
+            &sanction_list_pod,
+        )?;
 
         let mut prover = Prover {};
         let kyc_pod = kyc_builder.prove(&mut prover, &params)?;
@@ -324,6 +337,7 @@ mod tests {
             max_custom_predicate_wildcards: 12,
             ..Default::default()
         };
+        let vd_tree = &*DEFAULT_VD_TREE;
 
         let mut alice = MockSigner { pk: "Alice".into() };
         let bob = MockSigner { pk: "Bob".into() };
@@ -341,6 +355,7 @@ mod tests {
         let mut prover = MockProver {};
         let alice_bob_ethdos = eth_dos_pod_builder(
             &params,
+            &vd_tree,
             true,
             &alice_attestation,
             &charlie_attestation,

--- a/src/frontend/serialization.rs
+++ b/src/frontend/serialization.rs
@@ -112,7 +112,7 @@ mod tests {
         middleware::{
             self,
             containers::{Array, Dictionary, Set},
-            Params, RawValue, TypedValue, DEFAULT_VD_SET,
+            Params, TypedValue, DEFAULT_VD_SET,
         },
     };
 

--- a/src/frontend/serialization.rs
+++ b/src/frontend/serialization.rs
@@ -112,7 +112,7 @@ mod tests {
         middleware::{
             self,
             containers::{Array, Dictionary, Set},
-            Params, RawValue, TypedValue, DEFAULT_VD_SET, DEFAULT_VD_TREE,
+            Params, RawValue, TypedValue, DEFAULT_VD_SET,
         },
     };
 

--- a/src/frontend/serialization.rs
+++ b/src/frontend/serialization.rs
@@ -112,7 +112,7 @@ mod tests {
         middleware::{
             self,
             containers::{Array, Dictionary, Set},
-            Params, TypedValue, DEFAULT_VD_TREE,
+            Params, RawValue, TypedValue, DEFAULT_VD_SET, DEFAULT_VD_TREE,
         },
     };
 
@@ -235,7 +235,7 @@ mod tests {
 
     fn build_mock_zukyc_pod() -> Result<MainPod> {
         let params = middleware::Params::default();
-        let vd_tree = &*DEFAULT_VD_TREE;
+        let vd_set = &*DEFAULT_VD_SET;
 
         let (gov_id_builder, pay_stub_builder, sanction_list_builder) =
             zu_kyc_sign_pod_builders(&params);
@@ -253,7 +253,7 @@ mod tests {
         let sanction_list_pod = sanction_list_builder.sign(&mut signer).unwrap();
         let kyc_builder = zu_kyc_pod_builder(
             &params,
-            &vd_tree,
+            &vd_set,
             &gov_id_pod,
             &pay_stub_pod,
             &sanction_list_pod,
@@ -272,7 +272,7 @@ mod tests {
             max_input_recursive_pods: 1,
             ..Default::default()
         };
-        let vd_tree = &*DEFAULT_VD_TREE;
+        let vd_set = &*DEFAULT_VD_SET;
 
         let (gov_id_builder, pay_stub_builder, sanction_list_builder) =
             zu_kyc_sign_pod_builders(&params);
@@ -284,7 +284,7 @@ mod tests {
         let sanction_list_pod = sanction_list_builder.sign(&mut signer)?;
         let kyc_builder = zu_kyc_pod_builder(
             &params,
-            &vd_tree,
+            &vd_set,
             &gov_id_pod,
             &pay_stub_pod,
             &sanction_list_pod,
@@ -337,7 +337,7 @@ mod tests {
             max_custom_predicate_wildcards: 12,
             ..Default::default()
         };
-        let vd_tree = &*DEFAULT_VD_TREE;
+        let vd_set = &*DEFAULT_VD_SET;
 
         let mut alice = MockSigner { pk: "Alice".into() };
         let bob = MockSigner { pk: "Bob".into() };
@@ -355,7 +355,7 @@ mod tests {
         let mut prover = MockProver {};
         let alice_bob_ethdos = eth_dos_pod_builder(
             &params,
-            &vd_tree,
+            &vd_set,
             true,
             &alice_attestation,
             &charlie_attestation,

--- a/src/lang/processor.rs
+++ b/src/lang/processor.rs
@@ -659,8 +659,11 @@ fn process_literal_value(lit_val_pair: &Pair<Rule>) -> Result<Value, ProcessorEr
                 .into_inner()
                 .map(|elem_pair| process_literal_value(&elem_pair))
                 .collect();
-            let middleware_array = middleware::containers::Array::new(elements?)
-                .map_err(|e| ProcessorError::Internal(format!("Failed to create Array: {}", e)))?;
+            let middleware_array =
+                middleware::containers::Array::new(crate::constants::MAX_DEPTH, elements?)
+                    .map_err(|e| {
+                        ProcessorError::Internal(format!("Failed to create Array: {}", e))
+                    })?;
             Ok(Value::from(middleware_array))
         }
         Rule::literal_set => {
@@ -668,8 +671,10 @@ fn process_literal_value(lit_val_pair: &Pair<Rule>) -> Result<Value, ProcessorEr
                 .into_inner()
                 .map(|elem_pair| process_literal_value(&elem_pair))
                 .collect();
-            let middleware_set = middleware::containers::Set::new(elements?)
-                .map_err(|e| ProcessorError::Internal(format!("Failed to create Set: {}", e)))?;
+            let middleware_set =
+                middleware::containers::Set::new(crate::constants::MAX_DEPTH, elements?).map_err(
+                    |e| ProcessorError::Internal(format!("Failed to create Set: {}", e)),
+                )?;
             Ok(Value::from(middleware_set))
         }
         Rule::literal_dict => {
@@ -684,9 +689,11 @@ fn process_literal_value(lit_val_pair: &Pair<Rule>) -> Result<Value, ProcessorEr
                     Ok((Key::new(key_str), val))
                 })
                 .collect();
-            let middleware_dict = middleware::containers::Dictionary::new(pairs?).map_err(|e| {
-                ProcessorError::Internal(format!("Failed to create Dictionary: {}", e))
-            })?;
+            let middleware_dict =
+                middleware::containers::Dictionary::new(crate::constants::MAX_DEPTH, pairs?)
+                    .map_err(|e| {
+                        ProcessorError::Internal(format!("Failed to create Dictionary: {}", e))
+                    })?;
             Ok(Value::from(middleware_dict))
         }
         _ => unreachable!("Unexpected rule: {:?}", inner_lit.as_rule()),

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -609,10 +609,14 @@ pub struct Params {
     // max number of operations using custom predicates that can be verified in the MainPod
     pub max_custom_predicate_verifications: usize,
     pub max_custom_predicate_wildcards: usize,
-    // maximum number of merkle proofs
-    pub max_merkle_proofs: usize,
-    // maximum depth for merkle tree gadget
-    pub max_depth_mt_gadget: usize,
+    // maximum number of merkle proofs used for container operations
+    pub max_merkle_proofs_containers: usize,
+    // maximum depth for merkle tree gadget used for container operations
+    pub max_depth_mt_containers: usize,
+    // maximum depth of the merkle tree gadget used for verifier_data membership
+    // check.  This allows creating verifying sets of pod circuits of size
+    // 2^max_depth_mt_vds.
+    pub max_depth_mt_vds: usize,
     //
     // The following parameters define how a pod id is calculated.  They need to be the same among
     // different circuits to be compatible in their verification.
@@ -648,8 +652,9 @@ impl Default for Params {
             max_custom_predicate_arity: 5,
             max_custom_predicate_wildcards: 10,
             max_custom_batch_size: 5,
-            max_merkle_proofs: 5,
-            max_depth_mt_gadget: 32,
+            max_merkle_proofs_containers: 5,
+            max_depth_mt_containers: 32,
+            max_depth_mt_vds: 6, // up to 64 (2^6) different pod circuits
         }
     }
 }

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -846,7 +846,7 @@ pub struct MainPodInputs<'a> {
     /// Statements that need to be made public (they can come from input pods or input
     /// statements)
     pub public_statements: &'a [Statement],
-    pub vds_root: Hash, // TODO: Figure out if we use Hash or a Map here https://github.com/0xPARC/pod2/issues/249
+    pub vds_set: VDSet,
 }
 
 pub trait PodProver {

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -853,7 +853,7 @@ pub trait PodProver {
     fn prove(
         &self,
         params: &Params,
-        vd_tree: &VDTree,
+        vd_set: &VDSet,
         inputs: MainPodInputs,
     ) -> Result<Box<dyn RecursivePod>, Box<DynError>>;
 }

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -594,6 +594,7 @@ impl fmt::Display for PodType {
     }
 }
 
+/// Params: non dynamic parameters that define the circuit.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct Params {
@@ -852,6 +853,7 @@ pub trait PodProver {
     fn prove(
         &self,
         params: &Params,
+        vd_tree: &VDTree,
         inputs: MainPodInputs,
     ) -> Result<Box<dyn RecursivePod>, Box<DynError>>;
 }


### PR DESCRIPTION
When generating a MainPod, the circuit checks that the used verifier_datas for the verification of the recursive proofs, appear in the set of allowed verifier_datas (which is a `containers::Set`, a merkletree).

- Add `VDSet` construction
- Add `VDSet` proofs verification in the MainPod's circuit
- update containers (`Dictionary`, `Set`, `Array`)
- get rid of usage of the global constant `MAX_DEPTH` in most of places except for 3 locations, opened the issue #273 describing it.

This PR should resolve #249 , resolve #250.