### PR TITLE
Support public key literals and tidy up handling of Raw vs PodId

### DIFF
--- a/src/backends/plonky2/primitives/ec/curve.rs
+++ b/src/backends/plonky2/primitives/ec/curve.rs
@@ -159,19 +159,7 @@ impl<'de> Deserialize<'de> for Point {
         D: Deserializer<'de>,
     {
         let point_b58 = String::deserialize(deserializer)?;
-        let point_bytes: Vec<u8> = bs58::decode(point_b58)
-            .into_vec()
-            .map_err(serde::de::Error::custom)?;
-        if point_bytes.len() == 80 {
-            // Non-compressed
-            Ok(Point {
-                x: ec_field_from_bytes(&point_bytes[..40]).map_err(serde::de::Error::custom)?,
-                u: ec_field_from_bytes(&point_bytes[40..]).map_err(serde::de::Error::custom)?,
-            })
-        } else {
-            // Compressed
-            Self::from_bytes_into_subgroup(&point_bytes).map_err(serde::de::Error::custom)
-        }
+        Self::from_str(&point_b58).map_err(serde::de::Error::custom)
     }
 }
 

--- a/src/lang/grammar.pest
+++ b/src/lang/grammar.pest
@@ -32,7 +32,7 @@ document = { SOI ~ (use_statement | custom_predicate_def | request_def)* ~ EOI }
 use_statement = { "use" ~ use_predicate_list ~ "from" ~ batch_ref }
 use_predicate_list = { import_name ~ ("," ~ import_name)* }
 import_name = { identifier | "_" }
-batch_ref = { literal_raw }
+batch_ref = { hash_hex }
 
 request_def = { "REQUEST" ~ "(" ~ statement_list? ~ ")" } 
 
@@ -59,11 +59,13 @@ anchored_key = { wildcard ~ "[" ~ literal_string ~ "]" }
 
 // Literal Values (ordered to avoid ambiguity, e.g., string before int)
 literal_value = {
+    literal_public_key |
     literal_dict |
     literal_set |
     literal_array |
     literal_bool |
     literal_raw |
+    literal_pod_id |
     literal_string |
     literal_int
 }
