### PR TITLE
Automatically implement Pod::equals

### DIFF
--- a/src/backends/plonky2/emptypod.rs
+++ b/src/backends/plonky2/emptypod.rs
@@ -1,5 +1,4 @@
 use std::{
-    any::Any,
     collections::HashMap,
     sync::{LazyLock, Mutex},
 };
@@ -192,17 +191,6 @@ impl Pod for EmptyPod {
             proof: serialize_proof(&self.proof),
         })
         .expect("serialization to json")
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-    fn equals(&self, other: &dyn Pod) -> bool {
-        if let Some(other) = other.as_any().downcast_ref::<EmptyPod>() {
-            self == other
-        } else {
-            false
-        }
     }
 }
 

--- a/src/backends/plonky2/mainpod/mod.rs
+++ b/src/backends/plonky2/mainpod/mod.rs
@@ -676,17 +676,6 @@ impl Pod for MainPod {
         })
         .expect("serialization to json")
     }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-    fn equals(&self, other: &dyn Pod) -> bool {
-        if let Some(other) = other.as_any().downcast_ref::<MainPod>() {
-            self == other
-        } else {
-            false
-        }
-    }
 }
 
 impl RecursivePod for MainPod {

--- a/src/backends/plonky2/mock/emptypod.rs
+++ b/src/backends/plonky2/mock/emptypod.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-
 use itertools::Itertools;
 
 use crate::{
@@ -68,17 +66,6 @@ impl Pod for MockEmptyPod {
 
     fn serialize_data(&self) -> serde_json::Value {
         serde_json::Value::Null
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-    fn equals(&self, other: &dyn Pod) -> bool {
-        if let Some(other) = other.as_any().downcast_ref::<MockEmptyPod>() {
-            self == other
-        } else {
-            false
-        }
     }
 }
 

--- a/src/backends/plonky2/mock/mainpod.rs
+++ b/src/backends/plonky2/mock/mainpod.rs
@@ -2,7 +2,7 @@
 // MainPod
 //
 
-use std::{any::Any, fmt, iter};
+use std::{fmt, iter};
 
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -366,17 +366,6 @@ impl Pod for MockMainPod {
             input_recursive_pods,
         })
         .expect("serialization to json")
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-    fn equals(&self, other: &dyn Pod) -> bool {
-        if let Some(other) = other.as_any().downcast_ref::<MockMainPod>() {
-            self == other
-        } else {
-            false
-        }
     }
 }
 

--- a/src/backends/plonky2/mock/signedpod.rs
+++ b/src/backends/plonky2/mock/signedpod.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, collections::HashMap};
+use std::collections::HashMap;
 
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -165,17 +165,6 @@ impl Pod for MockSignedPod {
             kvs: self.kvs.clone(),
         })
         .expect("serialization to json")
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-    fn equals(&self, other: &dyn Pod) -> bool {
-        if let Some(other) = other.as_any().downcast_ref::<MockSignedPod>() {
-            self == other
-        } else {
-            false
-        }
     }
 }
 

--- a/src/backends/plonky2/signedpod.rs
+++ b/src/backends/plonky2/signedpod.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, collections::HashMap, sync::LazyLock};
+use std::{collections::HashMap, sync::LazyLock};
 
 use itertools::Itertools;
 use num_bigint::{BigUint, RandBigInt};
@@ -202,17 +202,6 @@ impl Pod for SignedPod {
             kvs: self.dict.clone(),
         })
         .expect("serialization to json")
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-    fn equals(&self, other: &dyn Pod) -> bool {
-        if let Some(other) = other.as_any().downcast_ref::<SignedPod>() {
-            self == other
-        } else {
-            false
-        }
     }
 }
 

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -774,7 +774,21 @@ pub fn normalize_statement(statement: &Statement, self_id: PodId) -> Statement {
     Statement::from_args(predicate, args).expect("statement was valid before normalization")
 }
 
-pub trait Pod: fmt::Debug + DynClone + Sync + Send + Any {
+pub trait EqualsAny {
+    fn equals_any(&self, other: &dyn Any) -> bool;
+}
+
+impl<T: Any + Eq> EqualsAny for T {
+    fn equals_any(&self, other: &dyn Any) -> bool {
+        if let Some(o) = other.downcast_ref::<T>() {
+            self == o
+        } else {
+            false
+        }
+    }
+}
+
+pub trait Pod: fmt::Debug + DynClone + Sync + Send + Any + EqualsAny {
     fn params(&self) -> &Params;
     fn verify(&self) -> Result<(), BackendError>;
     fn id(&self) -> PodId;
@@ -806,8 +820,9 @@ pub trait Pod: fmt::Debug + DynClone + Sync + Send + Any {
             .collect()
     }
 
-    fn as_any(&self) -> &dyn Any;
-    fn equals(&self, other: &dyn Pod) -> bool;
+    fn equals(&self, other: &dyn Pod) -> bool {
+        self.equals_any(other as &dyn Any)
+    }
 }
 impl PartialEq for Box<dyn Pod> {
     fn eq(&self, other: &Self) -> bool {


### PR DESCRIPTION
This patch introduces an automatic implementation of Pod::equals, so that it does not have to be manually implemented for each pod.