### PR TITLE
Fix accidental inclusion of extra input PODs

### DIFF
--- a/src/frontend/multi_pod/mod.rs
+++ b/src/frontend/multi_pod/mod.rs
@@ -313,23 +313,22 @@ impl SolvedMultiPod {
                     StatementSource::Internal(dep_idx) => {
                         // Check if dependency is in an earlier POD (not local)
                         if !statements_in_pod.contains(dep_idx) {
-                            for earlier_pod_idx in 0..pod_idx {
-                                if solution.pod_public_statements[earlier_pod_idx].contains(dep_idx)
-                                {
-                                    internal_pods.insert(earlier_pod_idx);
-                                    break;
-                                }
-                            }
+                            let earlier_pod_idx = (0..pod_idx)
+                                .find(|earlier_pod_idx| {
+                                    solution.pod_public_statements[*earlier_pod_idx]
+                                        .contains(dep_idx)
+                                })
+                                .expect("internal pod with dependency statement");
+                            internal_pods.insert(earlier_pod_idx);
                         }
                     }
                     StatementSource::External(pod_hash) => {
-                        if let Some(idx) = self
+                        let idx = self
                             .input_pods
                             .iter()
                             .position(|p| p.statements_hash() == *pod_hash)
-                        {
-                            external_pods.insert(idx);
-                        }
+                            .expect("external pod with dependency statement");
+                        external_pods.insert(idx);
                     }
                 }
             }


### PR DESCRIPTION
The final `prove` step has to compute which PODs are required for the statements we are using, ensuring that the dependencies are satisfied.

A bug was causing this to include dependencies from input PODs when the same dependency is already satisfied in the local POD. The solver correctly accounts for this, but the prover step mistakenly ignores the fact that the solver planned for that dependency to be local. This can cause too many input PODs to be added.

The fix is to refactor the logic for computing inputs, with an assertion to ensure that the total number of input PODs never exceeds `params.max_input_pods`. To aid in debugging I have also implemented the `Display` trait for `MultiPodSolution`.