### PR TITLE
allow downstream crates to instantiate *CircuitDataSerializer

### DIFF
--- a/src/backends/plonky2/serialization.rs
+++ b/src/backends/plonky2/serialization.rs
@@ -138,7 +138,8 @@ impl WitnessGeneratorSerializer<F, D> for Pod2GeneratorSerializer {
 
 /// Helper type to serialize and deserialize the pod2 `CircuitData` using serde traits.
 #[derive(Clone)]
-pub struct CircuitDataSerializer(pub(crate) CircuitData);
+#[repr(transparent)]
+pub struct CircuitDataSerializer(pub CircuitData);
 
 impl Deref for CircuitDataSerializer {
     type Target = CircuitData;
@@ -179,6 +180,7 @@ impl<'de> Deserialize<'de> for CircuitDataSerializer {
 
 /// Helper type to serialize and deserialize the pod2 `CommonCircuitData` using serde traits.
 #[derive(Clone)]
+#[repr(transparent)]
 pub struct CommonCircuitDataSerializer(pub CommonCircuitData);
 
 impl Deref for CommonCircuitDataSerializer {
@@ -218,7 +220,8 @@ impl<'de> Deserialize<'de> for CommonCircuitDataSerializer {
 
 /// Helper type to serialize and deserialize the pod2 `VerifierCircuitData` using serde traits.
 #[derive(Clone)]
-pub struct VerifierCircuitDataSerializer(pub(crate) VerifierCircuitData);
+#[repr(transparent)]
+pub struct VerifierCircuitDataSerializer(pub VerifierCircuitData);
 
 impl Deref for VerifierCircuitDataSerializer {
     type Target = VerifierCircuitData;
@@ -258,7 +261,8 @@ impl<'de> Deserialize<'de> for VerifierCircuitDataSerializer {
 
 /// Helper type to serialize and deserialize the pod2 `VerifierOnlyCircuitData` using serde traits.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct VerifierOnlyCircuitDataSerializer(pub(crate) VerifierOnlyCircuitData);
+#[repr(transparent)]
+pub struct VerifierOnlyCircuitDataSerializer(pub VerifierOnlyCircuitData);
 
 impl Deref for VerifierOnlyCircuitDataSerializer {
     type Target = VerifierOnlyCircuitData;


### PR DESCRIPTION
Since introduction pods need to be able to serialize their verifier data, it will be useful for external crates to be able to construct an instance of `VerifierOnlyCircuitDataSerializer`.  I suppose there is not much harm in allowing the other serializers to be constructed as well.

I added the `#[repr(transparent)]` in case the user wants to convert a reference to a `VerifierOnlyCircuitData` into a reference to a `VerifierOnlyCircuitDataSerializer`.