### PR TITLE
Remove unnecessary 'params' argument to MainPodBuilder::prove

### DIFF
--- a/examples/main_pod_points.rs
+++ b/examples/main_pod_points.rs
@@ -114,7 +114,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         st_level,
         st_points
     ))?;
-    let pod_alice_lvl_1_points = builder.prove(prover, &params).unwrap();
+    let pod_alice_lvl_1_points = builder.prove(prover).unwrap();
     println!("# pod_alice_lvl_1_points\n:{}", pod_alice_lvl_1_points);
     pod_alice_lvl_1_points.pod.verify().unwrap();
 
@@ -135,7 +135,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         st_level,
         st_points
     ))?;
-    let pod_alice_lvl_2_points = builder.prove(prover, &params).unwrap();
+    let pod_alice_lvl_2_points = builder.prove(prover).unwrap();
     println!("# pod_alice_lvl_2_points\n:{}", pod_alice_lvl_2_points);
     pod_alice_lvl_2_points.pod.verify().unwrap();
 
@@ -153,7 +153,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         st_points_total,
         st_gt_9000
     ));
-    let pod_alice_over_9000 = builder.prove(prover, &params).unwrap();
+    let pod_alice_over_9000 = builder.prove(prover).unwrap();
     println!("# pod_alice_over_9000\n:{}", pod_alice_over_9000);
     pod_alice_over_9000.pod.verify().unwrap();
 

