### PR TITLE
Add cases to desugar function for container update ops

### DIFF
--- a/src/backends/plonky2/primitives/ec/curve.rs
+++ b/src/backends/plonky2/primitives/ec/curve.rs
@@ -97,7 +97,7 @@ fn ec_field_from_bytes(b: &[u8]) -> Result<ECField, Error> {
     Ok(QuinticExtension(array::from_fn(|i| fields[i])))
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct Point {
     pub x: ECField,
     pub u: ECField,

--- a/src/frontend/custom.rs
+++ b/src/frontend/custom.rs
@@ -98,6 +98,35 @@ impl StatementTmplBuilder {
                     args: new_args,
                 }
             }
+            Predicate::Native(NativePredicate::DictInsert) => StatementTmplBuilder {
+                predicate: Predicate::Native(NativePredicate::ContainerInsert),
+                args: self.args,
+            },
+            Predicate::Native(NativePredicate::SetInsert) => {
+                let mut new_args = self.args.clone();
+                new_args.push(self.args[2].clone());
+                StatementTmplBuilder {
+                    predicate: Predicate::Native(NativePredicate::ContainerInsert),
+                    args: new_args,
+                }
+            }
+            Predicate::Native(NativePredicate::DictUpdate)
+            | Predicate::Native(NativePredicate::ArrayUpdate) => StatementTmplBuilder {
+                predicate: Predicate::Native(NativePredicate::ContainerUpdate),
+                args: self.args,
+            },
+            Predicate::Native(NativePredicate::DictDelete) => StatementTmplBuilder {
+                predicate: Predicate::Native(NativePredicate::ContainerDelete),
+                args: self.args,
+            },
+            Predicate::Native(NativePredicate::SetDelete) => {
+                let mut new_args = self.args.clone();
+                new_args.push(self.args[2].clone());
+                StatementTmplBuilder {
+                    predicate: Predicate::Native(NativePredicate::ContainerDelete),
+                    args: new_args,
+                }
+            }
             _ => self,
         }
     }


### PR DESCRIPTION
Container update operations were previously ignored by desugar. Desugar is used by Rob's solver, so we need to update it.