### PR TITLE
Restore typed data to serialized PODs

### DIFF
--- a/src/frontend/serialization.rs
+++ b/src/frontend/serialization.rs
@@ -1,10 +1,14 @@
+use std::collections::HashMap;
+
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::Error;
 use crate::{
     frontend::{MainPod, SignedPod},
-    middleware::{deserialize_pod, deserialize_signed_pod, Params, PodId, VDSet},
+    middleware::{
+        deserialize_pod, deserialize_signed_pod, Key, Params, PodId, Statement, VDSet, Value,
+    },
 };
 
 #[derive(Serialize, Deserialize, JsonSchema)]
@@ -19,6 +23,7 @@ pub enum SignedPodType {
 pub struct SerializedSignedPod {
     pod_type: (usize, String),
     id: PodId,
+    entries: HashMap<Key, Value>,
     data: serde_json::Value,
 }
 
@@ -30,6 +35,7 @@ pub struct SerializedMainPod {
     pod_type: (usize, String),
     id: PodId,
     vd_set: VDSet,
+    public_statements: Vec<Statement>,
     data: serde_json::Value,
 }
 
@@ -40,6 +46,7 @@ impl From<SignedPod> for SerializedSignedPod {
         SerializedSignedPod {
             pod_type: (pod_type, pod_type_name_str.to_string()),
             id: pod.id(),
+            entries: pod.kvs().clone(),
             data,
         }
     }
@@ -64,6 +71,7 @@ impl From<MainPod> for SerializedMainPod {
             id: pod.id(),
             vd_set: pod.pod.vd_set().clone(),
             params: pod.params.clone(),
+            public_statements: pod.pod.pub_statements(),
             data,
         }
     }


### PR DESCRIPTION
Closes #310 

This reintroduces the `public_statements` and `entries` fields for `SerializedMainPod` and `SerializedSignedPod` respectively. This allows us to generate meaningful JSON Schemas that tell third-party (non-Rust) clients what data they can find in the serialization format.

This does introduce a smaller problem: there is now duplication of data between the typed `entries`/`public_statements` field and the untyped `data` blob, which includes its own copies of that data. However, this is less bad than not having any meaningful schema for our serialization format.