### PR TITLE
Inline AND/OR

### DIFF
--- a/examples/main_pod_points.rs
+++ b/examples/main_pod_points.rs
@@ -88,7 +88,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         game_pk = game_pk,
     );
     println!("# custom predicate batch:{}", input);
-    let batch = parse(&input, &params, &[])?.custom_batch;
+    let batch = parse(&input, &params, &[])?
+        .first_batch()
+        .expect("Expected batch")
+        .clone();
     let points_pred = batch.predicate_ref_by_name("points").unwrap();
     let over_9000_pred = batch.predicate_ref_by_name("over_9000").unwrap();
 

--- a/src/backends/plonky2/mainpod/mod.rs
+++ b/src/backends/plonky2/mainpod/mod.rs
@@ -1179,7 +1179,9 @@ pub mod tests {
             &[],
         )
         .unwrap()
-        .custom_batch;
+        .first_batch()
+        .unwrap()
+        .clone();
         let mut builder = MainPodBuilder::new(&params, &DEFAULT_VD_SET);
         let cpr = CustomPredicateRef { batch, index: 0 };
         let eq_st = builder.priv_op(frontend::Operation::eq(1, 1)).unwrap();

--- a/src/examples/custom.rs
+++ b/src/examples/custom.rs
@@ -32,7 +32,11 @@ pub fn eth_dos_batch(params: &Params) -> Result<Arc<CustomPredicateBatch>> {
             eth_dos_ind(src, dst, distance)
         )
         "#;
-    let batch = parse(input, params, &[]).expect("lang parse").custom_batch;
+    let batch = parse(input, params, &[])
+        .expect("lang parse")
+        .first_batch()
+        .expect("Expected batch")
+        .clone();
     println!("a.0. {}", batch.predicates[0]);
     println!("a.1. {}", batch.predicates[1]);
     println!("a.2. {}", batch.predicates[2]);

--- a/src/frontend/error.rs
+++ b/src/frontend/error.rs
@@ -71,6 +71,12 @@ impl From<crate::lang::LangError> for Error {
     }
 }
 
+impl From<crate::lang::MultiOperationError> for Error {
+    fn from(value: crate::lang::MultiOperationError) -> Self {
+        Error::custom(value.to_string())
+    }
+}
+
 impl Debug for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(self, f)

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -1378,7 +1378,11 @@ pub mod tests {
             Equal(b, 5)
         )
         "#;
-        let batch = parse(input, &params, &[]).unwrap().custom_batch;
+        let batch = parse(input, &params, &[])
+            .unwrap()
+            .first_batch()
+            .unwrap()
+            .clone();
         let pred_test = batch.predicate_ref_by_name("Test").unwrap();
 
         // Try to build with wrong type in 1st arg

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -1406,4 +1406,94 @@ pub mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_apply_predicate_e2e() -> Result<()> {
+        // End-to-end test of apply_predicate with MockProver
+        // Tests a split predicate being applied through the full pipeline
+        let params = Params::default();
+        let vd_set = &*MOCK_VD_SET;
+
+        // Create a predicate that will split (6 Equal statements)
+        // The predicate checks that values at different keys are equal to specific literals
+        let input = r#"
+            large_pred(A) = AND(
+                Equal(A["a"], 1)
+                Equal(A["b"], 2)
+                Equal(A["c"], 3)
+                Equal(A["d"], 4)
+                Equal(A["e"], 5)
+                Equal(A["f"], 6)
+            )
+        "#;
+
+        // Parse and batch the predicate (this handles splitting internally)
+        let parsed = parse(input, &params, &[])?;
+        let batches = &parsed.custom_batches;
+
+        // Verify it was split
+        assert!(batches.split_chain("large_pred").is_some());
+        let chain_info = batches.split_chain("large_pred").unwrap();
+        assert_eq!(chain_info.chain_pieces.len(), 2);
+        assert_eq!(chain_info.total_real_statements, 6);
+
+        // Create a signed dict with the required entries
+        let mut signed_builder = SignedDictBuilder::new(&params);
+        signed_builder.insert("a", 1);
+        signed_builder.insert("b", 2);
+        signed_builder.insert("c", 3);
+        signed_builder.insert("d", 4);
+        signed_builder.insert("e", 5);
+        signed_builder.insert("f", 6);
+        let signer = Signer(SecretKey(1u32.into()));
+        let signed_dict = signed_builder.sign(&signer)?;
+
+        // Build the main pod
+        let mut builder = MainPodBuilder::new(&params, vd_set);
+        builder.pub_op(Operation::dict_signed_by(&signed_dict))?;
+
+        // Create 6 Equal statements (one for each predicate constraint) in original order
+        // Each proves that signed_dict["x"] = n, matching the Equal(A["x"], n) template
+        let st_a = builder.priv_op(Operation::eq((&signed_dict, "a"), 1))?;
+        let st_b = builder.priv_op(Operation::eq((&signed_dict, "b"), 2))?;
+        let st_c = builder.priv_op(Operation::eq((&signed_dict, "c"), 3))?;
+        let st_d = builder.priv_op(Operation::eq((&signed_dict, "d"), 4))?;
+        let st_e = builder.priv_op(Operation::eq((&signed_dict, "e"), 5))?;
+        let st_f = builder.priv_op(Operation::eq((&signed_dict, "f"), 6))?;
+
+        // Pass statements in original declaration order
+        let statements = vec![st_a, st_b, st_c, st_d, st_e, st_f];
+
+        // Use apply_predicate to automatically wire the split chain
+        let result = batches.apply_predicate(
+            "large_pred",
+            statements,
+            true, // public
+            |public, op| {
+                if public {
+                    builder.pub_op(op)
+                } else {
+                    builder.priv_op(op)
+                }
+            },
+        )?;
+
+        // The result should be a valid statement
+        let predicate = batches.predicate_ref_by_name("large_pred").unwrap();
+        match &result {
+            Statement::Custom(pred_ref, _) => {
+                assert_eq!(pred_ref, &predicate);
+            }
+            _ => panic!("Expected Statement::Custom, got {:?}", result),
+        }
+
+        // Prove with MockProver
+        let prover = MockProver {};
+        let pod = builder.prove(&prover)?;
+
+        // Verify the pod
+        pod.pod.verify()?;
+
+        Ok(())
+    }
 }

--- a/src/lang/error.rs
+++ b/src/lang/error.rs
@@ -22,6 +22,9 @@ pub enum LangError {
 
     #[error("Lowering error: {0}")]
     Lowering(Box<LoweringError>),
+
+    #[error("Batching error: {0}")]
+    Batching(Box<BatchingError>),
 }
 
 /// Validation errors from frontend AST validation
