### PR TITLE
Display point in base58

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ plonky2 = { git = "https://github.com/0xPolygonZero/plonky2", optional = true }
 serde = "1.0.219"
 serde_json = "1.0.140"
 base64 = "0.22.1"
+bs58 = "0.5.1"
 schemars = "0.8.22"
 num = { version = "0.4.3", features = ["num-bigint"] }
 num-bigint = { version = "0.4.6", features = ["rand"] }

--- a/examples/signed_pod.rs
+++ b/examples/signed_pod.rs
@@ -15,7 +15,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a schnorr key pair to sign the pod
     let sk = SecretKey::new_rand();
     let pk = sk.public_key();
-    println!("Public key: {:?}\n", pk);
+    println!("Public key: {}\n", pk);
 
     let mut signer = Signer(sk);
 

--- a/src/backends/plonky2/primitives/ec/curve.rs
+++ b/src/backends/plonky2/primitives/ec/curve.rs
@@ -164,8 +164,8 @@ impl Point {
         match self.is_in_subgroup() {
             true => Ok(self.u),
             false => Err(Error::custom(format!(
-                "Point must lie in EC subgroup: ({}, {})",
-                self.x, self.u
+                "Point must lie in EC subgroup: {}",
+                self
             ))),
         }
     }
@@ -863,7 +863,7 @@ mod test {
             match p == q {
                 true => Ok(()),
                 false => Err(Error::custom(format!(
-                    "Roundtrip compression failed: {:?} ≠ {:?}",
+                    "Roundtrip compression failed: {} ≠ {}",
                     p, q
                 ))),
             }

--- a/src/backends/plonky2/primitives/ec/curve.rs
+++ b/src/backends/plonky2/primitives/ec/curve.rs
@@ -11,10 +11,10 @@ use std::{
 use num::{bigint::BigUint, Num, One};
 use plonky2::{
     field::{
-        extension::{quintic::QuinticExtension, Extendable, FieldExtension},
+        extension::{quintic::QuinticExtension, Extendable, FieldExtension, Frobenius},
         goldilocks_field::GoldilocksField,
         ops::Square,
-        types::{Field, PrimeField},
+        types::{Field, Field64, PrimeField},
     },
     hash::poseidon::PoseidonHash,
     iop::{generator::SimpleGenerator, target::BoolTarget, witness::WitnessWrite},
@@ -34,6 +34,30 @@ use crate::backends::plonky2::{
 };
 
 type ECField = QuinticExtension<GoldilocksField>;
+
+/// Computes sqrt in ECField as sqrt(x) = sqrt(x^r)/x^((r-1)/2) with r
+/// = 1 + p + ... + p^4, where the numerator involves a sqrt in
+/// GoldilocksField, cf.
+/// https://github.com/pornin/ecgfp5/blob/ce059c6d1e1662db437aecbf3db6bb67fe63c716/rust/src/field.rs#L1041
+pub fn ec_field_sqrt(x: &ECField) -> Option<ECField> {
+    // Compute x^r.
+    let x_to_the_r = (0..5)
+        .map(|i| x.repeated_frobenius(i))
+        .reduce(|a, b| a * b)
+        .expect("Iterator should be nonempty.");
+    let num = QuinticExtension([
+        x_to_the_r.0[0].sqrt()?,
+        GoldilocksField::ZERO,
+        GoldilocksField::ZERO,
+        GoldilocksField::ZERO,
+        GoldilocksField::ZERO,
+    ]);
+    // Compute x^((r-1)/2) = x^(p*((1+p)/2)*(1+p^2))
+    let x1 = x.frobenius();
+    let x2 = x1.exp_u64((1 + GoldilocksField::ORDER) / 2);
+    let den = x2 * x2.repeated_frobenius(2);
+    Some(num / den)
+}
 
 fn ec_field_to_bytes(x: &ECField) -> Vec<u8> {
     x.0.iter()
@@ -78,14 +102,39 @@ impl Point {
     pub fn as_fields(&self) -> Vec<crate::middleware::F> {
         self.x.0.iter().chain(self.u.0.iter()).cloned().collect()
     }
-    pub fn as_bytes(&self) -> Vec<u8> {
-        [ec_field_to_bytes(&self.x), ec_field_to_bytes(&self.u)].concat()
+    pub fn compress_from_subgroup(&self) -> Result<ECField, Error> {
+        match self.is_in_subgroup() {
+            true => Ok(self.u),
+            false => Err(Error::custom(format!(
+                "Point must lie in EC subgroup: ({}, {})",
+                self.x, self.u
+            ))),
+        }
     }
-    pub fn from_bytes(b: &[u8]) -> Result<Self, Error> {
-        let x_bytes = &b[..40];
-        let u_bytes = &b[40..];
-        ec_field_from_bytes(x_bytes)
-            .and_then(|x| ec_field_from_bytes(u_bytes).map(|u| Self { x, u }))
+    pub fn decompress_into_subgroup(u: &ECField) -> Result<Self, Error> {
+        if u == &ECField::ZERO {
+            return Ok(Self::ZERO);
+        }
+        // Figure out x.
+        let b = ECField::TWO - ECField::ONE / (u.square());
+        let d = b.square() - ECField::TWO.square() * Self::b();
+        let alpha = ECField::NEG_ONE * b / ECField::TWO;
+        let beta = ec_field_sqrt(&d)
+            .ok_or(Error::custom(format!("Not a quadratic residue: {}", d)))?
+            / ECField::TWO;
+        let mut points = [ECField::ONE, ECField::NEG_ONE].into_iter().map(|s| Point {
+            x: alpha + s * beta,
+            u: *u,
+        });
+        points.find(|p| p.is_in_subgroup()).ok_or(Error::custom(
+            "One of the points must lie in the EC subgroup.".into(),
+        ))
+    }
+    pub fn as_bytes_from_subgroup(&self) -> Result<Vec<u8>, Error> {
+        self.compress_from_subgroup().map(|u| ec_field_to_bytes(&u))
+    }
+    pub fn from_bytes_into_subgroup(b: &[u8]) -> Result<Self, Error> {
+        ec_field_from_bytes(b).and_then(|u| Self::decompress_into_subgroup(&u))
     }
 }
 
@@ -648,7 +697,12 @@ mod test {
     use num::{BigUint, FromPrimitive};
     use num_bigint::RandBigInt;
     use plonky2::{
-        field::{goldilocks_field::GoldilocksField, types::Field},
+        field::{
+            extension::quintic::QuinticExtension,
+            goldilocks_field::GoldilocksField,
+            ops::Square,
+            types::{Field, Sample},
+        },
         iop::witness::PartialWitness,
         plonk::{
             circuit_builder::CircuitBuilder, circuit_data::CircuitConfig,
@@ -659,7 +713,9 @@ mod test {
 
     use crate::backends::plonky2::primitives::ec::{
         bits::CircuitBuilderBits,
-        curve::{CircuitBuilderElliptic, ECField, Point, WitnessWriteCurve, GROUP_ORDER},
+        curve::{
+            ec_field_sqrt, CircuitBuilderElliptic, ECField, Point, WitnessWriteCurve, GROUP_ORDER,
+        },
     };
 
     #[test]
@@ -686,6 +742,13 @@ mod test {
         let p3 = (&three) * g;
         assert_eq!(p1, p2);
         assert_eq!(p2, p3);
+    }
+
+    #[test]
+    fn test_sqrt() {
+        let x = QuinticExtension::rand().square();
+        let y = ec_field_sqrt(&x);
+        assert_eq!(y.map(|a| a.square()), Some(x));
     }
 
     #[test]

--- a/src/backends/plonky2/signedpod.rs
+++ b/src/backends/plonky2/signedpod.rs
@@ -138,7 +138,7 @@ impl SignedPod {
         let signer_bytes = deserialize_bytes(&data.signer)?;
         let signature_bytes = deserialize_bytes(&data.signature)?;
 
-        if signer_bytes.len() != 80 {
+        if signer_bytes.len() != 40 {
             return Err(Error::custom(
                 "Invalid byte encoding of signed POD signer.".to_string(),
             ));
@@ -149,7 +149,7 @@ impl SignedPod {
             ));
         }
 
-        let signer = Point::from_bytes(&signer_bytes)?;
+        let signer = Point::from_bytes_into_subgroup(&signer_bytes)?;
         let signature = Signature::from_bytes(&signature_bytes)?;
 
         Ok(Box::new(Self {
@@ -197,7 +197,12 @@ impl Pod for SignedPod {
     }
 
     fn serialize_data(&self) -> serde_json::Value {
-        let signer = serialize_bytes(&self.signer.as_bytes());
+        let signer = serialize_bytes(
+            &self
+                .signer
+                .as_bytes_from_subgroup()
+                .expect("Signer public key must lie in EC subgroup."),
+        );
         let signature = serialize_bytes(&self.signature.as_bytes());
         serde_json::to_value(Data {
             signer,

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -180,7 +180,7 @@ impl fmt::Display for TypedValue {
             TypedValue::Set(s) => write!(f, "set:{}", s.commitment()),
             TypedValue::Array(a) => write!(f, "arr:{}", a.commitment()),
             TypedValue::Raw(v) => write!(f, "{}", v),
-            TypedValue::PublicKey(p) => write!(f, "ecGFp5_pt:({},{})", p.x, p.u),
+            TypedValue::PublicKey(p) => write!(f, "pk:{}", p),
             TypedValue::PodId(id) => write!(f, "pod_id:{}", id),
         }
     }
@@ -849,6 +849,7 @@ pub struct MainPodInputs<'a> {
     /// Statements that need to be made public (they can come from input pods or input
     /// statements)
     pub public_statements: &'a [Statement],
+    // TODO: REMOVE THIS
     pub vd_set: VDSet,
 }
 


### PR DESCRIPTION
Depends on #304 

Implement Display for Point like this:
- In alternate mode, show the `x`, `u` coordinates using the display of the extension field
- In normal mode if the point is in the subgroup display the `u` coord in base58.  If not in the subgrup display the `x` and `u` coords concatenated in base58. 

Implement the serialization/deserialization using the base58 encoding.

The reason to use base58 VS base64 is to make it easier to select an entire public key and make it easy to compare two public keys or even read them aloud.