@@ -72,9 +74,12 @@ literal_value = {
 literal_int = @{ "-"? ~ ASCII_DIGIT+ }
 literal_bool = @{ "true" | "false" }
 
-// literal_raw: 0x followed by exactly 32 PAIRS of hex digits (64 hex characters)
+// hash_hex: 0x followed by exactly 32 PAIRS of hex digits (64 hex characters)
 // representing a 32-byte value in big-endian order
-literal_raw = @{ "0x" ~ (ASCII_HEX_DIGIT ~ ASCII_HEX_DIGIT){32} }
+hash_hex = @{ "0x" ~ (ASCII_HEX_DIGIT ~ ASCII_HEX_DIGIT){32} }
+
+literal_raw = { "Raw" ~ "(" ~ hash_hex ~ ")" }
+literal_pod_id = { hash_hex }
 
 // String literal parsing based on https://pest.rs/book/examples/json.html
 literal_string = ${ "\"" ~ inner ~ "\"" } // Compound atomic string rule
@@ -84,6 +89,11 @@ char = { // Rule for a single logical character (unescaped or escaped)
     | "\\" ~ ("\"" | "\\" | "/" | "b" | "f" | "n" | "r" | "t") // Simple escape sequences
     | "\\" ~ ("u" ~ ASCII_HEX_DIGIT{4}) // Unicode escape sequence
 }
+
+// PublicKey(...)
+base58_char = { '1'..'9' | 'A'..'H' | 'J'..'N' | 'P'..'Z' | 'a'..'k' | 'm'..'z' }
+base58_string = @{ base58_char+ }
+literal_public_key = { "PublicKey" ~ "(" ~ base58_string ~ ")" }
 
 // Container Literals (recursive definition using literal_value)
 literal_array = { "[" ~ (literal_value ~ ("," ~ literal_value)*)? ~ "]" }
@@ -95,7 +105,9 @@ dict_pair = { literal_string ~ ":" ~ literal_value }
 test_identifier = { SOI ~ identifier ~ EOI }
 test_wildcard = { SOI ~ wildcard ~ EOI }
 test_literal_int = { SOI ~ literal_int ~ EOI }
-test_literal_raw = { SOI ~ literal_raw ~ EOI } 
+test_hash_hex = { SOI ~ hash_hex ~ EOI } 
+test_literal_raw = { SOI ~ literal_raw ~ EOI }
+test_literal_pod_id = { SOI ~ literal_pod_id ~ EOI }
 test_literal_value = { SOI ~ literal_value ~ EOI }
 test_statement = { SOI ~ statement ~ EOI }
 test_custom_predicate_def = { SOI ~ custom_predicate_def ~ EOI } 

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -29,9 +29,9 @@ mod tests {
     use crate::{
         lang::error::ProcessorError,
         middleware::{
-            CustomPredicate, CustomPredicateBatch, CustomPredicateRef, Key, NativePredicate,
-            Params, PodType, Predicate, StatementTmpl, StatementTmplArg, Value, Wildcard,
-            SELF_ID_HASH,
+            hash_str, CustomPredicate, CustomPredicateBatch, CustomPredicateRef, Key,
+            NativePredicate, Params, PodId, PodType, Predicate, RawValue, StatementTmpl,
+            StatementTmplArg, Value, Wildcard, SELF_ID_HASH,
         },
     };
 
@@ -850,6 +850,78 @@ mod tests {
         };
 
         assert_eq!(defined_pred.statements[0], expected_statement);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_e2e_literals() -> Result<(), LangError> {
+        let pk = crate::backends::plonky2::primitives::ec::curve::Point::generator();
+        let pk_b58 = pk.to_string();
+        let pod_id = PodId(hash_str("test"));
+        let raw = RawValue::from(1);
+        let string = "hello";
+        let int = 123;
+        let bool = true;
+
+        let input = format!(
+            r#"
+            REQUEST(
+                Equal(?A["pk"], PublicKey({}))
+                Equal(?B["pod_id"], {})
+                Equal(?C["raw"], Raw({}))
+                Equal(?D["string"], "{}")
+                Equal(?E["int"], {})
+                Equal(?F["bool"], {})
+            )
+        "#,
+            pk_b58, pod_id, raw, string, int, bool
+        );
+        /*
+            REQUEST(
+                Equal(?A["pk"], PublicKey(3t9fNuU194n7mSJPRdeaJRMqw6ZQCUddzvECWNe1k2b1rdBezXpJxF))
+                Equal(?B["pod_id"], 0x735b31d3aad0f5b66002ffe1dc7d2eaa0ee9c59c09b641e8261530c5f3a02f29)
+                Equal(?C["raw"], Raw(0x0000000000000000000000000000000000000000000000000000000000000001))
+                Equal(?D["string"], "hello")
+                Equal(?E["int"], 123)
+                Equal(?F["bool"], true)
+            )
+        */
+
+        let params = Params::default();
+        let processed = parse(&input, &params, &[])?;
+        let request_templates = processed.request_templates;
+
+        assert_eq!(request_templates.len(), 6);
+
+        let expected_templates = vec![
+            StatementTmpl {
+                pred: Predicate::Native(NativePredicate::Equal),
+                args: vec![sta_ak(("A", 0), "pk"), sta_lit(Value::from(pk))],
+            },
+            StatementTmpl {
+                pred: Predicate::Native(NativePredicate::Equal),
+                args: vec![sta_ak(("B", 1), "pod_id"), sta_lit(Value::from(pod_id))],
+            },
+            StatementTmpl {
+                pred: Predicate::Native(NativePredicate::Equal),
+                args: vec![sta_ak(("C", 2), "raw"), sta_lit(Value::from(raw))],
+            },
+            StatementTmpl {
+                pred: Predicate::Native(NativePredicate::Equal),
+                args: vec![sta_ak(("D", 3), "string"), sta_lit(Value::from(string))],
+            },
+            StatementTmpl {
+                pred: Predicate::Native(NativePredicate::Equal),
+                args: vec![sta_ak(("E", 4), "int"), sta_lit(Value::from(int))],
+            },
+            StatementTmpl {
+                pred: Predicate::Native(NativePredicate::Equal),
+                args: vec![sta_ak(("F", 5), "bool"), sta_lit(Value::from(bool))],
+            },
+        ];
+
+        assert_eq!(request_templates, expected_templates);
 
         Ok(())
     }

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -868,8 +868,8 @@ mod tests {
             r#"
             REQUEST(
                 Equal(?A["pk"], PublicKey({}))
-                Equal(?B["pod_id"], {})
-                Equal(?C["raw"], Raw({}))
+                Equal(?B["pod_id"], {:#})
+                Equal(?C["raw"], Raw({:#}))
                 Equal(?D["string"], "{}")
                 Equal(?E["int"], {})
                 Equal(?F["bool"], {})

--- a/src/middleware/basetypes.rs
+++ b/src/middleware/basetypes.rs
@@ -200,6 +200,8 @@ impl Ord for Hash {
 impl fmt::Display for Hash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if f.alternate() {
+            write!(f, "0x{}", self.encode_hex::<String>())
+        } else {
             // display first hex digit in big endian
             write!(f, "0x")?;
             let v3 = self.0[3].to_canonical_u64();
@@ -207,8 +209,6 @@ impl fmt::Display for Hash {
                 write!(f, "{:02x}", (v3 >> ((7 - i) * 8)) & 0xff)?;
             }
             write!(f, "…")
-        } else {
-            write!(f, "0x{}", self.encode_hex::<String>())
         }
     }
 }

--- a/src/middleware/basetypes.rs
+++ b/src/middleware/basetypes.rs
@@ -200,8 +200,6 @@ impl Ord for Hash {
 impl fmt::Display for Hash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if f.alternate() {
-            write!(f, "0x{}", self.encode_hex::<String>())
-        } else {
             // display first hex digit in big endian
             write!(f, "0x")?;
             let v3 = self.0[3].to_canonical_u64();
@@ -209,6 +207,8 @@ impl fmt::Display for Hash {
                 write!(f, "{:02x}", (v3 >> ((7 - i) * 8)) & 0xff)?;
             }
             write!(f, "…")
+        } else {
+            write!(f, "0x{}", self.encode_hex::<String>())
         }
     }
 }

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -440,6 +440,8 @@ impl fmt::Display for PodId {
             write!(f, "self")
         } else if self.0 == EMPTY_HASH {
             write!(f, "null")
+        } else if f.alternate() {
+            write!(f, "{:#}", self.0)
         } else {
             write!(f, "{}", self.0)
         }


### PR DESCRIPTION
Closes #299 

PublicKeys can now be expressed as Podlang literals:

```
PublicKey(base58string)
```

I've also tidied up the handling of PodId vs Raw. Now, any bare hex string (0x-prefixed) is interpreted as a PodId, unless wrapped in `Raw()`, in which case it will be interpreted as a `RawValue`.

I'm open to changing these if the wrappers seem too verbose. For instance, maybe we could use a special character prefix for public keys, like `+` or `@`, but I thought that it would be better to start with something verbose and then introduce shortcuts if the verbose version is too annoying.