### PR TITLE
Fix nondeterminism in splitting

### DIFF
--- a/src/lang/frontend_ast_split.rs
+++ b/src/lang/frontend_ast_split.rs
@@ -976,10 +976,8 @@ mod tests {
         let remaining: HashSet<usize> = [0, 1].into_iter().collect();
         let active_wildcards = HashSet::new();
 
-        let key0 =
-            statement_selection_key(0, &statements, &active_wildcards, &remaining, false);
-        let key1 =
-            statement_selection_key(1, &statements, &active_wildcards, &remaining, false);
+        let key0 = statement_selection_key(0, &statements, &active_wildcards, &remaining, false);
+        let key1 = statement_selection_key(1, &statements, &active_wildcards, &remaining, false);
 
         assert_eq!(key0.0, key1.0, "Primary heuristic score should tie");
         assert_eq!(key0.1, key1.1, "Secondary tie-breaker metrics should tie");


### PR DESCRIPTION
This addresses two nondeterminism cases:

The first issue came during predicate splitting: we were storing candidate statement indices in a `HashSet`, and then picking the "best" one with `max_by_key`.

Most of the time that’s fine, because the scoring function picks a clear winner. But in tie cases, where two statements have exactly the same primary score and secondary tie-breaker metrics, `max_by_key` effectively falls back to iterator order. With a `HashSet`, that iteration order is non-deterministic.

That meant the chosen "best next statement" could vary from run to run in those tie situations. Once that first difference happens, downstream ordering, split boundaries, and promoted wildcard sets can also differ, even though the input predicate is identical.

The fix was to make tie resolution explicit and deterministic. The selection key is now `(primary_score, tie_breakers, Reverse(idx))`. Since `max_by_key` chooses the maximum key, `Reverse(idx)` makes smaller indices rank higher in otherwise-equal cases.

The second issue affected only diagnostic messages, and has been resolved by ensuring a sort order on the message elements.