### PR TITLE
Secret keys in Podlang

### DIFF
--- a/src/lang/grammar.pest
+++ b/src/lang/grammar.pest
@@ -60,6 +60,7 @@ anchored_key = { wildcard ~ "[" ~ literal_string ~ "]" }
 // Literal Values (ordered to avoid ambiguity, e.g., string before int)
 literal_value = {
     literal_public_key |
+    literal_secret_key |
     literal_dict |
     literal_set |
     literal_array |
@@ -94,6 +95,11 @@ char = { // Rule for a single logical character (unescaped or escaped)
 base58_char = { '1'..'9' | 'A'..'H' | 'J'..'N' | 'P'..'Z' | 'a'..'k' | 'm'..'z' }
 base58_string = @{ base58_char+ }
 literal_public_key = { "PublicKey" ~ "(" ~ base58_string ~ ")" }
+
+// SecretKey(...)
+base64_char = { 'a'..'z' | 'A'..'Z' | '0'..'9' | "+" | "/" | "=" }
+base64_string = @{ base64_char+ }
+literal_secret_key = { "SecretKey" ~ "(" ~ base64_string ~ ")" }
 
 // Container Literals (recursive definition using literal_value)
 literal_array = { "[" ~ (literal_value ~ ("," ~ literal_value)*)? ~ "]" }

--- a/src/lang/pretty_print.rs
+++ b/src/lang/pretty_print.rs
@@ -192,6 +192,7 @@ fn fmt_predicate_signature(
 mod tests {
     use super::*;
     use crate::{
+        backends::plonky2::primitives::ec::schnorr::SecretKey,
         lang::parse,
         middleware::{
             CustomPredicate, Key, NativePredicate, Params, Predicate, StatementTmpl,
@@ -490,6 +491,20 @@ mod tests {
             )
         "#;
         assert_round_trip(input);
+    }
+
+    #[test]
+    fn test_round_trip_secret_key() {
+        let sk = SecretKey::new_rand();
+        let input = format!(
+            r#"
+            secret_key_test(Pod) = AND(
+                Equal(?Pod["sk"], {})
+            )
+            "#,
+            Value::from(sk.clone()).to_podlang_string()
+        );
+        assert_round_trip(&input);
     }
 
     #[test]


### PR DESCRIPTION
This implements the SecretKey literal in Podlang, as follows:

```
SecretKey(base_64_encoded_string)
```

This follows the base64 encoding used for serialization of SecretKeys.