### PR TITLE
Support SELF keyword in Podlang parser

### DIFF
--- a/src/lang/grammar.pest
+++ b/src/lang/grammar.pest
@@ -68,7 +68,8 @@ literal_value = {
     literal_raw |
     literal_pod_id |
     literal_string |
-    literal_int
+    literal_int |
+    self_keyword
 }
 
 // Primitive literal types

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -34,7 +34,7 @@ mod tests {
         middleware::{
             hash_str, CustomPredicate, CustomPredicateBatch, CustomPredicateRef, Key,
             NativePredicate, Params, PodId, PodType, Predicate, RawValue, StatementTmpl,
-            StatementTmplArg, Value, Wildcard, KEY_SIGNER, KEY_TYPE,
+            StatementTmplArg, Value, Wildcard, KEY_SIGNER, KEY_TYPE, SELF,
         },
     };
 
@@ -877,6 +877,7 @@ mod tests {
                 Equal(?E["int"], {})
                 Equal(?F["bool"], {})
                 Equal(?G["sk"], {})
+                Equal(?H["self"], SELF)
             )
         "#,
             Value::from(pk).to_podlang_string(),
@@ -895,14 +896,14 @@ mod tests {
                 Equal(?D["string"], "hello")
                 Equal(?E["int"], 123)
                 Equal(?F["bool"], true)
+                Equal(?G["sk"], SecretKey(random_secret_key_base_64))
+                Equal(?H["self"], SELF)
             )
         */
 
         let params = Params::default();
         let processed = parse(&input, &params, &[])?;
         let request_templates = processed.request_templates;
-
-        assert_eq!(request_templates.len(), 7);
 
         let expected_templates = vec![
             StatementTmpl {
@@ -932,6 +933,10 @@ mod tests {
             StatementTmpl {
                 pred: Predicate::Native(NativePredicate::Equal),
                 args: vec![sta_ak(("G", 6), "sk"), sta_lit(Value::from(sk))],
+            },
+            StatementTmpl {
+                pred: Predicate::Native(NativePredicate::Equal),
+                args: vec![sta_ak(("H", 7), "self"), sta_lit(Value::from(SELF))],
             },
         ];
 

--- a/src/lang/pretty_print.rs
+++ b/src/lang/pretty_print.rs
@@ -508,6 +508,16 @@ mod tests {
     }
 
     #[test]
+    fn test_round_trip_self() {
+        let input = r#"
+            self_test(Pod) = AND(
+                Equal(?Pod["self"], SELF)
+            )
+        "#;
+        assert_round_trip(input);
+    }
+
+    #[test]
     fn test_pretty_print_demonstration() {
         let input = r#"
             base_check(Pod) = AND(

--- a/src/lang/processor.rs
+++ b/src/lang/processor.rs
@@ -817,6 +817,7 @@ fn process_literal_value(
             })?;
             Ok(Value::from(secret_key))
         }
+        Rule::self_keyword => Ok(Value::from(middleware::SELF)),
         _ => unreachable!("Unexpected rule: {:?}", inner_lit.as_rule()),
     }
 }

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -266,7 +266,11 @@ impl fmt::Display for TypedValue {
             TypedValue::PublicKey(p) => write!(f, "PublicKey({})", p),
             TypedValue::SecretKey(p) => write!(f, "SecretKey({})", p),
             TypedValue::PodId(p) => {
-                write!(f, "0x{}", p.0.encode_hex::<String>())
+                if *p == SELF {
+                    write!(f, "SELF")
+                } else {
+                    write!(f, "0x{}", p.0.encode_hex::<String>())
+                }
             }
             TypedValue::Raw(r) => {
                 write!(f, "Raw(0x{})", r.encode_hex::<String>())

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -341,6 +341,18 @@ impl JsonSchema for TypedValue {
             ..Default::default()
         };
 
+        let pod_id_schema = schemars::schema::SchemaObject {
+            instance_type: Some(SingleOrVec::Single(Box::new(InstanceType::Object))),
+            object: Some(Box::new(schemars::schema::ObjectValidation {
+                properties: [("PodId".to_string(), gen.subschema_for::<PodId>())]
+                    .into_iter()
+                    .collect(),
+                required: ["PodId".to_string()].into_iter().collect(),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+
         let public_key_schema = schemars::schema::SchemaObject {
             instance_type: Some(SingleOrVec::Single(Box::new(InstanceType::Object))),
             object: Some(Box::new(schemars::schema::ObjectValidation {
@@ -377,6 +389,7 @@ impl JsonSchema for TypedValue {
         Schema::Object(SchemaObject {
             subschemas: Some(Box::new(schemars::schema::SubschemaValidation {
                 any_of: Some(vec![
+                    Schema::Object(pod_id_schema),
                     Schema::Object(int_schema),
                     Schema::Object(raw_schema),
                     Schema::Object(public_key_schema),


### PR DESCRIPTION
Closes #351 

This adds support for a syntactic sugar SELF keyword.

I've simplified my original design, so that this is pure syntactic sugar that gets removed during parsing. It's simply a shortcut for writing out the full SELF keyword in hex.