### PR TITLE
MerkleTree insertion proofs

### DIFF
--- a/.github/workflows/typos.toml
+++ b/.github/workflows/typos.toml
@@ -8,3 +8,4 @@ nin = "nin" # not in
 kow = "kow" # key or wildcard
 KOW = "KOW" # Key Or Wildcard
 datas = "datas" # plural (for 'verifier_datas', a vector of 'verifier_data')
+typ = "typ" # from 'type', which can not be used as variable name since it is a keyword

--- a/src/backends/plonky2/primitives/merkletree/circuit.rs
+++ b/src/backends/plonky2/primitives/merkletree/circuit.rs
@@ -451,8 +451,7 @@ pub fn verify_merkle_state_transition_circuit(
         proof.enabled.target,
     );
 
-    // 4) assert proof_non_existence.root==old_root, and that it uses new_key &
-    // new_value
+    // 4) assert proof_non_existence.root==old_root, and that it uses new_key
     for j in 0..HASH_SIZE {
         // 4.1) assert that proof.proof_non_existence.root == proof.old_root
         builder.conditional_assert_eq(
@@ -460,16 +459,12 @@ pub fn verify_merkle_state_transition_circuit(
             proof.proof_non_existence.root.elements[j],
             proof.old_root.elements[j],
         );
-        // 4.2) assert that the non-existence proof uses the new_key & new_value
+        // 4.2) assert that the non-existence proof uses the new_key (value not needed for
+        //   non-existence)
         builder.conditional_assert_eq(
             proof.enabled.target,
             proof.proof_non_existence.key.elements[j],
             proof.new_key.elements[j],
-        );
-        builder.conditional_assert_eq(
-            proof.enabled.target,
-            proof.proof_non_existence.value.elements[j],
-            proof.new_value.elements[j],
         );
     }
 
@@ -590,7 +585,7 @@ impl MerkleProofStateTransitionTarget {
             &MerkleClaimAndProof {
                 root: mp.old_root,
                 key: mp.new_key,
-                value: mp.new_value,
+                value: EMPTY_VALUE, // not needed for non-existence
                 proof: mp.proof_non_existence.clone(),
             },
         )?;

--- a/src/backends/plonky2/primitives/merkletree/error.rs
+++ b/src/backends/plonky2/primitives/merkletree/error.rs
@@ -18,6 +18,8 @@ pub enum TreeInnerError {
     ProofFail(String), // inclusion / exclusion
     #[error("invalid {0} proof")]
     InvalidProof(String),
+    #[error("state transition proof does not verify, reason: {0}")]
+    StateTransitionProofFail(String),
     #[error("key too short (key length: {0}) for the max_depth: {1}")]
     TooShortKey(usize, usize),
 }
@@ -72,6 +74,9 @@ impl TreeError {
     }
     pub(crate) fn invalid_proof(obj: String) -> Self {
         new!(InvalidProof(obj))
+    }
+    pub(crate) fn state_transition_fail(reason: String) -> Self {
+        new!(StateTransitionProofFail(reason))
     }
     pub(crate) fn too_short_key(depth: usize, max_depth: usize) -> Self {
         new!(TooShortKey(depth, max_depth))

--- a/src/backends/plonky2/primitives/merkletree/mod.rs
+++ b/src/backends/plonky2/primitives/merkletree/mod.rs
@@ -451,13 +451,31 @@ impl fmt::Display for Node {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Intermediate(n) => {
-                writeln!(
-                    f,
-                    "\"{}\" -> {{ \"{}\" \"{}\" }}",
-                    n.hash(),
-                    n.left.hash(),
-                    n.right.hash()
-                )?;
+                let left_hash: String = if n.left.is_empty() {
+                    writeln!(
+                        f,
+                        "\"{}_child_of_{}\" [label=\"{}\"]",
+                        n.left.hash(),
+                        n.hash(),
+                        n.left.hash()
+                    )?;
+                    format!("\"{}_child_of_{}\"", n.left.hash(), n.hash())
+                } else {
+                    format!("\"{}\"", n.left.hash())
+                };
+                let right_hash = if n.right.is_empty() {
+                    writeln!(
+                        f,
+                        "\"{}_child_of_{}\" [label=\"{}\"]",
+                        n.right.hash(),
+                        n.hash(),
+                        n.right.hash()
+                    )?;
+                    format!("\"{}_child_of_{}\"", n.right.hash(), n.hash())
+                } else {
+                    format!("\"{}\"", n.right.hash())
+                };
+                writeln!(f, "\"{}\" -> {{ {} {} }}", n.hash(), left_hash, right_hash,)?;
                 write!(f, "{}", n.left)?;
                 write!(f, "{}", n.right)
             }

--- a/src/backends/plonky2/primitives/merkletree/mod.rs
+++ b/src/backends/plonky2/primitives/merkletree/mod.rs
@@ -353,7 +353,7 @@ impl MerkleProof {
             return Err(TreeError::max_depth());
         }
 
-        let mut h = node_hash.clone();
+        let mut h = *node_hash;
         for (i, sibling) in self.siblings.iter().enumerate().rev() {
             let mut input: Vec<F> = if path[i] {
                 [sibling.0, h.0].concat()

--- a/src/backends/plonky2/primitives/merkletree/mod.rs
+++ b/src/backends/plonky2/primitives/merkletree/mod.rs
@@ -233,8 +233,7 @@ impl MerkleTree {
         )?;
 
         // if other_leaf exists, check path divergence
-        if proof.proof_non_existence.other_leaf.is_some() {
-            let (other_key, _) = proof.proof_non_existence.other_leaf.unwrap();
+        if let Some((other_key, _)) = proof.proof_non_existence.other_leaf {
             let old_path = keypath(max_depth, other_key)?;
             let new_path = keypath(max_depth, proof.new_key)?;
 
@@ -274,7 +273,9 @@ impl MerkleTree {
                 .proof_non_existence
                 .other_leaf
                 .map(|(k, _)| k)
-                .unwrap_or(proof.new_key);
+                .ok_or(TreeError::state_transition_fail(
+                        "proof.proof_non_existence.other_leaf can not be empty for the case old_siblings[d]!=new_siblings[d]".to_string()
+                        ))?;
             let v: Option<RawValue> = proof.proof_non_existence.other_leaf.map(|(_, v)| v);
             let old_leaf_hash = kv_hash(&k, v);
             if new_siblings[d] != old_leaf_hash {
@@ -425,7 +426,7 @@ impl fmt::Display for MerkleClaimAndProof {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MerkleProofStateTransition {
-    // type: 0:insertion, 1:edition, 2:deletion
+    // type: 0:insertion, 1:update, 2:deletion
     pub(crate) typ: u8,
 
     pub(crate) old_root: Hash,

--- a/src/backends/plonky2/primitives/merkletree/mod.rs
+++ b/src/backends/plonky2/primitives/merkletree/mod.rs
@@ -218,6 +218,7 @@ impl MerkleTree {
             &proof.new_key,
         )?;
 
+        // TODO replace the next logic block by a call to verify() (merkleproof of existence)
         // check that new_siblings verify with the new_root
         let computed_new_root = MerkleProof {
             existence: true,
@@ -231,7 +232,12 @@ impl MerkleTree {
             ));
         }
 
-        // if newnode forced to go down_till_divergence
+        // let d=divergence_level, assert that:
+        // 1) old_siblings[i] == new_siblings[i] ∀ i \ {d}
+        // 2) at i=d:
+        //   if old_siblings[i] != new_siblings[i]:
+        //     old_siblings[i] == EMPTY_HASH
+        //     new_siblings[i] == old_leaf_hash
         let d = new_siblings.len() - 1;
         old_siblings.resize(d + 1, EMPTY_HASH);
         for i in 0..d {


### PR DESCRIPTION
- implement `tree.insert` method to add new leaves to the tree (till now we could only add leaves at tree initial creation, not after), which returns a proof of correct insertion (proof of correct *state transition*)
- implement verification of proofs of correct insertion of leaves
- implement circuit that verifies proofs of correct insertion
- fix graphviz method after endianness change

Update: thanks @ax0 for pointing out the [tampering proofs case](https://github.com/0xPARC/pod2/pull/344/commits/79a532e97bc4e63d465b0445469e576adf8d3ef6), which required adding the [check 5.3](https://github.com/0xPARC/pod2/pull/344/commits/2da2e8237b35b8d50e9a4dcbeefb2a0285a677d6).