### PR TITLE
make cache pub

### DIFF
--- a/src/cache/disk.rs
+++ b/src/cache/disk.rs
@@ -24,7 +24,7 @@ impl<T> Deref for CacheEntry<T> {
 /// Get the artifact named `name` from the disk cache.  If it doesn't exist, it will be built by
 /// calling `build_fn` and stored.
 /// The artifact is indexed by git commit first and then by `params: P` second.
-pub(crate) fn get<T: Serialize + DeserializeOwned, P: Serialize>(
+pub fn get<T: Serialize + DeserializeOwned, P: Serialize>(
     name: &str,
     params: &P,
     build_fn: fn(&P) -> T,

--- a/src/cache/mem.rs
+++ b/src/cache/mem.rs
@@ -28,7 +28,7 @@ impl<T> Deref for CacheEntry<T> {
 /// Get the artifact named `name` from the memory cache.  If it doesn't exist, it will be built by
 /// calling `build_fn` and stored.
 /// The artifact is indexed by `params: P`.
-pub(crate) fn get<T: Serialize + DeserializeOwned + Sync + 'static, P: Serialize>(
+pub fn get<T: Serialize + DeserializeOwned + Sync + 'static, P: Serialize>(
     name: &str,
     params: &P,
     build_fn: fn(&P) -> T,

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1,9 +1,9 @@
 #[cfg(feature = "disk_cache")]
 mod disk;
 #[cfg(feature = "disk_cache")]
-pub(crate) use disk::{get, CacheEntry};
+pub use disk::{get, CacheEntry};
 
 #[cfg(feature = "mem_cache")]
 mod mem;
 #[cfg(feature = "mem_cache")]
-pub(crate) use mem::{get, CacheEntry};
+pub use mem::{get, CacheEntry};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 #![feature(mapped_lock_guards)]
 
 pub mod backends;
-mod cache;
+pub mod cache;
 pub mod frontend;
 pub mod lang;
 pub mod middleware;


### PR DESCRIPTION
The cache is very useful for external libraries that have their own intro pods or wrapper circuits, so let's make it public.