--- a/src/backends/plonky2/mainpod/mod.rs
+++ b/src/backends/plonky2/mainpod/mod.rs
@@ -776,7 +776,7 @@ pub mod tests {
         let kyc_builder = zu_kyc_pod_builder(&params, &vd_set, &gov_id_pod, &pay_stub_pod)?;
 
         let prover = Prover {};
-        let kyc_pod = kyc_builder.prove(&prover, &params)?;
+        let kyc_pod = kyc_builder.prove(&prover)?;
         crate::measure_gates_print!();
         let pod = (kyc_pod.pod as Box<dyn Any>).downcast::<MainPod>().unwrap();
 
@@ -789,7 +789,7 @@ pub mod tests {
 
         let ticket_builder = tickets_pod_full_flow(&params, &DEFAULT_VD_SET)?;
         let prover = Prover {};
-        let kyc_pod = ticket_builder.prove(&prover, &params)?;
+        let kyc_pod = ticket_builder.prove(&prover)?;
         crate::measure_gates_print!();
         let pod = (kyc_pod.pod as Box<dyn Any>).downcast::<MainPod>().unwrap();
 
@@ -829,7 +829,7 @@ pub mod tests {
 
         // Mock
         let prover = MockProver {};
-        let kyc_pod = kyc_builder.prove(&prover, &params).unwrap();
+        let kyc_pod = kyc_builder.prove(&prover).unwrap();
         let pod = (kyc_pod.pod as Box<dyn Any>)
             .downcast::<MockMainPod>()
             .unwrap();
@@ -838,7 +838,7 @@ pub mod tests {
 
         // Real
         let prover = Prover {};
-        let kyc_pod = kyc_builder.prove(&prover, &params).unwrap();
+        let kyc_pod = kyc_builder.prove(&prover).unwrap();
         let pod = (kyc_pod.pod as Box<dyn Any>).downcast::<MainPod>().unwrap();
         pod.verify().unwrap()
     }
@@ -872,7 +872,7 @@ pub mod tests {
 
         // Mock
         let prover = MockProver {};
-        let kyc_pod = pod_builder.prove(&prover, &params).unwrap();
+        let kyc_pod = pod_builder.prove(&prover).unwrap();
         let pod = (kyc_pod.pod as Box<dyn Any>)
             .downcast::<MockMainPod>()
             .unwrap();
@@ -881,7 +881,7 @@ pub mod tests {
 
         // Real
         let prover = Prover {};
-        let kyc_pod = pod_builder.prove(&prover, &params).unwrap();
+        let kyc_pod = pod_builder.prove(&prover).unwrap();
         let pod = (kyc_pod.pod as Box<dyn Any>).downcast::<MainPod>().unwrap();
         pod.verify().unwrap()
     }
@@ -903,12 +903,12 @@ pub mod tests {
 
         let helper = EthDosHelper::new(&params, vd_set, false, alice.public_key())?;
         let prover = Prover {};
-        let dist_1 = helper.dist_1(&alice_attestation)?.prove(&prover, &params)?;
+        let dist_1 = helper.dist_1(&alice_attestation)?.prove(&prover)?;
         crate::measure_gates_print!();
         dist_1.pod.verify()?;
         let dist_2 = helper
             .dist_n_plus_1(&dist_1, &bob_attestation)?
-            .prove(&prover, &params)?;
+            .prove(&prover)?;
         Ok(dist_2.pod.verify()?)
     }
 
@@ -958,11 +958,11 @@ pub mod tests {
         let _st3 = pod_builder.priv_op(op!(custom, cpb_and.clone(), st0, st2))?;
 
         let prover = MockProver {};
-        let pod = pod_builder.prove(&prover, &params)?;
+        let pod = pod_builder.prove(&prover)?;
         assert!(pod.pod.verify().is_ok());
 
         let prover = Prover {};
-        let pod = pod_builder.prove(&prover, &params)?;
+        let pod = pod_builder.prove(&prover)?;
         crate::measure_gates_print!();
 
         let pod = (pod.pod as Box<dyn Any>).downcast::<MainPod>().unwrap();
@@ -986,7 +986,7 @@ pub mod tests {
         builder.pub_op(op!(set_contains, st, 1))?;
 
         let prover = Prover {};
-        let proof = builder.prove(&prover, &params).unwrap();
+        let proof = builder.prove(&prover).unwrap();
         let pod = (proof.pod as Box<dyn Any>).downcast::<MainPod>().unwrap();
         Ok(pod.verify()?)
     }

--- a/src/backends/plonky2/mock/mainpod.rs
+++ b/src/backends/plonky2/mock/mainpod.rs
@@ -445,7 +445,7 @@ pub mod tests {
         let kyc_builder = zu_kyc_pod_builder(&params, vd_set, &gov_id_pod, &pay_stub_pod)?;
 
         let prover = MockProver {};
-        let kyc_pod = kyc_builder.prove(&prover, &params)?;
+        let kyc_pod = kyc_builder.prove(&prover)?;
         let pod = (kyc_pod.pod as Box<dyn Any>)
             .downcast::<MockMainPod>()
             .unwrap();
@@ -465,10 +465,10 @@ pub mod tests {
 
     #[test]
     fn test_mock_main_great_boy() -> frontend::Result<()> {
-        let (params, great_boy_builder) = great_boy_pod_full_flow()?;
+        let great_boy_builder = great_boy_pod_full_flow()?;
 
         let prover = MockProver {};
-        let great_boy_pod = great_boy_builder.prove(&prover, &params)?;
+        let great_boy_pod = great_boy_builder.prove(&prover)?;
         let pod = (great_boy_pod.pod as Box<dyn Any>)
             .downcast::<MockMainPod>()
             .unwrap();
@@ -485,7 +485,7 @@ pub mod tests {
         let params = middleware::Params::default();
         let tickets_builder = tickets_pod_full_flow(&params, &MOCK_VD_SET)?;
         let prover = MockProver {};
-        let proof_pod = tickets_builder.prove(&prover, &params)?;
+        let proof_pod = tickets_builder.prove(&prover)?;
         let pod = (proof_pod.pod as Box<dyn Any>)
             .downcast::<MockMainPod>()
             .unwrap();

--- a/src/examples/mod.rs
+++ b/src/examples/mod.rs
@@ -351,7 +351,7 @@ pub fn great_boy_pod_builder(
     Ok(great_boy)
 }
 
-pub fn great_boy_pod_full_flow() -> Result<(Params, MainPodBuilder)> {
+pub fn great_boy_pod_full_flow() -> Result<MainPodBuilder> {
     let params = Params {
         max_input_signed_pods: 6,
         max_input_recursive_pods: 0,
@@ -416,7 +416,7 @@ pub fn great_boy_pod_full_flow() -> Result<(Params, MainPodBuilder)> {
         &alice,
     )?;
 
-    Ok((params, builder))
+    Ok(builder)
 }
 
 // Tickets

--- a/src/frontend/custom.rs
+++ b/src/frontend/custom.rs
@@ -312,7 +312,7 @@ mod tests {
 
         // Check that the POD builds
         let prover = MockProver {};
-        let proof = mp_builder.prove(&prover, &params)?;
+        let proof = mp_builder.prove(&prover)?;
 
         Ok(())
     }
@@ -361,7 +361,7 @@ mod tests {
         mp_builder.pub_op(op!(custom, set_contains_custom_pred, set_contains))?;
 
         let prover = MockProver {};
-        let proof = mp_builder.prove(&prover, &params)?;
+        let proof = mp_builder.prove(&prover)?;
 
         Ok(())
     }

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -553,7 +553,7 @@ impl MainPodBuilder {
         self.public_statements.push(st.clone());
     }
 
-    pub fn prove(&self, prover: &dyn PodProver, params: &Params) -> Result<MainPod> {
+    pub fn prove(&self, prover: &dyn PodProver) -> Result<MainPod> {
         let compiler = MainPodCompiler::new(&self.params);
         let inputs = MainPodCompilerInputs {
             // signed_pods: &self.input_signed_pods,
@@ -563,7 +563,7 @@ impl MainPodBuilder {
             public_statements: &self.public_statements,
         };
 
-        let (statements, operations, public_statements) = compiler.compile(inputs, params)?;
+        let (statements, operations, public_statements) = compiler.compile(inputs, &self.params)?;
 
         let inputs = MainPodInputs {
             signed_pods: &self
@@ -919,7 +919,7 @@ pub mod tests {
 
         // prove kyc with MockProver and print it
         let prover = MockProver {};
-        let kyc = kyc_builder.prove(&prover, &params)?;
+        let kyc = kyc_builder.prove(&prover)?;
 
         println!("{}", kyc);
 
@@ -955,7 +955,7 @@ pub mod tests {
         let prover = MockProver {};
 
         let alice_attestation = attest_eth_friend(&params, &alice, bob.public_key());
-        let dist_1 = helper.dist_1(&alice_attestation)?.prove(&prover, &params)?;
+        let dist_1 = helper.dist_1(&alice_attestation)?.prove(&prover)?;
         dist_1.pod.verify()?;
         let request = eth_dos_request()?;
         assert!(request.exact_match_pod(&*dist_1.pod).is_ok());
@@ -967,7 +967,7 @@ pub mod tests {
         let bob_attestation = attest_eth_friend(&params, &bob, charlie.public_key());
         let dist_2 = helper
             .dist_n_plus_1(&dist_1, &bob_attestation)?
-            .prove(&prover, &params)?;
+            .prove(&prover)?;
         dist_2.pod.verify()?;
         assert!(request.exact_match_pod(&*dist_2.pod).is_ok());
         let bindings = request.exact_match_pod(&*dist_2.pod).unwrap();
@@ -978,7 +978,7 @@ pub mod tests {
         let charlie_attestation = attest_eth_friend(&params, &charlie, david.public_key());
         let dist_3 = helper
             .dist_n_plus_1(&dist_2, &charlie_attestation)?
-            .prove(&prover, &params)?;
+            .prove(&prover)?;
         dist_3.pod.verify()?;
         assert!(request.exact_match_pod(&*dist_3.pod).is_ok());
         let bindings = request.exact_match_pod(&*dist_3.pod).unwrap();
@@ -991,7 +991,7 @@ pub mod tests {
 
     #[test]
     fn test_front_great_boy() -> Result<()> {
-        let (_, great_boy) = great_boy_pod_full_flow()?;
+        let great_boy = great_boy_pod_full_flow()?;
         println!("{}", great_boy);
 
         // TODO: prove great_boy with MockProver and print it
@@ -1055,7 +1055,7 @@ pub mod tests {
         builder.op(true, op_eq3).unwrap();
 
         let prover = MockProver {};
-        let pod = builder.prove(&prover, &params).unwrap();
+        let pod = builder.prove(&prover).unwrap();
 
         println!("{}", pod);
     }
@@ -1078,7 +1078,7 @@ pub mod tests {
         builder.pub_op(op!(gt, (&pod, "num"), 5)).unwrap();
 
         let prover = MockProver {};
-        let false_pod = builder.prove(&prover, &params).unwrap();
+        let false_pod = builder.prove(&prover).unwrap();
 
         println!("{}", builder);
         println!("{}", false_pod);
@@ -1123,7 +1123,7 @@ pub mod tests {
             ))
             .unwrap();
         let main_prover = MockProver {};
-        let main_pod = builder.prove(&main_prover, &params).unwrap();
+        let main_pod = builder.prove(&main_prover).unwrap();
 
         println!("{}", main_pod);
 
@@ -1164,7 +1164,7 @@ pub mod tests {
 
         // Prove Main POD to check.
         let main_prover = MockProver {};
-        let main_pod = builder.prove(&main_prover, &params).unwrap();
+        let main_pod = builder.prove(&main_prover).unwrap();
 
         println!("{}", main_pod);
 
@@ -1279,7 +1279,7 @@ pub mod tests {
         builder.insert(false, (st, op_new_entry.clone()));
 
         let prover = MockProver {};
-        let pod = builder.prove(&prover, &params).unwrap();
+        let pod = builder.prove(&prover).unwrap();
         pod.pod.verify().unwrap();
     }
 
@@ -1315,7 +1315,7 @@ pub mod tests {
         builder.insert(false, (st, op));
 
         let prover = MockProver {};
-        let pod = builder.prove(&prover, &params).unwrap();
+        let pod = builder.prove(&prover).unwrap();
         pod.pod.verify().unwrap();
     }
 }

--- a/src/frontend/pod_request.rs
+++ b/src/frontend/pod_request.rs
@@ -194,7 +194,7 @@ mod tests {
         let pay_stub = pay_stub.sign(&Signer(SecretKey(2u32.into()))).unwrap();
         let builder = zu_kyc_pod_builder(&Params::default(), vd_set, &gov_id, &pay_stub).unwrap();
         let prover = MockProver {};
-        let kyc = builder.prove(&prover, &params).unwrap();
+        let kyc = builder.prove(&prover).unwrap();
 
         // This request matches the POD
         let request = zu_kyc_pod_request(
@@ -231,7 +231,7 @@ mod tests {
 
         let prover = MockProver {};
 
-        let pod = builder.prove(&prover, &params).unwrap();
+        let pod = builder.prove(&prover).unwrap();
 
         println!("{pod}");
 

--- a/src/frontend/serialization.rs
+++ b/src/frontend/serialization.rs
@@ -275,7 +275,7 @@ mod tests {
         let kyc_builder = zu_kyc_pod_builder(&params, vd_set, &gov_id_pod, &pay_stub_pod).unwrap();
 
         let prover = MockProver {};
-        let kyc_pod = kyc_builder.prove(&prover, &params).unwrap();
+        let kyc_pod = kyc_builder.prove(&prover).unwrap();
         Ok(kyc_pod)
     }
 
@@ -298,7 +298,7 @@ mod tests {
         let kyc_builder = zu_kyc_pod_builder(&params, &vd_set, &gov_id_pod, &pay_stub_pod)?;
 
         let prover = Prover {};
-        let kyc_pod = kyc_builder.prove(&prover, &params)?;
+        let kyc_pod = kyc_builder.prove(&prover)?;
 
         Ok(kyc_pod)
     }
@@ -350,10 +350,10 @@ mod tests {
 
         let helper = EthDosHelper::new(&params, vd_set, true, alice.public_key())?;
         let prover = MockProver {};
-        let dist_1 = helper.dist_1(&alice_attestation)?.prove(&prover, &params)?;
+        let dist_1 = helper.dist_1(&alice_attestation)?.prove(&prover)?;
         let dist_2 = helper
             .dist_n_plus_1(&dist_1, &bob_attestation)?
-            .prove(&prover, &params)?;
+            .prove(&prover)?;
 
         Ok(dist_2)
     }


### PR DESCRIPTION
MainPodBuilder::prove takes an argument containing `params`, but the MainPodBuilder struct already has a `params` field. At best this is redundant, at worst there is the possibility of passing different `params` to the compiler than those that were used when building the operations in MainPodBuilder.

This PR removes the `params` argument and uses `self.params` instead.