### PR TITLE
pad_circuit: use config to determine zk and check for underflow

### DIFF
--- a/src/backends/plonky2/recursion/circuit.rs
+++ b/src/backends/plonky2/recursion/circuit.rs
@@ -457,7 +457,6 @@ fn estimate_gates_after_zk(degree_bits: usize) -> usize {
 }
 
 // how many blinding gates are in this zk circuit
-#[cfg(feature = "zk")]
 fn blinding_gates(degree_bits: usize) -> usize {
     // Table data obtained using `test_measure_zk_recursion`, and printing
     // `regular_poly_openings + 2 * z_openings` at method `blind` of the file

--- a/src/backends/plonky2/recursion/circuit.rs
+++ b/src/backends/plonky2/recursion/circuit.rs
@@ -543,23 +543,28 @@ pub fn pad_circuit(builder: &mut CircuitBuilder<F, D>, common_data: &CommonCircu
     assert_eq!(common_data.num_public_inputs, builder.num_public_inputs());
 
     let degree = common_data.degree();
+    // in the zk case, account for the blinding gates, to avoid
+    // padding to them too, because then plonky2's in the builder.build()
+    // phase would add new blinding gates on top of the ones that we already
+    // accounted for in the `common_data_for_recursion`, increasing (w.h.p.)
+    // the degree of the circuit.
+    let num_blinding_gates = if common_data.config.zero_knowledge {
+        blinding_gates(log2_ceil(degree))
+    } else {
+        0
+    };
     // Need to account for public input hashing, a `PublicInputGate` and MAX_CONSTANT_GATES
     // `ConstantGate`. NOTE: the builder doesn't have any public method to see how many constants
     // have been registered, so we can't know exactly how many `ConstantGates` will be required.
     // We hope that no more than MAX_CONSTANT_GATES*2 constants are used :pray:.  Maybe we should
     // make a PR to plonky2 to expose this?
-    #[allow(unused_mut)]
-    let mut num_gates = degree - common_data.num_public_inputs.div_ceil(8) - 1 - MAX_CONSTANT_GATES;
-    #[cfg(feature = "zk")]
-    {
-        // in the zk config case, account for the blinding gates, to avoid
-        // padding to them too, because then plonky2's in the builder.build()
-        // phase would add new blinding gates on top of the ones that we already
-        // accounted for in the `common_data_for_recursion`, increasing (w.h.p.)
-        // the degree of the circuit.
-        num_gates -= blinding_gates(log2_ceil(degree));
-    }
-
+    let degree_adjustment =
+        common_data.num_public_inputs.div_ceil(8) + 1 + MAX_CONSTANT_GATES + num_blinding_gates;
+    assert!(
+        degree_adjustment <= degree,
+        "calculated a negative padding target: {degree} - {degree_adjustment}"
+    );
+    let num_gates = degree - degree_adjustment;
     assert!(
         builder.num_gates() < num_gates,
         "builder has more gates ({}) than the padding target ({})",


### PR DESCRIPTION
The `pad_circuit` function is potentially useful outside of pod2.  In order for the function to be correct when called by external code, it needs to check whether the provided `CommonCircuitData` uses zk, rather than checking if pod2 is configured to use zk.

While testing, I encountered an unfortunate issue where the `num_gates` calculation underflowed and the program kept adding gates until my system ran out of memory.  I assume that the underflow won't happen now that the function checks if the circuit is zk.  But it seems like a good idea to check for underflow anyway.