### PR TITLE
quickfix Rename some `id` to `sts_hash`

### DIFF
--- a/src/backends/plonky2/mainpod/mod.rs
+++ b/src/backends/plonky2/mainpod/mod.rs
@@ -784,7 +784,7 @@ impl Pod for MainPod {
         params: Params,
         data: serde_json::Value,
         vd_set: VDSet,
-        id: Hash,
+        sts_hash: Hash,
     ) -> Result<Self> {
         let data: Data = serde_json::from_value(data)?;
         let common = cache_get_rec_main_pod_common_circuit_data(&params);
@@ -792,7 +792,7 @@ impl Pod for MainPod {
         let verifier_only = deserialize_verifier_only(&data.verifier_only)?;
         Ok(Self {
             params,
-            sts_hash: id,
+            sts_hash,
             verifier_only,
             common_hash: data.common_hash,
             vd_set,

--- a/src/backends/plonky2/mock/emptypod.rs
+++ b/src/backends/plonky2/mock/emptypod.rs
@@ -87,11 +87,11 @@ impl Pod for MockEmptyPod {
         params: Params,
         _data: serde_json::Value,
         vd_set: VDSet,
-        id: Hash,
+        sts_hash: Hash,
     ) -> Result<Self> {
         Ok(Self {
             params,
-            sts_hash: id,
+            sts_hash,
             vd_set,
         })
     }

--- a/src/backends/plonky2/mock/mainpod.rs
+++ b/src/backends/plonky2/mock/mainpod.rs
@@ -338,7 +338,7 @@ impl Pod for MockMainPod {
         params: Params,
         data: serde_json::Value,
         vd_set: VDSet,
-        id: Hash,
+        sts_hash: Hash,
     ) -> Result<Self> {
         let Data {
             public_statements,
@@ -351,13 +351,13 @@ impl Pod for MockMainPod {
         } = serde_json::from_value(data)?;
         let input_pods = input_pods
             .into_iter()
-            .map(|(pod_type, params, id, vd_set, data)| {
-                deserialize_pod(pod_type, params, id, vd_set, data)
+            .map(|(pod_type, params, sts_hash, vd_set, data)| {
+                deserialize_pod(pod_type, params, sts_hash, vd_set, data)
             })
             .collect::<Result<Vec<_>>>()?;
         Ok(Self {
             params,
-            sts_hash: id,
+            sts_hash,
             vd_set,
             input_pods,
             public_statements,

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -136,7 +136,7 @@ impl fmt::Display for MainPodBuilder {
         writeln!(f, "MainPod:")?;
         writeln!(f, "  input_main_pods:")?;
         for in_pod in &self.input_pods {
-            writeln!(f, "    - {}", in_pod.id())?;
+            writeln!(f, "    - {}", in_pod.statements_hash())?;
         }
         writeln!(f, "  statements:")?;
         for (st, op) in self.statements.iter().zip_eq(self.operations.iter()) {
@@ -662,24 +662,8 @@ impl fmt::Display for MainPod {
 }
 
 impl MainPod {
-    pub fn id(&self) -> Hash {
+    pub fn statements_hash(&self) -> Hash {
         self.pod.statements_hash()
-    }
-
-    /// Returns the value of a Equal statement with self id that defines key if it exists.
-    pub fn get(&self, key: impl Into<Key>) -> Option<Value> {
-        let key: Key = key.into();
-        self.public_statements
-            .iter()
-            .find_map(|st| match st {
-                Statement::Equal(ValueRef::Key(ak), ValueRef::Literal(value))
-                    if ak.root == self.id() && ak.key.hash() == key.hash() =>
-                {
-                    Some(value)
-                }
-                _ => None,
-            })
-            .cloned()
     }
 }
 

--- a/src/frontend/serialization.rs
+++ b/src/frontend/serialization.rs
@@ -13,15 +13,15 @@ use crate::{
 pub struct SerializedMainPod {
     params: Params,
     pod_type: (usize, String),
-    id: Hash,
+    sts_hash: Hash,
     vd_set: VDSet,
     public_statements: Vec<Statement>,
     data: serde_json::Value,
 }
 
 impl SerializedMainPod {
-    pub fn id(&self) -> Hash {
-        self.id
+    pub fn statements_hash(&self) -> Hash {
+        self.sts_hash
     }
 }
 
@@ -31,7 +31,7 @@ impl From<MainPod> for SerializedMainPod {
         let data = pod.pod.serialize_data();
         SerializedMainPod {
             pod_type: (pod_type, pod_type_name_str.to_string()),
-            id: pod.id(),
+            sts_hash: pod.statements_hash(),
             vd_set: pod.pod.vd_set().clone(),
             params: pod.params.clone(),
             public_statements: pod.pod.pub_statements(),
@@ -47,7 +47,7 @@ impl TryFrom<SerializedMainPod> for MainPod {
         let pod = deserialize_pod(
             serialized.pod_type.0,
             serialized.params.clone(),
-            serialized.id,
+            serialized.sts_hash,
             serialized.vd_set,
             serialized.data,
         )?;

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -938,7 +938,7 @@ pub trait Pod: fmt::Debug + DynClone + Sync + Send + Any + EqualsAny {
         params: Params,
         data: serde_json::Value,
         vd_set: VDSet,
-        id: Hash,
+        sts_hash: Hash,
     ) -> Result<Self, BackendError>
     where
         Self: Sized;

--- a/src/middleware/pod_deserialization.rs
+++ b/src/middleware/pod_deserialization.rs
@@ -9,7 +9,7 @@ type DeserializeFn = fn(
     params: Params,
     data: serde_json::Value,
     vd_set: VDSet,
-    id: Hash,
+    sts_hash: Hash,
 ) -> Result<Box<dyn Pod>, BackendError>;
 
 static DESERIALIZERS: LazyLock<Mutex<HashMap<usize, DeserializeFn>>> =
@@ -25,7 +25,7 @@ pub fn register_pod_deserializer(pod_type: usize, deserialize_fn: DeserializeFn)
 pub fn deserialize_pod(
     pod_type: usize,
     params: Params,
-    id: Hash,
+    sts_hash: Hash,
     vd_set: VDSet,
     data: serde_json::Value,
 ) -> Result<Box<dyn Pod>, BackendError> {
@@ -39,7 +39,7 @@ pub fn deserialize_pod(
                 pod_type
             )))?;
 
-    deserialize_fn(params, data, vd_set, id)
+    deserialize_fn(params, data, vd_set, sts_hash)
 }
 
 #[cfg(feature = "backend_plonky2")]
@@ -56,9 +56,11 @@ mod backend {
             params: Params,
             data: serde_json::Value,
             vd_set: VDSet,
-            id: Hash,
+            sts_hash: Hash,
         ) -> Result<Box<dyn Pod>, BackendError> {
-            Ok(Box::new(P::deserialize_data(params, data, vd_set, id)?))
+            Ok(Box::new(P::deserialize_data(
+                params, data, vd_set, sts_hash,
+            )?))
         }
 
         let mut map: HashMap<usize, DeserializeFn> = HashMap::new();


### PR DESCRIPTION
I missed this changes in #394 
Renames a few instances of `id` from the old PodID to `sts_hash` (as in statements hash)