### PR TITLE
add eq & partial_eq for RecursivePod, Pod traits and VDSet struct (for usage from introduction-pods)

### DIFF
--- a/src/backends/plonky2/basetypes.rs
+++ b/src/backends/plonky2/basetypes.rs
@@ -77,6 +77,15 @@ pub struct VDSet {
     vds_hashes: Vec<Hash>,
 }
 
+impl PartialEq for VDSet {
+    fn eq(&self, other: &Self) -> bool {
+        self.root == other.root
+            && self.tree_depth == other.tree_depth
+            && self.vds_hashes == other.vds_hashes
+    }
+}
+impl Eq for VDSet {}
+
 impl VDSet {
     fn new_from_vds_hashes(tree_depth: usize, mut vds_hashes: Vec<Hash>) -> Result<Self> {
         // before using the hash values, sort them, so that each set of

--- a/src/backends/plonky2/emptypod.rs
+++ b/src/backends/plonky2/emptypod.rs
@@ -1,4 +1,5 @@
 use std::{
+    any::Any,
     collections::HashMap,
     sync::{LazyLock, Mutex},
 };
@@ -73,7 +74,7 @@ impl EmptyPodVerifyTarget {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EmptyPod {
     params: Params,
     id: PodId,
@@ -186,6 +187,17 @@ impl Pod for EmptyPod {
             proof: serialize_proof(&self.proof),
         })
         .expect("serialization to json")
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn equals(&self, other: &dyn Pod) -> bool {
+        if let Some(other) = other.as_any().downcast_ref::<EmptyPod>() {
+            self == other
+        } else {
+            false
+        }
     }
 }
 

--- a/src/backends/plonky2/mainpod/mod.rs
+++ b/src/backends/plonky2/mainpod/mod.rs
@@ -561,7 +561,7 @@ impl PodProver for Prover {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MainPod {
     params: Params,
     id: PodId,
@@ -675,6 +675,17 @@ impl Pod for MainPod {
             public_statements: self.public_statements.clone(),
         })
         .expect("serialization to json")
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn equals(&self, other: &dyn Pod) -> bool {
+        if let Some(other) = other.as_any().downcast_ref::<MainPod>() {
+            self == other
+        } else {
+            false
+        }
     }
 }
 

--- a/src/backends/plonky2/mainpod/statement.rs
+++ b/src/backends/plonky2/mainpod/statement.rs
@@ -10,6 +10,8 @@ use crate::{
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Statement(pub Predicate, pub Vec<StatementArg>);
 
+impl Eq for Statement {}
+
 impl Statement {
     pub fn is_none(&self) -> bool {
         self.0 == Predicate::Native(NativePredicate::None)

--- a/src/backends/plonky2/mock/emptypod.rs
+++ b/src/backends/plonky2/mock/emptypod.rs
@@ -1,3 +1,5 @@
+use std::any::Any;
+
 use itertools::Itertools;
 
 use crate::{
@@ -12,7 +14,7 @@ use crate::{
     },
 };
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MockEmptyPod {
     params: Params,
     id: PodId,
@@ -66,6 +68,17 @@ impl Pod for MockEmptyPod {
 
     fn serialize_data(&self) -> serde_json::Value {
         serde_json::Value::Null
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn equals(&self, other: &dyn Pod) -> bool {
+        if let Some(other) = other.as_any().downcast_ref::<MockEmptyPod>() {
+            self == other
+        } else {
+            false
+        }
     }
 }
 

--- a/src/backends/plonky2/mock/mainpod.rs
+++ b/src/backends/plonky2/mock/mainpod.rs
@@ -2,7 +2,7 @@
 // MainPod
 //
 
-use std::{fmt, iter};
+use std::{any::Any, fmt, iter};
 
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -55,6 +55,21 @@ pub struct MockMainPod {
     // All Merkle proofs
     merkle_proofs_containers: Vec<MerkleClaimAndProof>,
 }
+
+impl PartialEq for MockMainPod {
+    fn eq(&self, other: &Self) -> bool {
+        self.params == other.params
+            && self.id == other.id
+            && self.vd_set == other.vd_set
+            && self.input_signed_pods == other.input_signed_pods
+            && self.input_recursive_pods == other.input_recursive_pods
+            && self.statements == other.statements
+            && self.operations == other.operations
+            && self.public_statements == other.public_statements
+            && self.merkle_proofs_containers == other.merkle_proofs_containers
+    }
+}
+impl Eq for MockMainPod {}
 
 impl fmt::Display for MockMainPod {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -364,6 +379,17 @@ impl Pod for MockMainPod {
             input_recursive_pods,
         })
         .expect("serialization to json")
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn equals(&self, other: &dyn Pod) -> bool {
+        if let Some(other) = other.as_any().downcast_ref::<MockMainPod>() {
+            self == other
+        } else {
+            false
+        }
     }
 }
 

--- a/src/backends/plonky2/mock/signedpod.rs
+++ b/src/backends/plonky2/mock/signedpod.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{any::Any, collections::HashMap};
 
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -45,7 +45,7 @@ impl PodSigner for MockSigner {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MockSignedPod {
     id: PodId,
     signature: String,
@@ -157,6 +157,17 @@ impl Pod for MockSignedPod {
             kvs: self.kvs.clone(),
         })
         .expect("serialization to json")
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn equals(&self, other: &dyn Pod) -> bool {
+        if let Some(other) = other.as_any().downcast_ref::<MockSignedPod>() {
+            self == other
+        } else {
+            false
+        }
     }
 }
 

--- a/src/backends/plonky2/primitives/ec/schnorr.rs
+++ b/src/backends/plonky2/primitives/ec/schnorr.rs
@@ -35,7 +35,7 @@ use crate::{
 };
 
 /// Schnorr signature over ecGFp5.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Signature {
     pub s: BigUint,
     pub e: BigUint,

--- a/src/backends/plonky2/signedpod.rs
+++ b/src/backends/plonky2/signedpod.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::LazyLock};
+use std::{any::Any, collections::HashMap, sync::LazyLock};
 
 use itertools::Itertools;
 use num_bigint::{BigUint, RandBigInt};
@@ -67,7 +67,7 @@ impl PodSigner for Signer {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SignedPod {
     pub id: PodId,
     pub signature: Signature,
@@ -203,6 +203,17 @@ impl Pod for SignedPod {
             kvs: self.dict.clone(),
         })
         .expect("serialization to json")
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn equals(&self, other: &dyn Pod) -> bool {
+        if let Some(other) = other.as_any().downcast_ref::<SignedPod>() {
+            self == other
+        } else {
+            false
+        }
     }
 }
 

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -805,7 +805,17 @@ pub trait Pod: fmt::Debug + DynClone + Any {
             })
             .collect()
     }
+
+    fn as_any(&self) -> &dyn Any;
+    fn equals(&self, other: &dyn Pod) -> bool;
 }
+impl PartialEq for Box<dyn Pod> {
+    fn eq(&self, other: &Self) -> bool {
+        self.equals(&**other)
+    }
+}
+
+impl Eq for Box<dyn Pod> {}
 
 // impl Clone for Box<dyn Pod>
 dyn_clone::clone_trait_object!(Pod);
@@ -828,6 +838,13 @@ pub trait RecursivePod: Pod {
     where
         Self: Sized;
 }
+impl PartialEq for Box<dyn RecursivePod> {
+    fn eq(&self, other: &Self) -> bool {
+        self.equals(&**other)
+    }
+}
+
+impl Eq for Box<dyn RecursivePod> {}
 
 // impl Clone for Box<dyn RecursivePod>
 dyn_clone::clone_trait_object!(RecursivePod);


### PR DESCRIPTION
add eq & partial_eq for RecursivePod, Pod traits and VDSet struct.
(this is in order to be able to check parsed data structs in the introduction-pods, but probably useful in other use cases where we need to compare PODs)