@@ -90,14 +93,6 @@ pub enum ValidationError {
 /// Lowering errors from frontend AST lowering to middleware
 #[derive(Debug, thiserror::Error)]
 pub enum LoweringError {
-    #[error("Too many custom predicates in batch '{batch_name}': {count} exceeds limit of {max}{}", if *.original_count != *.count { format!(" (started with {} predicates before automatic splitting)", original_count) } else { String::new() })]
-    TooManyPredicates {
-        batch_name: String,
-        count: usize,
-        max: usize,
-        original_count: usize,
-    },
-
     #[error("Too many statements in predicate '{predicate}': {count} exceeds limit of {max}")]
     TooManyStatements {
         predicate: String,
@@ -126,6 +121,9 @@ pub enum LoweringError {
 
     #[error("Splitting error: {0}")]
     Splitting(#[from] SplittingError),
+
+    #[error("Batching error: {0}")]
+    Batching(#[from] BatchingError),
 
     #[error("Cannot lower document with validation errors")]
     ValidationErrors,
@@ -235,6 +233,21 @@ fn format_public_args_at_split_error(
     msg
 }
 
+/// Batching errors from multi-batch packing
+#[derive(Debug, thiserror::Error)]
+pub enum BatchingError {
+    #[error("Forward cross-batch reference: predicate '{caller}' (batch {caller_batch}) calls '{callee}' (batch {callee_batch}). Move '{callee}' earlier or '{caller}' later.")]
+    ForwardCrossBatchReference {
+        caller: String,
+        caller_batch: usize,
+        callee: String,
+        callee_batch: usize,
+    },
+
+    #[error("Internal batching error: {message}")]
+    Internal { message: String },
+}
+
 /// Splitting errors from predicate splitting
 #[derive(Debug, thiserror::Error)]
 pub enum SplittingError {
@@ -271,13 +284,6 @@ pub enum SplittingError {
         max_allowed: usize,
         suggestion: Option<Box<RefactorSuggestion>>,
     },
-
-    #[error("Too many predicates in chain for '{predicate}': {count} exceeds batch limit of {max_allowed}")]
-    TooManyPredicatesInChain {
-        predicate: String,
-        count: usize,
-        max_allowed: usize,
-    },
 }
 
 impl From<ParseError> for LangError {
@@ -301,5 +307,11 @@ impl From<ValidationError> for LangError {
 impl From<LoweringError> for LangError {
     fn from(err: LoweringError) -> Self {
         LangError::Lowering(Box::new(err))
+    }
+}
+
+impl From<BatchingError> for LangError {
+    fn from(err: BatchingError) -> Self {
+        LangError::Batching(Box::new(err))
     }
 }

--- a/src/lang/frontend_ast_batch.rs
+++ b/src/lang/frontend_ast_batch.rs
@@ -1,0 +1,636 @@
+//! Multi-batch packing for predicates
+//!
+//! This module implements packing of multiple predicates (including split chains)
+//! into multiple CustomPredicateBatches when they exceed single-batch limits.
+//!
+//! The algorithm:
+//! 1. Assign predicates to batches in declaration order (fill each before starting new)
+//! 2. Build batches in order, resolving references:
+//!    - Same batch: BatchSelf(index) - works for any intra-batch reference
+//!    - Earlier batch: Custom(CustomPredicateRef)
+//!    - Later batch: Error (forward cross-batch references not allowed)
+//!
+//! Mutual recursion within a batch is fully supported since BatchSelf references
+//! work regardless of declaration order.
+
+use std::{collections::HashMap, str::FromStr, sync::Arc};
+
+use crate::{
+    frontend::{BuilderArg, CustomPredicateBatchBuilder, StatementTmplBuilder},
+    lang::{
+        error::BatchingError,
+        frontend_ast::{AnchoredKeyPath, ConjunctionType, CustomPredicateDef, StatementTmplArg},
+    },
+    middleware::{CustomPredicateBatch, CustomPredicateRef, NativePredicate, Params, Predicate},
+};
+
+/// Container for multiple predicate batches
+#[derive(Debug, Clone)]
+pub struct PredicateBatches {
+    batches: Vec<Arc<CustomPredicateBatch>>,
+    /// Maps predicate name to (batch_index, predicate_index_within_batch)
+    predicate_index: HashMap<String, (usize, usize)>,
+}
+
+impl Default for PredicateBatches {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PredicateBatches {
+    pub fn new() -> Self {
+        Self {
+            batches: Vec::new(),
+            predicate_index: HashMap::new(),
+        }
+    }
+
+    /// Get a reference to a predicate by name
+    pub fn predicate_ref_by_name(&self, name: &str) -> Option<CustomPredicateRef> {
+        let (batch_idx, pred_idx) = self.predicate_index.get(name)?;
+        let batch = self.batches.get(*batch_idx)?;
+        Some(CustomPredicateRef::new(batch.clone(), *pred_idx))
+    }
+
+    /// Get all batches
+    pub fn batches(&self) -> &[Arc<CustomPredicateBatch>] {
+        &self.batches
+    }
+
+    /// Get the first batch (for backwards compatibility)
+    pub fn first_batch(&self) -> Option<&Arc<CustomPredicateBatch>> {
+        self.batches.first()
+    }
+
+    /// Get batch count
+    pub fn batch_count(&self) -> usize {
+        self.batches.len()
+    }
+
+    /// Check if empty
+    pub fn is_empty(&self) -> bool {
+        self.batches.is_empty()
+    }
+
+    /// Total predicate count across all batches
+    pub fn total_predicate_count(&self) -> usize {
+        self.batches.iter().map(|b| b.predicates().len()).sum()
+    }
+}
+
+/// Assignment of a predicate to a batch
+#[derive(Debug, Clone)]
+struct PredicateAssignment {
+    /// Full name (e.g., "my_pred_1" for split link)
+    full_name: String,
+    /// Which batch this goes into
+    batch_index: usize,
+    /// Index within that batch
+    index_in_batch: usize,
+}
+
+/// Information about an imported predicate for use during batching
+#[derive(Debug, Clone)]
+pub struct ImportedPredicateInfo {
+    pub batch: Arc<CustomPredicateBatch>,
+    pub index: usize,
+}
+
+/// Pack predicates into multiple batches
+///
+/// Takes a list of predicates (already split if needed) and packs them into
+/// batches, handling cross-batch references correctly.
+///
+/// Predicates are assigned to batches in declaration order. Within a batch,
+/// predicates can reference each other freely via BatchSelf. Cross-batch
+/// references must point to earlier batches (forward cross-batch references
+/// are an error).
+///
+/// `imported_predicates` maps predicate names to their imported batch info,
+/// allowing predicates to call imported predicates from other batches.
+pub fn batch_predicates(
+    predicates: Vec<CustomPredicateDef>,
+    params: &Params,
+    base_batch_name: &str,
+    imported_predicates: &HashMap<String, ImportedPredicateInfo>,
+) -> Result<PredicateBatches, BatchingError> {
+    if predicates.is_empty() {
+        return Ok(PredicateBatches::new());
+    }
+
+    // Plan batch assignments in declaration order
+    let assignments = plan_batch_assignments(&predicates, params.max_custom_batch_size);
+
+    // Build reference map: name -> (batch_idx, idx_in_batch)
+    let reference_map: HashMap<String, (usize, usize)> = assignments
+        .iter()
+        .map(|a| (a.full_name.clone(), (a.batch_index, a.index_in_batch)))
+        .collect();
+
+    // Determine number of batches
+    let num_batches = assignments
+        .iter()
+        .map(|a| a.batch_index)
+        .max()
+        .map(|m| m + 1)
+        .unwrap_or(0);
+
+    // Build batches in order
+    let mut batches = Vec::new();
+    let mut predicate_index = HashMap::new();
+
+    for batch_idx in 0..num_batches {
+        // Collect predicates for this batch (in assignment order)
+        let batch_predicates: Vec<_> = predicates
+            .iter()
+            .zip(assignments.iter())
+            .filter(|(_, a)| a.batch_index == batch_idx)
+            .map(|(p, _)| p.clone())
+            .collect();
+
+        let batch_name = if num_batches == 1 {
+            base_batch_name.to_string()
+        } else {
+            format!("{}_{}", base_batch_name, batch_idx)
+        };
+
+        let batch = build_single_batch(
+            &batch_predicates,
+            batch_idx,
+            &reference_map,
+            &batches,
+            imported_predicates,
+            params,
+            &batch_name,
+        )?;
+
+        // Update predicate index
+        for (idx, pred) in batch_predicates.iter().enumerate() {
+            predicate_index.insert(pred.name.name.clone(), (batch_idx, idx));
+        }
+
+        batches.push(batch);
+    }
+
+    Ok(PredicateBatches {
+        batches,
+        predicate_index,
+    })
+}
+
+/// Plan batch assignments (greedy fill in declaration order)
+fn plan_batch_assignments(
+    predicates: &[CustomPredicateDef],
+    max_batch_size: usize,
+) -> Vec<PredicateAssignment> {
+    let mut assignments = Vec::new();
+    let mut current_batch = 0;
+    let mut current_batch_count = 0;
+
+    for pred in predicates {
+        if current_batch_count >= max_batch_size {
+            current_batch += 1;
+            current_batch_count = 0;
+        }
+
+        assignments.push(PredicateAssignment {
+            full_name: pred.name.name.clone(),
+            batch_index: current_batch,
+            index_in_batch: current_batch_count,
+        });
+
+        current_batch_count += 1;
+    }
+
+    assignments
+}
+
+/// Build a single batch with properly resolved references
+fn build_single_batch(
+    predicates: &[CustomPredicateDef],
+    batch_idx: usize,
+    reference_map: &HashMap<String, (usize, usize)>,
+    existing_batches: &[Arc<CustomPredicateBatch>],
+    imported_predicates: &HashMap<String, ImportedPredicateInfo>,
+    params: &Params,
+    batch_name: &str,
+) -> Result<Arc<CustomPredicateBatch>, BatchingError> {
+    let mut builder = CustomPredicateBatchBuilder::new(params.clone(), batch_name.to_string());
+
+    for pred in predicates {
+        let name = &pred.name.name;
+
+        // Collect argument names
+        let public_args: Vec<&str> = pred
+            .args
+            .public_args
+            .iter()
+            .map(|a| a.name.as_str())
+            .collect();
+
+        let private_args: Vec<&str> = pred
+            .args
+            .private_args
+            .as_ref()
+            .map(|args| args.iter().map(|a| a.name.as_str()).collect())
+            .unwrap_or_default();
+
+        // Build statement templates with resolved predicates
+        let statement_builders: Vec<StatementTmplBuilder> = pred
+            .statements
+            .iter()
+            .map(|stmt| {
+                build_statement_with_resolved_refs(
+                    stmt,
+                    name,
+                    batch_idx,
+                    reference_map,
+                    existing_batches,
+                    imported_predicates,
+                )
+            })
+            .collect::<Result<_, _>>()?;
+
+        let conjunction = pred.conjunction_type == ConjunctionType::And;
+
+        builder
+            .predicate(
+                name,
+                conjunction,
+                &public_args,
+                &private_args,
+                &statement_builders,
+            )
+            .map_err(|e| BatchingError::Internal {
+                message: format!("Failed to add predicate '{}': {}", name, e),
+            })?;
+    }
+
+    Ok(builder.finish())
+}
+
+/// Build a statement template with properly resolved predicate references
+fn build_statement_with_resolved_refs(
+    stmt: &crate::lang::frontend_ast::StatementTmpl,
+    caller_name: &str,
+    current_batch_idx: usize,
+    reference_map: &HashMap<String, (usize, usize)>,
+    existing_batches: &[Arc<CustomPredicateBatch>],
+    imported_predicates: &HashMap<String, ImportedPredicateInfo>,
+) -> Result<StatementTmplBuilder, BatchingError> {
+    let callee_name = &stmt.predicate.name;
+
+    // Resolve the predicate
+    let predicate = if let Ok(native) = NativePredicate::from_str(callee_name) {
+        Predicate::Native(native)
+    } else if let Some(&(target_batch, target_idx)) = reference_map.get(callee_name) {
+        // Local predicate in this document
+        if target_batch == current_batch_idx {
+            // Same batch - use BatchSelf
+            Predicate::BatchSelf(target_idx)
+        } else if target_batch < current_batch_idx {
+            // Earlier batch - use Custom ref
+            let batch = &existing_batches[target_batch];
+            Predicate::Custom(CustomPredicateRef::new(batch.clone(), target_idx))
+        } else {
+            // Forward reference to later batch - error
+            return Err(BatchingError::ForwardCrossBatchReference {
+                caller: caller_name.to_string(),
+                caller_batch: current_batch_idx,
+                callee: callee_name.to_string(),
+                callee_batch: target_batch,
+            });
+        }
+    } else if let Some(imported) = imported_predicates.get(callee_name) {
+        // Imported predicate from another batch
+        Predicate::Custom(CustomPredicateRef::new(
+            imported.batch.clone(),
+            imported.index,
+        ))
+    } else {
+        // Unknown predicate
+        return Err(BatchingError::Internal {
+            message: format!("Unknown predicate reference: '{}'", callee_name),
+        });
+    };
+
+    // Build the statement template
+    let mut builder = StatementTmplBuilder::new(predicate);
+
+    for arg in &stmt.args {
+        let builder_arg = match arg {
+            StatementTmplArg::Literal(lit) => {
+                let value = lower_literal(lit)?;
+                BuilderArg::Literal(value)
+            }
+            StatementTmplArg::Wildcard(id) => BuilderArg::WildcardLiteral(id.name.clone()),
+            StatementTmplArg::AnchoredKey(ak) => {
+                let key_str = match &ak.key {
+                    AnchoredKeyPath::Bracket(s) => s.value.clone(),
+                    AnchoredKeyPath::Dot(id) => id.name.clone(),
+                };
+                BuilderArg::Key(ak.root.name.clone(), key_str)
+            }
+        };
+        builder = builder.arg(builder_arg);
+    }
+
+    Ok(builder)
+}
+
+/// Lower a literal value to middleware Value
+fn lower_literal(
+    lit: &crate::lang::frontend_ast::LiteralValue,
+) -> Result<crate::middleware::Value, BatchingError> {
+    use crate::{
+        lang::frontend_ast::LiteralValue,
+        middleware::{containers, Value},
+    };
+
+    let value = match lit {
+        LiteralValue::Int(i) => Value::from(i.value),
+        LiteralValue::Bool(b) => Value::from(b.value),
+        LiteralValue::String(s) => Value::from(s.value.clone()),
+        LiteralValue::Raw(r) => Value::from(r.hash.hash),
+        LiteralValue::PublicKey(pk) => Value::from(pk.point),
+        LiteralValue::SecretKey(sk) => Value::from(sk.secret_key.clone()),
+        LiteralValue::Array(a) => {
+            let elements: Result<Vec<_>, _> = a.elements.iter().map(lower_literal).collect();
+            let array = containers::Array::new(elements?);
+            Value::from(array)
+        }
+        LiteralValue::Set(s) => {
+            let elements: Result<Vec<_>, _> = s.elements.iter().map(lower_literal).collect();
+            let set_values: std::collections::HashSet<_> = elements?.into_iter().collect();
+            let set = containers::Set::new(set_values);
+            Value::from(set)
+        }
+        LiteralValue::Dict(d) => {
+            let pairs: Result<Vec<_>, BatchingError> = d
+                .pairs
+                .iter()
+                .map(|pair| {
+                    let key = crate::middleware::Key::from(pair.key.value.as_str());
+                    let value = lower_literal(&pair.value)?;
+                    Ok((key, value))
+                })
+                .collect();
+            let dict_map: std::collections::HashMap<_, _> = pairs?.into_iter().collect();
+            let dict = containers::Dictionary::new(dict_map);
+            Value::from(dict)
+        }
+    };
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lang::{
+        frontend_ast::parse::parse_document, frontend_ast_split::split_predicate_if_needed,
+        parser::parse_podlang,
+    };
+
+    fn parse_predicates(input: &str) -> Vec<CustomPredicateDef> {
+        let parsed = parse_podlang(input).expect("Failed to parse");
+        let document = parse_document(parsed.into_iter().next().unwrap()).expect("Failed to parse");
+
+        document
+            .items
+            .into_iter()
+            .filter_map(|item| match item {
+                crate::lang::frontend_ast::DocumentItem::CustomPredicateDef(pred) => Some(pred),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_single_predicate_single_batch() {
+        let input = r#"
+            my_pred(A, B) = AND(
+                Equal(A["x"], B["y"])
+            )
+        "#;
+
+        let predicates = parse_predicates(input);
+        let params = Params::default();
+
+        let result = batch_predicates(predicates, &params, "TestBatch", &HashMap::new());
+        assert!(result.is_ok());
+
+        let batches = result.unwrap();
+        assert_eq!(batches.batch_count(), 1);
+        assert_eq!(batches.total_predicate_count(), 1);
+    }
+
+    #[test]
+    fn test_multiple_predicates_single_batch() {
+        let input = r#"
+            pred1(A) = AND(Equal(A["x"], 1))
+            pred2(B) = AND(Equal(B["y"], 2))
+            pred3(C) = AND(Equal(C["z"], 3))
+        "#;
+
+        let predicates = parse_predicates(input);
+        let params = Params::default(); // max_custom_batch_size = 4
+
+        let result = batch_predicates(predicates, &params, "TestBatch", &HashMap::new());
+        assert!(result.is_ok());
+
+        let batches = result.unwrap();
+        assert_eq!(batches.batch_count(), 1);
+        assert_eq!(batches.total_predicate_count(), 3);
+    }
+
+    #[test]
+    fn test_predicates_span_multiple_batches() {
+        let input = r#"
+            pred1(A) = AND(Equal(A["x"], 1))
+            pred2(B) = AND(Equal(B["y"], 2))
+            pred3(C) = AND(Equal(C["z"], 3))
+            pred4(D) = AND(Equal(D["w"], 4))
+            pred5(E) = AND(Equal(E["v"], 5))
+        "#;
+
+        let predicates = parse_predicates(input);
+        let params = Params::default(); // max_custom_batch_size = 4
+
+        let result = batch_predicates(predicates, &params, "TestBatch", &HashMap::new());
+        assert!(result.is_ok());
+
+        let batches = result.unwrap();
+        assert_eq!(batches.batch_count(), 2);
+        assert_eq!(batches.total_predicate_count(), 5);
+
+        // First batch should have 4 predicates
+        assert_eq!(batches.batches()[0].predicates().len(), 4);
+        // Second batch should have 1 predicate
+        assert_eq!(batches.batches()[1].predicates().len(), 1);
+    }
+
+    #[test]
+    fn test_intra_batch_forward_reference() {
+        // pred2 calls pred1, but pred2 is declared first
+        // This should work because they're in the same batch
+        let input = r#"
+            pred2(B) = AND(pred1(B))
+            pred1(A) = AND(Equal(A["x"], 1))
+        "#;
+
+        let predicates = parse_predicates(input);
+        let params = Params::default();
+
+        let result = batch_predicates(predicates, &params, "TestBatch", &HashMap::new());
+        assert!(result.is_ok());
+
+        let batches = result.unwrap();
+        assert_eq!(batches.batch_count(), 1);
+
+        // pred2 should reference pred1 via BatchSelf
+        let pred2 = &batches.batches()[0].predicates()[0];
+        let stmt = &pred2.statements[0];
+        assert!(matches!(stmt.pred(), Predicate::BatchSelf(1))); // pred1 is at index 1
+    }
+
+    #[test]
+    fn test_mutual_recursion_in_same_batch() {
+        // pred1 calls pred2, pred2 calls pred1 - mutual recursion
+        // This should work because they're in the same batch
+        let input = r#"
+            pred1(A) = AND(pred2(A))
+            pred2(B) = AND(pred1(B))
+        "#;
+
+        let predicates = parse_predicates(input);
+        let params = Params::default();
+
+        let result = batch_predicates(predicates, &params, "TestBatch", &HashMap::new());
+        assert!(result.is_ok());
+
+        let batches = result.unwrap();
+        assert_eq!(batches.batch_count(), 1);
+        assert_eq!(batches.total_predicate_count(), 2);
+
+        // Both should use BatchSelf references
+        let pred1 = &batches.batches()[0].predicates()[0];
+        let pred2 = &batches.batches()[0].predicates()[1];
+        assert!(matches!(
+            pred1.statements[0].pred(),
+            Predicate::BatchSelf(1)
+        )); // calls pred2
+        assert!(matches!(
+            pred2.statements[0].pred(),
+            Predicate::BatchSelf(0)
+        )); // calls pred1
+    }
+
+    #[test]
+    fn test_cross_batch_reference() {
+        // 5 predicates where pred5 calls pred1
+        // pred1-4 go in batch 0, pred5 in batch 1
+        // pred5's call to pred1 should be a cross-batch reference
+        let input = r#"
+            pred1(A) = AND(Equal(A["x"], 1))
+            pred2(B) = AND(Equal(B["y"], 2))
+            pred3(C) = AND(Equal(C["z"], 3))
+            pred4(D) = AND(Equal(D["w"], 4))
+            pred5(E) = AND(pred1(E))
+        "#;
+
+        let predicates = parse_predicates(input);
+        let params = Params::default(); // max_custom_batch_size = 4
+
+        let result = batch_predicates(predicates, &params, "TestBatch", &HashMap::new());
+        assert!(result.is_ok());
+
+        let batches = result.unwrap();
+        assert_eq!(batches.batch_count(), 2);
+
+        // pred5 should reference pred1 via CustomPredicateRef
+        let pred5_batch = &batches.batches()[1];
+        let pred5 = &pred5_batch.predicates()[0];
+        let pred5_stmt = &pred5.statements[0];
+
+        // The predicate should be a Custom reference to batch 0
+        match pred5_stmt.pred() {
+            Predicate::Custom(ref_) => {
+                // Should reference batch 0, index 0 (pred1)
+                assert_eq!(ref_.batch.id(), batches.batches()[0].id());
+            }
+            _ => panic!("Expected Custom predicate reference"),
+        }
+    }
+
+    #[test]
+    fn test_split_chain_spans_batches() {
+        // Create a predicate that will split into 2-3 predicates
+        // Then add more predicates to force the chain to span batches
+        let input = r#"
+            pred1(A) = AND(Equal(A["x"], 1))
+            pred2(B) = AND(Equal(B["y"], 2))
+            pred3(C) = AND(Equal(C["z"], 3))
+            large_pred(D) = AND(
+                Equal(D["a"], 1)
+                Equal(D["b"], 2)
+                Equal(D["c"], 3)
+                Equal(D["d"], 4)
+                Equal(D["e"], 5)
+                Equal(D["f"], 6)
+            )
+        "#;
+
+        let predicates = parse_predicates(input);
+        let params = Params::default();
+
+        // Split the large predicate
+        let mut all_predicates = Vec::new();
+        for pred in predicates {
+            let chain = split_predicate_if_needed(pred, &params).expect("Split failed");
+            all_predicates.extend(chain);
+        }
+
+        // We should have: pred1, pred2, pred3, large_pred, large_pred_1
+        // That's 5 predicates, which spans 2 batches
+        assert_eq!(all_predicates.len(), 5);
+
+        let result = batch_predicates(all_predicates, &params, "TestBatch", &HashMap::new());
+        assert!(result.is_ok());
+
+        let batches = result.unwrap();
+        assert_eq!(batches.batch_count(), 2);
+        assert_eq!(batches.total_predicate_count(), 5);
+    }
+
+    #[test]
+    fn test_empty_input() {
+        let predicates: Vec<CustomPredicateDef> = vec![];
+        let params = Params::default();
+
+        let result = batch_predicates(predicates, &params, "TestBatch", &HashMap::new());
+        assert!(result.is_ok());
+
+        let batches = result.unwrap();
+        assert!(batches.is_empty());
+        assert_eq!(batches.batch_count(), 0);
+    }
+
+    #[test]
+    fn test_predicate_ref_by_name() {
+        let input = r#"
+            pred1(A) = AND(Equal(A["x"], 1))
+            pred2(B) = AND(Equal(B["y"], 2))
+        "#;
+
+        let predicates = parse_predicates(input);
+        let params = Params::default();
+
+        let batches = batch_predicates(predicates, &params, "TestBatch", &HashMap::new()).unwrap();
+
+        // Should be able to look up both predicates
+        assert!(batches.predicate_ref_by_name("pred1").is_some());
+        assert!(batches.predicate_ref_by_name("pred2").is_some());
+        assert!(batches.predicate_ref_by_name("nonexistent").is_none());
+    }
+}

--- a/src/lang/frontend_ast_batch.rs
+++ b/src/lang/frontend_ast_batch.rs
@@ -503,7 +503,8 @@ fn build_statement_with_resolved_refs(
     existing_batches: &[Arc<CustomPredicateBatch>],
     imported_predicates: &HashMap<String, ImportedPredicateInfo>,
 ) -> Result<StatementTmplBuilder, BatchingError> {
-    let callee_name = &stmt.predicate.name;
+    let (predicate_id, args) = stmt.expect_call();
+    let callee_name = &predicate_id.name;
 
     // Resolve the predicate
     let predicate = if let Ok(native) = NativePredicate::from_str(callee_name) {
@@ -542,7 +543,7 @@ fn build_statement_with_resolved_refs(
     // Build the statement template
     let mut builder = StatementTmplBuilder::new(predicate);
 
-    for arg in &stmt.args {
+    for arg in args {
         let builder_arg = match arg {
             StatementTmplArg::Literal(lit) => {
                 let value = lower_literal(lit)?;
@@ -863,7 +864,12 @@ mod tests {
         // That's 5 predicates, which spans 2 batches
         assert_eq!(total_preds, 5);
 
-        let result = batch_predicates(all_split_results, &params, "TestBatch", &HashMap::new());
+        let result = batch_predicates(
+            all_split_results,
+            &params,
+            "TestBatch",
+            &HashMap::new(),
+        );
         assert!(result.is_ok());
 
         let batches = result.unwrap();
@@ -883,7 +889,12 @@ mod tests {
         let split_results: Vec<SplitResult> = vec![];
         let params = Params::default();
 
-        let result = batch_predicates(split_results, &params, "TestBatch", &HashMap::new());
+        let result = batch_predicates(
+            split_results,
+            &params,
+            "TestBatch",
+            &HashMap::new(),
+        );
         assert!(result.is_ok());
 
         let batches = result.unwrap();
@@ -1001,8 +1012,13 @@ mod tests {
         assert_eq!(split_results[0].predicates.len(), 2);
         assert!(split_results[0].chain_info.is_some());
 
-        let batches = batch_predicates(split_results, &params, "TestBatch", &HashMap::new())
-            .expect("Batch failed");
+        let batches = batch_predicates(
+            split_results,
+            &params,
+            "TestBatch",
+            &HashMap::new(),
+        )
+        .expect("Batch failed");
 
         // Verify chain info
         let chain_info = batches.split_chain("large_pred").unwrap();
@@ -1065,8 +1081,13 @@ mod tests {
         assert_eq!(split_results[0].predicates.len(), 3);
         assert!(split_results[0].chain_info.is_some());
 
-        let batches = batch_predicates(split_results, &params, "TestBatch", &HashMap::new())
-            .expect("Batch failed");
+        let batches = batch_predicates(
+            split_results,
+            &params,
+            "TestBatch",
+            &HashMap::new(),
+        )
+        .expect("Batch failed");
 
         // Verify chain info
         let chain_info = batches.split_chain("very_large_pred").unwrap();
@@ -1121,8 +1142,13 @@ mod tests {
             split_results.push(result);
         }
 
-        let batches = batch_predicates(split_results, &params, "TestBatch", &HashMap::new())
-            .expect("Batch failed");
+        let batches = batch_predicates(
+            split_results,
+            &params,
+            "TestBatch",
+            &HashMap::new(),
+        )
+        .expect("Batch failed");
 
         // Try with wrong number of statements (3 instead of 6)
         let statements: Vec<Statement> = (0..3).map(test_statement).collect();
@@ -1200,8 +1226,13 @@ mod tests {
             split_results.push(result);
         }
 
-        let batches = batch_predicates(split_results, &params, "TestBatch", &HashMap::new())
-            .expect("Batch failed");
+        let batches = batch_predicates(
+            split_results,
+            &params,
+            "TestBatch",
+            &HashMap::new(),
+        )
+        .expect("Batch failed");
 
         let statements: Vec<Statement> = (0..6).map(test_statement).collect();
 

--- a/src/lang/frontend_ast_lift.rs
+++ b/src/lang/frontend_ast_lift.rs
@@ -1,0 +1,392 @@
+//! Lifting pass for anonymous inline predicates
+//!
+//! This module transforms inline conjunctions (AND/OR blocks within predicate bodies)
+//! into separate anonymous predicates. This is necessary because the middleware
+//! `CustomPredicate` can only have a single conjunction type (AND or OR).
+//!
+//! Example transformation:
+//! ```text
+//! some_pred(A, B) = AND(
+//!     AND(
+//!         Equal(A["foo"], 123)
+//!     )
+//!     Equal(A["bar"], B)
+//! )
+//! ```
+//!
+//! Becomes:
+//! ```text
+//! some_pred$anon_0(A) = AND(
+//!     Equal(A["foo"], 123)
+//! )
+//!
+//! some_pred(A, B) = AND(
+//!     some_pred$anon_0(A)
+//!     Equal(A["bar"], B)
+//! )
+//! ```
+
+use std::collections::HashSet;
+
+use super::frontend_ast::{
+    ArgSection, CustomPredicateDef, Identifier, StatementTmpl, StatementTmplArg, StatementTmplKind,
+};
+
+/// Lifts inline conjunctions to anonymous predicates
+pub struct AnonPredicateLifter {
+    /// Counter for generating unique names
+    counter: usize,
+    /// Generated anonymous predicates (in dependency order - inner predicates first)
+    generated: Vec<CustomPredicateDef>,
+}
+
+impl AnonPredicateLifter {
+    /// Create a new lifter
+    fn new() -> Self {
+        Self {
+            counter: 0,
+            generated: Vec::new(),
+        }
+    }
+
+    /// Lift all inline conjunctions in the given predicates.
+    /// Returns predicates in dependency order (anonymous first).
+    pub fn lift_predicates(predicates: Vec<CustomPredicateDef>) -> Vec<CustomPredicateDef> {
+        let mut lifter = Self::new();
+        let mut result = Vec::new();
+
+        for pred in predicates {
+            let transformed = lifter.transform_predicate(pred);
+            result.push(transformed);
+        }
+
+        // Anonymous predicates come first (they're already in dependency order from DFS)
+        let mut final_predicates = lifter.generated;
+        final_predicates.extend(result);
+
+        final_predicates
+    }
+
+    /// Transform a single predicate, lifting any inline conjunctions in its statements.
+    fn transform_predicate(&mut self, pred: CustomPredicateDef) -> CustomPredicateDef {
+        let parent_name = pred.name.name.clone();
+
+        // Collect all wildcards in scope (both public and private)
+        let wildcards_in_scope: HashSet<String> = {
+            let mut set: HashSet<String> = pred
+                .args
+                .public_args
+                .iter()
+                .map(|id| id.name.clone())
+                .collect();
+            if let Some(private_args) = &pred.args.private_args {
+                set.extend(private_args.iter().map(|id| id.name.clone()));
+            }
+            set
+        };
+
+        // Transform statements
+        let new_statements: Vec<StatementTmpl> = pred
+            .statements
+            .into_iter()
+            .map(|stmt| self.transform_statement(stmt, &parent_name, &wildcards_in_scope))
+            .collect();
+
+        CustomPredicateDef {
+            name: pred.name,
+            args: pred.args,
+            conjunction_type: pred.conjunction_type,
+            statements: new_statements,
+            span: pred.span,
+        }
+    }
+
+    /// Transform a single statement, lifting inline conjunctions to anonymous predicates.
+    fn transform_statement(
+        &mut self,
+        stmt: StatementTmpl,
+        parent_name: &str,
+        wildcards_in_scope: &HashSet<String>,
+    ) -> StatementTmpl {
+        match stmt.kind {
+            StatementTmplKind::Call { .. } => {
+                // Regular call - no transformation needed
+                stmt
+            }
+            StatementTmplKind::InlineConjunction {
+                conjunction_type,
+                statements,
+            } => {
+                // Generate unique name for anonymous predicate
+                let anon_name = self.generate_name(parent_name);
+
+                // Collect all wildcards used in this inline conjunction
+                let used_wildcards = collect_wildcards_from_statements(&statements);
+
+                // Filter to only wildcards that are in scope
+                let mut anon_args: Vec<String> = used_wildcards
+                    .iter()
+                    .filter(|w| wildcards_in_scope.contains(*w))
+                    .cloned()
+                    .collect();
+                // Sort for deterministic ordering
+                anon_args.sort();
+
+                // Build the set of wildcards in scope for the anonymous predicate
+                let anon_scope: HashSet<String> = anon_args.iter().cloned().collect();
+
+                // Recursively transform nested statements
+                let transformed_statements: Vec<StatementTmpl> = statements
+                    .into_iter()
+                    .map(|s| self.transform_statement(s, &anon_name, &anon_scope))
+                    .collect();
+
+                // Create anonymous predicate with public-only args
+                let anon_pred = CustomPredicateDef {
+                    name: Identifier {
+                        name: anon_name.clone(),
+                        span: None,
+                    },
+                    args: ArgSection {
+                        public_args: anon_args
+                            .iter()
+                            .map(|name| Identifier {
+                                name: name.clone(),
+                                span: None,
+                            })
+                            .collect(),
+                        private_args: None, // Anonymous predicates have no private args
+                        span: None,
+                    },
+                    conjunction_type,
+                    statements: transformed_statements,
+                    span: None,
+                };
+
+                // Add to generated predicates (inner predicates are added first due to DFS)
+                self.generated.push(anon_pred);
+
+                // Replace inline conjunction with call to anonymous predicate
+                let call_args: Vec<StatementTmplArg> = anon_args
+                    .iter()
+                    .map(|name| {
+                        StatementTmplArg::Wildcard(Identifier {
+                            name: name.clone(),
+                            span: None,
+                        })
+                    })
+                    .collect();
+
+                StatementTmpl::call(
+                    Identifier {
+                        name: anon_name,
+                        span: None,
+                    },
+                    call_args,
+                    stmt.span,
+                )
+            }
+        }
+    }
+
+    /// Generate a unique name for an anonymous predicate
+    fn generate_name(&mut self, parent_name: &str) -> String {
+        let name = format!("{}$anon_{}", parent_name, self.counter);
+        self.counter += 1;
+        name
+    }
+}
+
+/// Collect all wildcard names from a list of statements
+fn collect_wildcards_from_statements(statements: &[StatementTmpl]) -> HashSet<String> {
+    let mut wildcards = HashSet::new();
+    for stmt in statements {
+        collect_wildcards_from_statement_recursive(stmt, &mut wildcards);
+    }
+    wildcards
+}
+
+/// Recursively collect wildcards from a statement (including nested inline conjunctions)
+fn collect_wildcards_from_statement_recursive(
+    stmt: &StatementTmpl,
+    wildcards: &mut HashSet<String>,
+) {
+    match &stmt.kind {
+        StatementTmplKind::Call { args, .. } => {
+            for arg in args {
+                match arg {
+                    StatementTmplArg::Wildcard(id) => {
+                        wildcards.insert(id.name.clone());
+                    }
+                    StatementTmplArg::AnchoredKey(ak) => {
+                        wildcards.insert(ak.root.name.clone());
+                    }
+                    StatementTmplArg::Literal(_) => {}
+                }
+            }
+        }
+        StatementTmplKind::InlineConjunction { statements, .. } => {
+            for inner_stmt in statements {
+                collect_wildcards_from_statement_recursive(inner_stmt, wildcards);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lang::{
+        frontend_ast::{parse, ConjunctionType},
+        parser::parse_podlang,
+    };
+
+    fn parse_predicates(input: &str) -> Vec<CustomPredicateDef> {
+        let parsed = parse_podlang(input).expect("Failed to parse");
+        let doc =
+            parse::parse_document(parsed.into_iter().next().unwrap()).expect("Failed to parse");
+        doc.items
+            .into_iter()
+            .filter_map(|item| {
+                if let crate::lang::frontend_ast::DocumentItem::CustomPredicateDef(pred) = item {
+                    Some(pred)
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_no_inline_conjunctions() {
+        let input = r#"
+            simple_pred(A, B) = AND(
+                Equal(A["foo"], 123)
+                Equal(A["bar"], B)
+            )
+        "#;
+
+        let predicates = parse_predicates(input);
+        let result = AnonPredicateLifter::lift_predicates(predicates);
+
+        // No inline conjunctions, so no anonymous predicates generated
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name.name, "simple_pred");
+    }
+
+    #[test]
+    fn test_simple_inline_and() {
+        let input = r#"
+            my_pred(A, B) = AND(
+                AND(
+                    Equal(A["foo"], 123)
+                )
+                Equal(A["bar"], B)
+            )
+        "#;
+
+        let predicates = parse_predicates(input);
+        let result = AnonPredicateLifter::lift_predicates(predicates);
+
+        // Should generate 2 predicates: anon first, then original
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].name.name, "my_pred$anon_0");
+        assert_eq!(result[1].name.name, "my_pred");
+
+        // Anonymous predicate should have 1 statement
+        assert_eq!(result[0].statements.len(), 1);
+        // And should have A as its only public arg
+        assert_eq!(result[0].args.public_args.len(), 1);
+        assert_eq!(result[0].args.public_args[0].name, "A");
+
+        // Original predicate should have 2 statements
+        assert_eq!(result[1].statements.len(), 2);
+        // First statement should be call to anonymous predicate
+        assert_eq!(
+            result[1].statements[0].predicate().unwrap().name,
+            "my_pred$anon_0"
+        );
+    }
+
+    #[test]
+    fn test_deeply_nested() {
+        let input = r#"
+            deep(A) = AND(
+                OR(
+                    AND(
+                        Equal(A["x"], 1)
+                    )
+                    Equal(A["y"], 2)
+                )
+            )
+        "#;
+
+        let predicates = parse_predicates(input);
+        let result = AnonPredicateLifter::lift_predicates(predicates);
+
+        // Should generate 3 predicates:
+        // Processing order: deep's OR gets processed, which processes its AND child
+        // Counter is global, so:
+        // 1. deep$anon_0$anon_1 (innermost AND, named from its parent deep$anon_0 + counter 1)
+        // 2. deep$anon_0 (OR, counter 0)
+        // 3. deep (original)
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0].name.name, "deep$anon_0$anon_1");
+        assert_eq!(result[1].name.name, "deep$anon_0");
+        assert_eq!(result[2].name.name, "deep");
+
+        // Innermost is AND
+        assert_eq!(result[0].conjunction_type, ConjunctionType::And);
+        // Middle is OR
+        assert_eq!(result[1].conjunction_type, ConjunctionType::Or);
+    }
+
+    #[test]
+    fn test_uses_parent_private_wildcard() {
+        let input = r#"
+            my_pred(A, private: B) = AND(
+                AND(
+                    Equal(A["foo"], B["bar"])
+                )
+            )
+        "#;
+
+        let predicates = parse_predicates(input);
+        let result = AnonPredicateLifter::lift_predicates(predicates);
+
+        // Should work - B becomes public arg of anon pred
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].name.name, "my_pred$anon_0");
+
+        // Anonymous predicate should have both A and B as public args
+        let anon_args: Vec<&str> = result[0]
+            .args
+            .public_args
+            .iter()
+            .map(|id| id.name.as_str())
+            .collect();
+        assert!(anon_args.contains(&"A"));
+        assert!(anon_args.contains(&"B"));
+    }
+
+    #[test]
+    fn test_arg_subset() {
+        let input = r#"
+            my_pred(A, B, C) = AND(
+                AND(
+                    Equal(A["foo"], 123)
+                )
+                Equal(B["bar"], C)
+            )
+        "#;
+
+        let predicates = parse_predicates(input);
+        let result = AnonPredicateLifter::lift_predicates(predicates);
+
+        assert_eq!(result.len(), 2);
+
+        // Anonymous predicate should only have A (the only wildcard it uses)
+        assert_eq!(result[0].args.public_args.len(), 1);
+        assert_eq!(result[0].args.public_args[0].name, "A");
+    }
+}

--- a/src/lang/frontend_ast_lower.rs
+++ b/src/lang/frontend_ast_lower.rs
@@ -272,7 +272,9 @@ impl<'a> Lowerer<'a> {
         }
     }
 
-    fn extract_and_split_predicates(&self) -> Result<Vec<CustomPredicateDef>, LoweringError> {
+    fn extract_and_split_predicates(
+        &self,
+    ) -> Result<Vec<frontend_ast_split::SplitResult>, LoweringError> {
         let doc = self.validated.document();
         let predicates: Vec<CustomPredicateDef> = doc
             .items
@@ -284,13 +286,13 @@ impl<'a> Lowerer<'a> {
             .collect();
 
         // Apply splitting to each predicate as needed
-        let mut split_predicates = Vec::new();
+        let mut split_results = Vec::new();
         for pred in predicates {
-            let chain = frontend_ast_split::split_predicate_if_needed(pred, self.params)?;
-            split_predicates.extend(chain);
+            let result = frontend_ast_split::split_predicate_if_needed(pred, self.params)?;
+            split_results.push(result);
         }
 
-        Ok(split_predicates)
+        Ok(split_results)
     }
 
     fn lower_statement_arg_to_builder(arg: &StatementTmplArg) -> Result<BuilderArg, LoweringError> {

--- a/src/lang/frontend_ast_lower.rs
+++ b/src/lang/frontend_ast_lower.rs
@@ -78,10 +78,10 @@ impl<'a> Lowerer<'a> {
 
     fn lower_batches(&self, batch_name: String) -> Result<Option<PredicateBatches>, LoweringError> {
         // Extract and split custom predicates from document
-        let custom_predicates = self.extract_and_split_predicates()?;
+        let split_results = self.extract_and_split_predicates()?;
 
         // If no custom predicates, return None
-        if custom_predicates.is_empty() {
+        if split_results.is_empty() {
             return Ok(None);
         }
 
@@ -90,7 +90,7 @@ impl<'a> Lowerer<'a> {
 
         // Use the new batching module to pack predicates into batches
         let batches = frontend_ast_batch::batch_predicates(
-            custom_predicates,
+            split_results,
             self.params,
             &batch_name,
             &imported_predicates,
@@ -155,7 +155,8 @@ impl<'a> Lowerer<'a> {
         wildcard_map: &HashMap<String, usize>,
         batches: Option<&PredicateBatches>,
     ) -> Result<MWStatementTmpl, LoweringError> {
-        let pred_name = &stmt.predicate.name;
+        let (predicate_id, args) = stmt.expect_call();
+        let pred_name = &predicate_id.name;
         let symbols = self.validated.symbols();
 
         // Resolve predicate - for request statements, local custom predicates
@@ -197,7 +198,7 @@ impl<'a> Lowerer<'a> {
 
         // Create a builder with the resolved predicate and desugar
         let mut builder = StatementTmplBuilder::new(predicate);
-        for arg in &stmt.args {
+        for arg in args {
             let builder_arg = Self::lower_statement_arg_to_builder(arg)?;
             builder = builder.arg(builder_arg);
         }
@@ -253,7 +254,8 @@ impl<'a> Lowerer<'a> {
         names: &mut Vec<String>,
         seen: &mut HashSet<String>,
     ) {
-        for arg in &stmt.args {
+        let (_, args) = stmt.expect_call();
+        for arg in args {
             match arg {
                 StatementTmplArg::Wildcard(id) => {
                     if !seen.contains(&id.name) {
@@ -275,6 +277,8 @@ impl<'a> Lowerer<'a> {
     fn extract_and_split_predicates(
         &self,
     ) -> Result<Vec<frontend_ast_split::SplitResult>, LoweringError> {
+        use super::frontend_ast_lift::AnonPredicateLifter;
+
         let doc = self.validated.document();
         let predicates: Vec<CustomPredicateDef> = doc
             .items
@@ -285,9 +289,13 @@ impl<'a> Lowerer<'a> {
             })
             .collect();
 
+        // Lift inline conjunctions to anonymous predicates
+        // This transforms nested AND/OR blocks into separate predicates
+        let lifted_predicates = AnonPredicateLifter::lift_predicates(predicates);
+
         // Apply splitting to each predicate as needed
         let mut split_results = Vec::new();
-        for pred in predicates {
+        for pred in lifted_predicates {
             let result = frontend_ast_split::split_predicate_if_needed(pred, self.params)?;
             split_results.push(result);
         }

--- a/src/lang/frontend_ast_split.rs
+++ b/src/lang/frontend_ast_split.rs
@@ -34,6 +34,40 @@ pub struct ChainLink {
     pub public_args_out: Vec<String>,
 }
 
+/// Information about a single piece of a split predicate chain
+#[derive(Debug, Clone)]
+pub struct SplitChainPiece {
+    /// Name of this predicate piece (e.g., "foo_1")
+    pub name: String,
+    /// Number of "real" statements in this piece (excludes chain call)
+    pub real_statement_count: usize,
+    /// Whether this piece has a chain call to the next piece
+    pub has_chain_call: bool,
+}
+
+/// Metadata about a split predicate chain
+#[derive(Debug, Clone)]
+pub struct SplitChainInfo {
+    /// Original predicate name (e.g., "foo")
+    pub original_name: String,
+    /// Chain pieces in execution order (innermost continuation first: [foo_2, foo_1, foo])
+    pub chain_pieces: Vec<SplitChainPiece>,
+    /// Total number of "real" user statements (excludes chain calls)
+    pub total_real_statements: usize,
+    /// Maps original statement index → reordered index
+    /// e.g., if original stmt 0 became reordered stmt 3, then reorder_map[0] = 3
+    pub reorder_map: Vec<usize>,
+}
+
+/// Result of splitting a predicate
+#[derive(Debug, Clone)]
+pub struct SplitResult {
+    /// The predicates (continuations first, original last if split)
+    pub predicates: Vec<CustomPredicateDef>,
+    /// Split chain info, if splitting occurred (None for non-split)
+    pub chain_info: Option<SplitChainInfo>,
+}
+
 /// Wildcard usage information
 #[derive(Debug, Clone)]
 struct WildcardUsage {
@@ -66,19 +100,25 @@ pub fn validate_predicate_is_splittable(
 pub fn split_predicate_if_needed(
     pred: CustomPredicateDef,
     params: &Params,
-) -> Result<Vec<CustomPredicateDef>, SplittingError> {
+) -> Result<SplitResult, SplittingError> {
     // Early validation
     validate_predicate_is_splittable(&pred, params)?;
 
     // If within limits, no splitting needed
     if pred.statements.len() <= params.max_custom_predicate_arity {
-        return Ok(vec![pred]);
+        return Ok(SplitResult {
+            predicates: vec![pred],
+            chain_info: None,
+        });
     }
 
     // Need to split - execute the splitting algorithm
-    let chain = split_into_chain(pred, params)?;
+    let (predicates, chain_info) = split_into_chain(pred, params)?;
 
-    Ok(chain)
+    Ok(SplitResult {
+        predicates,
+        chain_info: Some(chain_info),
+    })
 }
 
 fn analyze_wildcards(statements: &[StatementTmpl]) -> HashMap<String, WildcardUsage> {
@@ -121,18 +161,33 @@ fn collect_wildcards_from_statement(stmt: &StatementTmpl) -> HashSet<String> {
 }
 
 /// Order constraints optimally to minimize liveness at boundaries
+/// Result of ordering statements optimally for splitting
+struct OrderingResult {
+    /// Reordered statements
+    statements: Vec<StatementTmpl>,
+    /// Maps original statement index → reordered index
+    /// reorder_map[original_idx] = new_idx
+    reorder_map: Vec<usize>,
+}
+
 fn order_constraints_optimally(
     statements: Vec<StatementTmpl>,
     _usage: &HashMap<String, WildcardUsage>,
     params: &Params,
-) -> Vec<StatementTmpl> {
-    // If no splitting needed, preserve original order
-    if statements.len() <= params.max_custom_predicate_arity {
-        return statements;
+) -> OrderingResult {
+    let n = statements.len();
+
+    // If no splitting needed, preserve original order (identity mapping)
+    if n <= params.max_custom_predicate_arity {
+        return OrderingResult {
+            statements,
+            reorder_map: (0..n).collect(),
+        };
     }
 
     let mut ordered = Vec::new();
-    let mut remaining: HashSet<usize> = (0..statements.len()).collect();
+    let mut reorder_map = vec![0; n];
+    let mut remaining: HashSet<usize> = (0..n).collect();
     let mut active_wildcards: HashSet<String> = HashSet::new();
 
     while !remaining.is_empty() {
@@ -146,6 +201,9 @@ fn order_constraints_optimally(
 
         remaining.remove(&best_idx);
         let stmt = &statements[best_idx];
+
+        // Record the mapping: original index best_idx → new index ordered.len()
+        reorder_map[best_idx] = ordered.len();
         ordered.push(stmt.clone());
 
         // Update active wildcards
@@ -160,7 +218,10 @@ fn order_constraints_optimally(
         active_wildcards.retain(|w| needed_later.contains(w));
     }
 
-    ordered
+    OrderingResult {
+        statements: ordered,
+        reorder_map,
+    }
 }
 
 /// Compute tie-breaker metrics for deterministic ordering when scores are equal
@@ -360,16 +421,20 @@ fn generate_refactor_suggestion(
 }
 
 /// Split into chain using bucket-filling approach
+/// Returns the split predicates and metadata about the split
 fn split_into_chain(
     pred: CustomPredicateDef,
     params: &Params,
-) -> Result<Vec<CustomPredicateDef>, SplittingError> {
+) -> Result<(Vec<CustomPredicateDef>, SplitChainInfo), SplittingError> {
     let original_name = pred.name.name.clone();
     let conjunction = pred.conjunction_type;
 
     let usage = analyze_wildcards(&pred.statements);
+    let total_real_statements = pred.statements.len();
 
-    let ordered_statements = order_constraints_optimally(pred.statements, &usage, params);
+    let ordering_result = order_constraints_optimally(pred.statements, &usage, params);
+    let ordered_statements = ordering_result.statements;
+    let reorder_map = ordering_result.reorder_map;
 
     let original_public_args: Vec<String> = pred
         .args
@@ -479,6 +544,32 @@ fn split_into_chain(
         }
     }
 
+    // Build SplitChainInfo from chain_links before generating predicates
+    // Pieces are in execution order: innermost continuation first, original last
+    let num_links = chain_links.len();
+    let mut chain_pieces = Vec::new();
+    for i in (0..num_links).rev() {
+        let link = &chain_links[i];
+        let is_last = i == num_links - 1;
+        let name = if i == 0 {
+            original_name.clone()
+        } else {
+            format!("{}_{}", original_name, i)
+        };
+        chain_pieces.push(SplitChainPiece {
+            name,
+            real_statement_count: link.statements.len(),
+            has_chain_call: !is_last,
+        });
+    }
+
+    let chain_info = SplitChainInfo {
+        original_name: original_name.clone(),
+        chain_pieces,
+        total_real_statements,
+        reorder_map,
+    };
+
     let mut chain_predicates =
         generate_chain_predicates(&original_name, chain_links, conjunction, params)?;
 
@@ -489,7 +580,7 @@ fn split_into_chain(
     // and can be referenced by their callers.
     chain_predicates.reverse();
 
-    Ok(chain_predicates)
+    Ok((chain_predicates, chain_info))
 }
 
 /// Phase 4: Generate synthetic predicates from chain links
@@ -524,20 +615,19 @@ fn generate_chain_predicates(
                 span: None,
             };
 
-            // Create arguments for chain call: all public args (incoming + promoted)
-            let mut chain_call_args = Vec::new();
-            for arg_name in &link.public_args_in {
-                chain_call_args.push(StatementTmplArg::Wildcard(Identifier {
-                    name: arg_name.clone(),
-                    span: None,
-                }));
-            }
-            for arg_name in &link.public_args_out {
-                chain_call_args.push(StatementTmplArg::Wildcard(Identifier {
-                    name: arg_name.clone(),
-                    span: None,
-                }));
-            }
+            // Create arguments for chain call: use next link's public_args_in
+            // which is the deduplicated union of current public_args_in and public_args_out
+            let next_link = &chain_links[i + 1];
+            let chain_call_args: Vec<StatementTmplArg> = next_link
+                .public_args_in
+                .iter()
+                .map(|arg_name| {
+                    StatementTmplArg::Wildcard(Identifier {
+                        name: arg_name.clone(),
+                        span: None,
+                    })
+                })
+                .collect();
 
             let chain_call = StatementTmpl {
                 predicate: next_pred_name,
@@ -681,8 +771,9 @@ mod tests {
         let result = split_predicate_if_needed(pred, &params);
         assert!(result.is_ok());
 
-        let chain = result.unwrap();
-        assert_eq!(chain.len(), 1); // No split needed
+        let split_result = result.unwrap();
+        assert_eq!(split_result.predicates.len(), 1); // No split needed
+        assert!(split_result.chain_info.is_none()); // No chain info for non-split
     }
 
     #[test]
@@ -704,7 +795,8 @@ mod tests {
         let result = split_predicate_if_needed(pred, &params);
         assert!(result.is_ok());
 
-        let chain = result.unwrap();
+        let split_result = result.unwrap();
+        let chain = &split_result.predicates;
         assert_eq!(chain.len(), 2); // Should split into 2 predicates
 
         // Chain is reversed: continuation comes first, original comes last
@@ -715,6 +807,17 @@ mod tests {
         // First predicate (index 0): continuation, 2 remaining statements
         assert_eq!(chain[0].statements.len(), 2);
         assert_eq!(chain[0].name.name, "my_pred_1");
+
+        // Verify chain_info is present
+        let chain_info = split_result.chain_info.as_ref().unwrap();
+        assert_eq!(chain_info.original_name, "my_pred");
+        assert_eq!(chain_info.total_real_statements, 6);
+        assert_eq!(chain_info.chain_pieces.len(), 2);
+        // Pieces are in execution order: innermost first
+        assert_eq!(chain_info.chain_pieces[0].name, "my_pred_1");
+        assert!(!chain_info.chain_pieces[0].has_chain_call);
+        assert_eq!(chain_info.chain_pieces[1].name, "my_pred");
+        assert!(chain_info.chain_pieces[1].has_chain_call);
     }
 
     #[test]
@@ -736,7 +839,8 @@ mod tests {
         let result = split_predicate_if_needed(pred, &params);
         assert!(result.is_ok());
 
-        let chain = result.unwrap();
+        let split_result = result.unwrap();
+        let chain = &split_result.predicates;
         assert_eq!(chain.len(), 2); // Should split into 2 predicates
 
         // Chain is reversed: continuation first, original last
@@ -771,7 +875,8 @@ mod tests {
         let result = split_predicate_if_needed(pred, &params);
         assert!(result.is_ok());
 
-        let chain = result.unwrap();
+        let split_result = result.unwrap();
+        let chain = &split_result.predicates;
         assert_eq!(chain.len(), 3); // Should split into 3 predicates
 
         // Chain is reversed: [_2, _1, original]
@@ -784,6 +889,15 @@ mod tests {
         // chain[2]: large_pred (4 + chain call = 5)
         assert_eq!(chain[2].statements.len(), 5);
         assert_eq!(chain[2].name.name, "large_pred");
+
+        // Verify chain_info
+        let chain_info = split_result.chain_info.as_ref().unwrap();
+        assert_eq!(chain_info.total_real_statements, 11);
+        assert_eq!(chain_info.chain_pieces.len(), 3);
+        // Execution order: innermost first
+        assert_eq!(chain_info.chain_pieces[0].name, "large_pred_2");
+        assert_eq!(chain_info.chain_pieces[1].name, "large_pred_1");
+        assert_eq!(chain_info.chain_pieces[2].name, "large_pred");
     }
 
     #[test]
@@ -810,7 +924,8 @@ mod tests {
         let result = split_predicate_if_needed(pred, &params);
         assert!(result.is_ok());
 
-        let chain = result.unwrap();
+        let split_result = result.unwrap();
+        let chain = &split_result.predicates;
         // Should split into 2 predicates
         // T is used in first segment and crosses to second, then used again in second
         assert_eq!(chain.len(), 2);
@@ -876,7 +991,8 @@ mod tests {
         let result = split_predicate_if_needed(pred, &params);
         assert!(result.is_ok());
 
-        let chain = result.unwrap();
+        let split_result = result.unwrap();
+        let chain = &split_result.predicates;
         assert_eq!(chain.len(), 2, "Predicate should split into 2 links");
 
         let second_pred = &chain[1];

--- a/src/lang/frontend_ast_split.rs
+++ b/src/lang/frontend_ast_split.rs
@@ -145,7 +145,8 @@ fn analyze_wildcards(statements: &[StatementTmpl]) -> HashMap<String, WildcardUs
 fn collect_wildcards_from_statement(stmt: &StatementTmpl) -> HashSet<String> {
     let mut wildcards = HashSet::new();
 
-    for arg in &stmt.args {
+    let (_, args) = stmt.expect_call();
+    for arg in args {
         match arg {
             StatementTmplArg::Wildcard(id) => {
                 wildcards.insert(id.name.clone());
@@ -629,11 +630,7 @@ fn generate_chain_predicates(
                 })
                 .collect();
 
-            let chain_call = StatementTmpl {
-                predicate: next_pred_name,
-                args: chain_call_args,
-                span: None,
-            };
+            let chain_call = StatementTmpl::call(next_pred_name, chain_call_args, None);
 
             statements.push(chain_call);
         }
@@ -848,7 +845,7 @@ mod tests {
         let original = &chain[1];
         assert_eq!(original.name.name, "complex");
         let last_stmt = original.statements.last().unwrap();
-        assert_eq!(last_stmt.predicate.name, "complex_1");
+        assert_eq!(last_stmt.predicate().unwrap().name, "complex_1");
     }
 
     #[test]

--- a/src/lang/grammar.pest
+++ b/src/lang/grammar.pest
@@ -55,7 +55,15 @@ statement_list = { statement+ }
 statement_arg = { literal_value | anchored_key | identifier }
 statement_arg_list = { statement_arg ~ ("," ~ statement_arg)* }
 
-statement = { identifier ~ "(" ~ statement_arg_list? ~ ")" }
+// A statement can be either an inline conjunction (AND/OR nested block) or a predicate call
+statement = { inline_conjunction | predicate_call }
+
+// Inline conjunction: AND(...) or OR(...) appearing where a statement would
+// Allows arbitrary nesting of conjunctions
+inline_conjunction = { conjunction_type ~ "(" ~ statement+ ~ ")" }
+
+// Regular predicate call: pred_name(arg1, arg2, ...)
+predicate_call = { identifier ~ "(" ~ statement_arg_list? ~ ")" }
 
 // Anchored Key: Var["key_literal"] or Var.key_identifier
 anchored_key = {

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -10,7 +10,8 @@ pub mod pretty_print;
 use std::sync::Arc;
 
 pub use error::LangError;
-pub use frontend_ast_batch::PredicateBatches;
+pub use frontend_ast_batch::{MultiOperationError, PredicateBatches};
+pub use frontend_ast_split::{SplitChainInfo, SplitChainPiece, SplitResult};
 pub use parser::{parse_podlang, Pairs, ParseError, Rule};
 pub use pretty_print::PrettyPrint;
 

--- a/src/lang/pretty_print.rs
+++ b/src/lang/pretty_print.rs
@@ -384,15 +384,17 @@ mod tests {
             parse(input, &params, available_batches).expect("Initial parsing should succeed");
 
         // Step 2: Pretty-print the parsed batch
-        let pretty_printed = parsed_result.custom_batch.to_podlang_string();
+        let batch = parsed_result.first_batch().expect("Expected batch");
+        let pretty_printed = batch.to_podlang_string();
 
         // Step 3: Parse the pretty-printed result
         let reparsed_result =
             parse(&pretty_printed, &params, available_batches).expect("Reparsing should succeed");
+        let reparsed_batch = reparsed_result.first_batch().expect("Expected batch");
 
         // Step 4: Verify the ASTs are equivalent
         assert_eq!(
-            parsed_result.custom_batch.predicates, reparsed_result.custom_batch.predicates,
+            batch.predicates, reparsed_batch.predicates,
             "Original AST should match reparsed AST.\nOriginal input:\n{}\nPretty-printed:\n{}\n",
             input, pretty_printed
         );
@@ -542,18 +544,17 @@ mod tests {
 
         let params = Params::default();
         let parsed_result = parse(input, &params, &[]).expect("Parsing should succeed");
+        let batch = parsed_result.first_batch().expect("Expected batch");
 
-        let pretty_printed = parsed_result.custom_batch.to_podlang_string();
+        let pretty_printed = batch.to_podlang_string();
 
         println!("Original input:\n{}", input);
         println!("\nPretty-printed output:\n{}", pretty_printed);
 
         let reparsed = parse(&pretty_printed, &params, &[]).expect("Reparsing should succeed");
+        let reparsed_batch = reparsed.first_batch().expect("Expected batch");
 
-        assert_eq!(
-            parsed_result.custom_batch.predicates,
-            reparsed.custom_batch.predicates
-        );
+        assert_eq!(batch.predicates, reparsed_batch.predicates);
     }
 
     #[test]
@@ -616,14 +617,16 @@ mod tests {
 
             let params = Params::default();
             let parsed_result = parse(&input, &params, &[]).expect("Should parse successfully");
+            let batch = parsed_result.first_batch().expect("Expected batch");
 
-            let pretty_printed = parsed_result.custom_batch.to_podlang_string();
+            let pretty_printed = batch.to_podlang_string();
 
             let reparsed_result =
                 parse(&pretty_printed, &params, &[]).expect("Should reparse successfully");
+            let reparsed_batch = reparsed_result.first_batch().expect("Expected batch");
 
             assert_eq!(
-                parsed_result.custom_batch.predicates, reparsed_result.custom_batch.predicates,
+                batch.predicates, reparsed_batch.predicates,
                 "Round-trip failed for string: {:?}\nPretty-printed: {}",
                 test_string, pretty_printed
             );


### PR DESCRIPTION
Add support for inline conjunction blocks (AND/OR) within predicate definitions. This allows users to write nested predicates directly in their definitions, which are then lifted into anonymous predicates during the lowering pass.

Example:
```
my_pred(A, B) = AND(
    AND(
        Equal(A["foo"], 123)
    )
    Equal(A["bar"], B)
)
```

Gets transformed into:
```
my_pred$anon_0(A) = AND(
  Equal(A["foo"], 123)
)

my_pred(A, B) = AND(
  my_pred$anon_0(A)
  Equal(A["bar"], B)
)
```

Key changes:
- Grammar: Add inline_conjunction and predicate_call rules
- AST: Add StatementTmplKind enum with Call and InlineConjunction variants
- Lifting: New frontend_ast_lift.rs with AnonPredicateLifter
- Validation: Handle inline conjunction validation
- Lower: Call lifting pass before splitting