### PR TITLE
Allow creation of opaque custom predicate batch

### DIFF
--- a/src/middleware/custom.rs
+++ b/src/middleware/custom.rs
@@ -404,6 +404,14 @@ impl CustomPredicateBatch {
         Arc::new(cpb)
     }
 
+    pub fn new_opaque(name: String, id: Hash) -> Arc<Self> {
+        Arc::new(Self {
+            id,
+            name,
+            predicates: vec![],
+        })
+    }
+
     /// Cryptographic identifier for the batch.
     fn calculate_id(&self, params: &Params) -> Hash {
         // NOTE: This implementation just hashes the concatenation of all the custom predicates,


### PR DESCRIPTION
This is useful for a verifier that wants to verify a MainPod that contains a custom predicate in a public statement without knowledge of how the custom predicate is defined.