### PR TITLE
chore(frontend): add max input POD check to MainPodBuilder

### DIFF
--- a/examples/main_pod_points.rs
+++ b/examples/main_pod_points.rs
@@ -148,8 +148,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Build a pod to prove the statement `over_9000("Alice")`
     let mut builder = MainPodBuilder::new(&params, vd_set);
-    builder.add_pod(pod_alice_lvl_1_points);
-    builder.add_pod(pod_alice_lvl_2_points);
+    builder.add_pod(pod_alice_lvl_1_points)?;
+    builder.add_pod(pod_alice_lvl_2_points)?;
     let st_points_total = builder.priv_op(Operation::sum_of(3512 + 5771, 3512, 5771))?;
     let st_gt_9000 = builder.priv_op(Operation::gt(3512 + 5771, 9000))?;
     let _st_over_9000 = builder.pub_op(Operation::custom(

--- a/src/examples/mod.rs
+++ b/src/examples/mod.rs
@@ -166,7 +166,7 @@ impl EthDosHelper {
         int_attestation: &SignedDict, // int signs dst
     ) -> Result<MainPodBuilder> {
         let mut pod = MainPodBuilder::new(&self.params, &self.vd_set);
-        pod.add_pod(eth_dos_src_to_int_pod.clone());
+        pod.add_pod(eth_dos_src_to_int_pod.clone())?;
 
         let eth_dos_int_to_dst = eth_dos_src_to_int_pod
             .pod

--- a/src/frontend/error.rs
+++ b/src/frontend/error.rs
@@ -35,6 +35,8 @@ pub enum InnerError {
     PodlangParse(String),
     #[error("POD Request validation error: {0}")]
     PodRequestValidation(String),
+    #[error("Too many input PODs provided: {0} were provided, but the maximum is {1}")]
+    TooManyInputPods(usize, usize),
     #[error("Too many public statements provided: {0} were provided, but the maximum is {1}")]
     TooManyPublicStatements(usize, usize),
     #[error("Too many statements provided: {0} were provided, but the maximum is {1}")]
@@ -107,6 +109,9 @@ impl Error {
     }
     pub(crate) fn pod_request_validation(e: String) -> Self {
         new!(PodRequestValidation(e))
+    }
+    pub(crate) fn too_many_input_pods(found: usize, max: usize) -> Self {
+        new!(TooManyInputPods(found, max))
     }
     pub(crate) fn too_many_public_statements(found: usize, max: usize) -> Self {
         new!(TooManyPublicStatements(found, max))

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -164,8 +164,15 @@ impl MainPodBuilder {
             dict_contains: Vec::new(),
         }
     }
-    pub fn add_pod(&mut self, pod: MainPod) {
+    pub fn add_pod(&mut self, pod: MainPod) -> Result<()> {
         self.input_pods.push(pod);
+        match self.input_pods.len() > self.params.max_input_pods {
+            true => Err(Error::too_many_input_pods(
+                self.input_pods.len(),
+                self.params.max_input_pods,
+            )),
+            _ => Ok(()),
+        }
     }
     pub fn insert(&mut self, public: bool, st_op: (Statement, Operation)) -> Result<()> {
         // TODO: Do error handling instead of panic


### PR DESCRIPTION
This PR adds a check to `MainPodBuilder` ensure that the number of input PODs does not exceed the maximum specified by the chosen parameters.