### PR TITLE
change Hash (and RawValue) hex-string representation to show the least-significant field element as big-endian hex string

### DIFF
--- a/src/middleware/basetypes.rs
+++ b/src/middleware/basetypes.rs
@@ -236,13 +236,13 @@ impl fmt::Display for Hash {
         if f.alternate() {
             write!(f, "0x{}", self.encode_hex::<String>())
         } else {
-            // display first hex digit in big endian
-            write!(f, "0x")?;
-            let v3 = self.0[3].to_canonical_u64();
-            for i in 0..4 {
-                write!(f, "{:02x}", (v3 >> ((7 - i) * 8)) & 0xff)?;
+            // display the lest significant field element in big endian
+            write!(f, "0x…")?;
+            let v3 = self.0[0].to_canonical_u64();
+            for i in (0..4).rev() {
+                write!(f, "{:02x}", (v3 >> (i * 8)) & 0xff)?;
             }
-            write!(f, "…")
+            write!(f, "")
         }
     }
 }

--- a/src/middleware/basetypes.rs
+++ b/src/middleware/basetypes.rs
@@ -236,13 +236,13 @@ impl fmt::Display for Hash {
         if f.alternate() {
             write!(f, "0x{}", self.encode_hex::<String>())
         } else {
-            // display the lest significant field element in big endian
+            // display the least significant field element in big endian
             write!(f, "0x…")?;
-            let v3 = self.0[0].to_canonical_u64();
+            let v0 = self.0[0].to_canonical_u64();
             for i in (0..4).rev() {
-                write!(f, "{:02x}", (v3 >> (i * 8)) & 0xff)?;
+                write!(f, "{:02x}", (v0 >> (i * 8)) & 0xff)?;
             }
-            write!(f, "")
+            Ok(())
         }
     }
 }


### PR DESCRIPTION
The motivation is that since some commits ago, the hex representation was changed from little-endian to big-endian, and when cropping the long strings of hex (hex representation of byte-arrays), the small values (224 bits or less) were being represented by `0x00000000...`, which is indistinguishable from the `0` value.
This commit updates this cropped representation to print the last characters of the string (the less signifcant bytes of the big-endian representation), so that for example for the integer `5` the representation would be `0x...00000005`.

More context at https://github.com/0xPARC/pod2/issues/337.