### PR TITLE
Fix handling of Lt, LtEq

### DIFF
--- a/src/backends/plonky2/mainpod/mod.rs
+++ b/src/backends/plonky2/mainpod/mod.rs
@@ -1095,4 +1095,14 @@ pub mod tests {
         let std_common = &*cache_get_standard_rec_main_pod_common_circuit_data();
         assert_eq!(std_common.0, main_common.0);
     }
+
+    #[test]
+    fn test_negative_less_than_zero() -> frontend::Result<()> {
+        let params = Params::default();
+        let mut builder = MainPodBuilder::new(&params, &DEFAULT_VD_SET);
+        builder.pub_op(frontend::Operation::lt(-1, 0))?;
+        let prover = Prover {};
+        builder.prove(&prover)?;
+        Ok(())
+    }
 }

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -408,8 +408,8 @@ impl MainPodBuilder {
                         }
                     }
                     (LtFromEntries, &[a1, a2]) => {
-                        let (r1, v1) = a1.value_and_ref().ok_or_else(native_arg_error)?;
-                        let (r2, v2) = a2.value_and_ref().ok_or_else(native_arg_error)?;
+                        let (r1, v1) = a1.int_value_and_ref().ok_or_else(native_arg_error)?;
+                        let (r2, v2) = a2.int_value_and_ref().ok_or_else(native_arg_error)?;
                         if v1 < v2 {
                             Statement::lt(r1, r2)
                         } else {
@@ -417,10 +417,10 @@ impl MainPodBuilder {
                         }
                     }
                     (LtEqFromEntries, &[a1, a2]) => {
-                        let (r1, v1) = a1.value_and_ref().ok_or_else(native_arg_error)?;
-                        let (r2, v2) = a2.value_and_ref().ok_or_else(native_arg_error)?;
+                        let (r1, v1) = a1.int_value_and_ref().ok_or_else(native_arg_error)?;
+                        let (r2, v2) = a2.int_value_and_ref().ok_or_else(native_arg_error)?;
                         if v1 <= v2 {
-                            Statement::not_equal(r1, r2)
+                            Statement::lt_eq(r1, r2)
                         } else {
                             return Err(native_arg_error());
                         }

--- a/src/frontend/operation.rs
+++ b/src/frontend/operation.rs
@@ -4,7 +4,7 @@ use crate::{
     frontend::{MainPod, SignedPod},
     middleware::{
         AnchoredKey, CustomPredicateRef, NativeOperation, OperationAux, OperationType, Statement,
-        Value, ValueRef,
+        TypedValue, Value, ValueRef,
     },
 };
 
@@ -32,6 +32,13 @@ impl OperationArg {
             Self::Statement(Statement::Equal(k, ValueRef::Literal(v))) => Some((k.clone(), v)),
             _ => None,
         }
+    }
+
+    pub(crate) fn int_value_and_ref(&self) -> Option<(ValueRef, i64)> {
+        self.value_and_ref().and_then(|(r, v)| match v.typed() {
+            &TypedValue::Int(i) => Some((r, i)),
+            _ => None,
+        })
     }
 }
 

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -7,10 +7,7 @@ use hex::ToHex;
 use itertools::Itertools;
 use strum_macros::FromRepr;
 mod basetypes;
-use std::{
-    cmp::{Ordering, PartialEq, PartialOrd},
-    hash,
-};
+use std::{cmp::PartialEq, hash};
 
 use containers::{Array, Dictionary, Set};
 use schemars::JsonSchema;
@@ -254,7 +251,7 @@ impl fmt::Display for TypedValue {
             }
             TypedValue::Set(s) => {
                 write!(f, "#[")?;
-                let values: Vec<_> = s.set().iter().sorted().collect();
+                let values: Vec<_> = s.set().iter().sorted_by_key(|k| k.raw()).collect();
                 for (i, v) in values.iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;
@@ -460,18 +457,6 @@ impl PartialEq for Value {
 }
 
 impl Eq for Value {}
-
-impl PartialOrd for Value {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for Value {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.raw.cmp(&other.raw)
-    }
-}
 
 impl hash::Hash for Value {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {

--- a/src/middleware/serialization.rs
+++ b/src/middleware/serialization.rs
@@ -139,7 +139,7 @@ where
 {
     let mut set = serializer.serialize_seq(Some(value.len()))?;
     let mut sorted_values: Vec<&Value> = value.iter().collect();
-    sorted_values.sort();
+    sorted_values.sort_by_key(|v| v.raw());
     for v in sorted_values {
         set.serialize_element(v)?;
     }


### PR DESCRIPTION
Changed the middleware to only allow comparison of integers and to use the implementation of `Ord` for `i64`.  This matches the backend behavior.

Also fixed a separate bug where `LtEqFromEntries` was producing a `NotEqual` statement.

Fixes #392.