### PR TITLE
Predicate literals for Podlang

### DIFF
--- a/src/lang/diagnostics.rs
+++ b/src/lang/diagnostics.rs
@@ -287,6 +287,33 @@ fn render_validation_error(
         ValidationError::NoRequestBlock => {
             render_title_only(renderer, "requests must contain a REQUEST block")
         }
+
+        ValidationError::ShadowsNativePredicate { name, span } => {
+            let title = format!("'{}' shadows a native predicate", name);
+            render_with_optional_span(
+                renderer,
+                source,
+                path,
+                &title,
+                span.as_ref(),
+                "this name is reserved for a native predicate",
+            )
+        }
+
+        ValidationError::SameModulePredicateLiteral { name, span } => {
+            let title = format!(
+                "cannot use same-module predicate '{}' as a literal value",
+                name
+            );
+            render_with_optional_span(
+                renderer,
+                source,
+                path,
+                &title,
+                span.as_ref(),
+                "its hash depends on the module's Merkle root, which is not yet known",
+            )
+        }
     }
 }
 

--- a/src/lang/error.rs
+++ b/src/lang/error.rs
@@ -156,6 +156,9 @@ pub enum ValidationError {
     #[error("Wildcard '{name}' collides with a predicate name")]
     WildcardPredicateNameCollision { name: String },
 
+    #[error("Name '{name}' shadows a native predicate")]
+    ShadowsNativePredicate { name: String, span: Option<Span> },
+
     #[error("Predicate definitions are not allowed in requests")]
     PredicatesNotAllowedInRequest { span: Option<Span> },
 
@@ -167,6 +170,9 @@ pub enum ValidationError {
 
     #[error("Requests must contain a REQUEST block")]
     NoRequestBlock,
+
+    #[error("Cannot use same-module predicate '{name}' as a literal value (its hash depends on the module's Merkle root, which is not yet known)")]
+    SameModulePredicateLiteral { name: String, span: Option<Span> },
 }
 
 /// Lowering errors from frontend AST lowering to middleware
@@ -191,6 +197,9 @@ pub enum LoweringError {
 
     #[error("Predicate '{name}' not found in symbol table")]
     PredicateNotFound { name: String },
+
+    #[error("Cannot use same-module predicate '{name}' as a literal value (its hash depends on the module's Merkle root, which is not yet known)")]
+    SameModulePredicateLiteral { name: String },
 
     #[error("Invalid argument type in statement template")]
     InvalidArgumentType,

--- a/src/lang/frontend_ast.rs
+++ b/src/lang/frontend_ast.rs
@@ -168,6 +168,9 @@ pub enum LiteralValue {
     Array(LiteralArray),
     Set(LiteralSet),
     Dict(LiteralDict),
+    /// Predicate reference as a literal value (resolves to predicate identity hash).
+    /// Allowed in containers (arrays, sets, dicts) and statement arguments.
+    PredicateLiteral(PredicateRef),
 }
 
 /// Integer literal
@@ -422,6 +425,7 @@ impl fmt::Display for LiteralValue {
             LiteralValue::Array(a) => write!(f, "{}", a),
             LiteralValue::Set(s) => write!(f, "{}", s),
             LiteralValue::Dict(d) => write!(f, "{}", d),
+            LiteralValue::PredicateLiteral(pred_ref) => write!(f, "{}", pred_ref),
         }
     }
 }
@@ -823,6 +827,28 @@ pub mod parse {
             Rule::literal_array => Ok(LiteralValue::Array(parse_literal_array(inner)?)),
             Rule::literal_set => Ok(LiteralValue::Set(parse_literal_set(inner)?)),
             Rule::literal_dict => Ok(LiteralValue::Dict(parse_literal_dict(inner)?)),
+            Rule::predicate_literal => {
+                let pred_inner = inner.into_inner().next().unwrap();
+                match pred_inner.as_rule() {
+                    Rule::qualified_predicate_ref => {
+                        let mut parts = pred_inner.into_inner();
+                        let module = parse_identifier(parts.next().unwrap());
+                        let predicate = parse_identifier(parts.next().unwrap());
+                        Ok(LiteralValue::PredicateLiteral(PredicateRef::Qualified {
+                            module,
+                            predicate,
+                        }))
+                    }
+                    Rule::unqualified_predicate_ref => {
+                        let id = parse_identifier(pred_inner.into_inner().next().unwrap());
+                        Ok(LiteralValue::PredicateLiteral(PredicateRef::Local(id)))
+                    }
+                    _ => unreachable!(
+                        "Unexpected predicate_literal rule: {:?}",
+                        pred_inner.as_rule()
+                    ),
+                }
+            }
             _ => unreachable!("Unexpected literal value rule: {:?}", inner.as_rule()),
         }
     }
@@ -1138,6 +1164,9 @@ mod tests {
                     pair.key.span = None;
                     clear_literal_spans(&mut pair.value);
                 }
+            }
+            LiteralValue::PredicateLiteral(pred_ref) => {
+                clear_predicate_ref_spans(pred_ref);
             }
         }
     }

--- a/src/lang/frontend_ast_lower.rs
+++ b/src/lang/frontend_ast_lower.rs
@@ -157,7 +157,8 @@ fn resolve_local_predicate(
 
 /// Lower a literal value from AST to middleware Value.
 ///
-/// This is a pure conversion that cannot fail.
+/// This is a pure conversion that cannot fail. Panics on `PredicateLiteral` —
+/// use `lower_literal_with_context` when predicate literals may appear (e.g. in containers).
 pub fn lower_literal(lit: &LiteralValue) -> Value {
     match lit {
         LiteralValue::Int(i) => Value::from(i.value),
@@ -190,12 +191,80 @@ pub fn lower_literal(lit: &LiteralValue) -> Value {
             let dict = containers::Dictionary::new(pairs);
             Value::from(dict)
         }
+        LiteralValue::PredicateLiteral(_) => {
+            unreachable!("PredicateLiteral in literal position must be lowered with context via lower_literal_with_context")
+        }
+    }
+}
+
+/// Lower a literal value, resolving predicate literals using the symbol table.
+pub fn lower_literal_with_context(
+    lit: &LiteralValue,
+    symbols: &SymbolTable,
+    context: &ResolutionContext,
+) -> Result<Value, LoweringError> {
+    match lit {
+        LiteralValue::PredicateLiteral(pred_ref) => {
+            let pred_or_wc =
+                resolve_predicate_ref(pred_ref, symbols, context).ok_or_else(|| {
+                    LoweringError::PredicateNotFound {
+                        name: format!("{}", pred_ref),
+                    }
+                })?;
+            let predicate = match pred_or_wc {
+                crate::frontend::PredicateOrWildcard::Predicate(p) => p,
+                crate::frontend::PredicateOrWildcard::Wildcard(name) => {
+                    return Err(LoweringError::PredicateNotFound {
+                        name: format!("wildcard '{}' cannot be used as a predicate literal", name),
+                    });
+                }
+            };
+            if matches!(predicate, Predicate::BatchSelf(_)) {
+                return Err(LoweringError::SameModulePredicateLiteral {
+                    name: format!("{}", pred_ref),
+                });
+            }
+            let hash = predicate.hash();
+            Ok(Value::from(hash))
+        }
+        LiteralValue::Array(a) => {
+            let elements: Vec<_> = a
+                .elements
+                .iter()
+                .map(|e| lower_literal_with_context(e, symbols, context))
+                .collect::<Result<_, _>>()?;
+            Ok(Value::from(containers::Array::new(elements)))
+        }
+        LiteralValue::Set(s) => {
+            let elements: std::collections::HashSet<_> = s
+                .elements
+                .iter()
+                .map(|e| lower_literal_with_context(e, symbols, context))
+                .collect::<Result<_, _>>()?;
+            Ok(Value::from(containers::Set::new(elements)))
+        }
+        LiteralValue::Dict(d) => {
+            let pairs: HashMap<_, _> = d
+                .pairs
+                .iter()
+                .map(|pair| {
+                    let key = Key::from(pair.key.value.as_str());
+                    let value = lower_literal_with_context(&pair.value, symbols, context)?;
+                    Ok((key, value))
+                })
+                .collect::<Result<_, LoweringError>>()?;
+            Ok(Value::from(containers::Dictionary::new(pairs)))
+        }
+        // All other variants are context-free
+        other => Ok(lower_literal(other)),
     }
 }
 
 /// Lower a statement argument from AST to BuilderArg.
 ///
-/// This is a pure conversion that cannot fail.
+/// This handles all argument types except literals containing predicate references,
+/// which require symbol table context. Use `lower_statement_arg_with_context`
+/// when predicate literals may appear (including inside containers).
 pub fn lower_statement_arg(arg: &StatementTmplArg) -> BuilderArg {
     match arg {
         StatementTmplArg::Literal(lit) => {
@@ -210,6 +279,21 @@ pub fn lower_statement_arg(arg: &StatementTmplArg) -> BuilderArg {
             };
             BuilderArg::Key(ak.root.name.clone(), key_str)
         }
+    }
+}
+
+/// Lower a statement argument, resolving predicate literals using the symbol table.
+pub fn lower_statement_arg_with_context(
+    arg: &StatementTmplArg,
+    symbols: &SymbolTable,
+    context: &ResolutionContext,
+) -> Result<BuilderArg, LoweringError> {
+    match arg {
+        StatementTmplArg::Literal(lit) => {
+            let value = lower_literal_with_context(lit, symbols, context)?;
+            Ok(BuilderArg::Literal(value))
+        }
+        other => Ok(lower_statement_arg(other)),
     }
 }
 
@@ -324,7 +408,7 @@ impl<'a> Lowerer<'a> {
         // Create a builder with the resolved predicate and desugar
         let mut builder = StatementTmplBuilder::new(predicate.clone());
         for arg in &stmt.args {
-            let builder_arg = lower_statement_arg(arg);
+            let builder_arg = lower_statement_arg_with_context(arg, symbols, &context)?;
             builder = builder.arg(builder_arg);
         }
         let desugared = builder.desugar();

--- a/src/lang/frontend_ast_validate.rs
+++ b/src/lang/frontend_ast_validate.rs
@@ -260,6 +260,13 @@ impl Validator {
         let args = &use_stmt.args;
         let intro_predicate_ref = &use_stmt.intro_hash;
 
+        if NativePredicate::from_str(intro_name).is_ok() {
+            return Err(ValidationError::ShadowsNativePredicate {
+                name: intro_name.clone(),
+                span: use_stmt.span,
+            });
+        }
+
         if self.symbols.predicates.contains_key(intro_name) {
             return Err(ValidationError::DuplicateImport {
                 name: intro_name.clone(),
@@ -288,6 +295,13 @@ impl Validator {
         pred_def: &CustomPredicateDef,
     ) -> Result<(), ValidationError> {
         let name = &pred_def.name.name;
+
+        if NativePredicate::from_str(name).is_ok() {
+            return Err(ValidationError::ShadowsNativePredicate {
+                name: name.clone(),
+                span: pred_def.name.span,
+            });
+        }
 
         if self.symbols.predicates.contains_key(name) {
             let first_span = self.symbols.predicates[name].source_span;
@@ -559,7 +573,9 @@ impl Validator {
                             }
                         }
                     }
-                    StatementTmplArg::Literal(_) => {}
+                    StatementTmplArg::Literal(lit) => {
+                        self.validate_literal_value(lit)?;
+                    }
                 }
             }
         } else {
@@ -588,11 +604,93 @@ impl Validator {
                             }
                         }
                     }
-                    StatementTmplArg::Literal(_) => {}
+                    StatementTmplArg::Literal(lit) => {
+                        self.validate_literal_value(lit)?;
+                    }
                 }
             }
         }
 
+        Ok(())
+    }
+
+    /// Recursively validate a literal value, checking any predicate literals inside containers.
+    fn validate_literal_value(&self, lit: &LiteralValue) -> Result<(), ValidationError> {
+        match lit {
+            LiteralValue::PredicateLiteral(pred_ref) => {
+                self.validate_predicate_literal_ref(pred_ref)
+            }
+            LiteralValue::Array(a) => {
+                for elem in &a.elements {
+                    self.validate_literal_value(elem)?;
+                }
+                Ok(())
+            }
+            LiteralValue::Set(s) => {
+                for elem in &s.elements {
+                    self.validate_literal_value(elem)?;
+                }
+                Ok(())
+            }
+            LiteralValue::Dict(d) => {
+                for pair in &d.pairs {
+                    self.validate_literal_value(&pair.value)?;
+                }
+                Ok(())
+            }
+            // Scalar literals need no validation
+            _ => Ok(()),
+        }
+    }
+
+    /// Validate a predicate reference used as a literal value in argument position.
+    /// Ensures the referenced module and predicate exist.
+    fn validate_predicate_literal_ref(
+        &self,
+        pred_ref: &PredicateRef,
+    ) -> Result<(), ValidationError> {
+        match pred_ref {
+            PredicateRef::Qualified { module, predicate } => {
+                let module_name = &module.name;
+                if let Some(imported_module) = self.symbols.imported_modules.get(module_name) {
+                    if !imported_module
+                        .predicate_index
+                        .contains_key(&predicate.name)
+                    {
+                        return Err(ValidationError::UndefinedPredicate {
+                            name: format!("{}::{}", module_name, predicate.name),
+                            span: predicate.span,
+                        });
+                    }
+                } else {
+                    return Err(ValidationError::ModuleNotFound {
+                        name: module_name.clone(),
+                        span: module.span,
+                    });
+                }
+            }
+            PredicateRef::Local(id) => {
+                // Local predicate references as values: check native or symbol table
+                if NativePredicate::from_str(&id.name).is_err()
+                    && !self.symbols.predicates.contains_key(&id.name)
+                {
+                    return Err(ValidationError::UndefinedPredicate {
+                        name: id.name.clone(),
+                        span: id.span,
+                    });
+                }
+                // Same-module custom predicates can't be used as literals because their
+                // hash depends on the batch Merkle root, creating circularity.
+                if let Some(info) = self.symbols.predicates.get(&id.name) {
+                    if matches!(info.kind, PredicateKind::Custom { .. }) {
+                        return Err(ValidationError::SameModulePredicateLiteral {
+                            name: id.name.clone(),
+                            span: id.span,
+                        });
+                    }
+                }
+            }
+        }
         Ok(())
     }
 }
@@ -892,5 +990,50 @@ mod tests {
         )"#;
         let result = parse_and_validate_request(input, &HashMap::new());
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_same_module_predicate_literal_rejected() {
+        // ::other_pred refers to a predicate defined in the same module.
+        // Its hash depends on the batch Merkle root, creating circularity.
+        let input = r#"
+            other_pred(X) = AND(Equal(X["x"], 1))
+            checker(A) = AND(
+                Equal(A.pred_id, ::other_pred)
+            )
+        "#;
+        let result = parse_and_validate_module(input, &HashMap::new());
+        assert!(
+            matches!(result, Err(ValidationError::SameModulePredicateLiteral { ref name, .. }) if name == "other_pred"),
+            "Expected SameModulePredicateLiteral error, got: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_shadows_native_predicate_custom_def() {
+        let input = r#"
+            Equal(X) = AND(Equal(X["x"], 1))
+        "#;
+        let result = parse_and_validate_module(input, &HashMap::new());
+        assert!(
+            matches!(result, Err(ValidationError::ShadowsNativePredicate { ref name, .. }) if name == "Equal"),
+        );
+    }
+
+    #[test]
+    fn test_shadows_native_predicate_intro() {
+        let input = format!(
+            r#"
+            use intro Equal(X) from 0x{}
+
+            REQUEST(Equal(A))
+        "#,
+            EMPTY_HASH.encode_hex::<String>()
+        );
+        let result = parse_and_validate_request(&input, &HashMap::new());
+        assert!(
+            matches!(result, Err(ValidationError::ShadowsNativePredicate { ref name, .. }) if name == "Equal"),
+        );
     }
 }

--- a/src/lang/grammar.pest
+++ b/src/lang/grammar.pest
@@ -50,6 +50,11 @@ custom_predicate_def = {
 statement_list = { statement+ }
 
 statement_arg = { literal_value | anchored_key | identifier }
+
+// Predicate literal in argument position: resolves to the predicate's identity hash.
+// Either qualified (module::predicate) or local (::predicate) for native/intro predicates.
+predicate_literal = { qualified_predicate_ref | unqualified_predicate_ref }
+unqualified_predicate_ref = { "::" ~ identifier }
 statement_arg_list = { statement_arg ~ ("," ~ statement_arg)* }
 
 // Predicate reference: either qualified (module::predicate) or local (predicate)
@@ -65,6 +70,7 @@ anchored_key = {
 }
 
 // Literal Values (ordered to avoid ambiguity, e.g., string before int)
+// predicate_literal is included so that predicate identity hashes can appear inside containers.
 literal_value = {
     literal_public_key |
     literal_secret_key |
@@ -74,6 +80,7 @@ literal_value = {
     literal_bool |
     literal_raw |
     literal_string |
+    predicate_literal |
     literal_int
 }
 

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -141,9 +141,9 @@ mod tests {
     use crate::{
         backends::plonky2::primitives::ec::schnorr::SecretKey,
         middleware::{
-            CustomPredicate, CustomPredicateBatch, CustomPredicateRef, Key, NativePredicate,
-            Params, Predicate, PredicateOrWildcard, RawValue, StatementTmpl, StatementTmplArg,
-            Value, Wildcard, EMPTY_HASH,
+            CustomPredicate, CustomPredicateBatch, CustomPredicateRef, IntroPredicateRef, Key,
+            NativePredicate, Params, Predicate, PredicateOrWildcard, RawValue, StatementTmpl,
+            StatementTmplArg, Value, Wildcard, EMPTY_HASH,
         },
     };
 
@@ -1073,5 +1073,218 @@ mod tests {
             },
             e => panic!("Expected LangError::Validation, but got {:?}", e),
         }
+    }
+
+    #[test]
+    fn test_e2e_predicate_literal_in_arg() -> Result<(), LangError> {
+        let params = Params::default();
+
+        // 1. Create an external module with a predicate
+        let imported_pred =
+            CustomPredicate::and(&params, "target_pred".to_string(), vec![], 1, names(&["A"]))?;
+        let batch = CustomPredicateBatch::new("extmod".to_string(), vec![imported_pred]);
+        let extmod = Arc::new(Module::new(batch.clone(), HashMap::new()));
+        let extmod_hash = extmod.id().encode_hex::<String>();
+
+        // Compute the expected hash of the imported predicate
+        let expected_pred_ref = CustomPredicateRef::new(batch.clone(), 0);
+        let expected_hash = Predicate::Custom(expected_pred_ref).hash();
+
+        // 2. Define a module that uses extmod::target_pred as a literal argument value
+        let input = format!(
+            r#"
+            use module 0x{} as extmod
+
+            checker(X) = AND(
+                Equal(X.pred_id, extmod::target_pred)
+            )
+        "#,
+            extmod_hash
+        );
+
+        // 3. Load the module
+        let module = load_module(&input, "test", &params, &[extmod])?;
+        assert_eq!(module.batch.predicates().len(), 1);
+
+        let pred = &module.batch.predicates()[0];
+        assert_eq!(pred.name, "checker");
+        assert_eq!(pred.statements().len(), 1);
+
+        // 4. Verify the second argument is a literal containing the predicate hash
+        let stmt = &pred.statements()[0];
+        let expected_stmt = StatementTmpl {
+            pred_or_wc: pred_lit(Predicate::Native(NativePredicate::Equal)),
+            args: vec![sta_ak(("X", 0), "pred_id"), sta_lit(expected_hash)],
+        };
+        assert_eq!(*stmt, expected_stmt);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_e2e_predicate_literal_in_request() -> Result<(), LangError> {
+        let params = Params::default();
+
+        // Create a module with a predicate
+        let pred = CustomPredicate::and(&params, "my_pred".to_string(), vec![], 1, names(&["A"]))?;
+        let batch = CustomPredicateBatch::new("mod1".to_string(), vec![pred]);
+        let mod1 = Arc::new(Module::new(batch.clone(), HashMap::new()));
+        let mod1_hash = mod1.id().encode_hex::<String>();
+
+        let expected_pred_ref = CustomPredicateRef::new(batch.clone(), 0);
+        let expected_hash = Predicate::Custom(expected_pred_ref).hash();
+
+        // Parse a request that uses the predicate literal as an argument
+        let input = format!(
+            r#"
+            use module 0x{} as mod1
+
+            REQUEST(
+                Equal(X.pred_id, mod1::my_pred)
+            )
+        "#,
+            mod1_hash
+        );
+
+        let request = parse_request(&input, &params, std::slice::from_ref(&mod1))?;
+        let templates = request.templates();
+        assert_eq!(templates.len(), 1);
+
+        // The second arg should be a literal with the predicate hash
+        assert_eq!(
+            templates[0].args[1],
+            StatementTmplArg::Literal(Value::from(expected_hash))
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_e2e_native_predicate_literal() -> Result<(), LangError> {
+        let params = Params::default();
+
+        let expected_hash = Predicate::Native(NativePredicate::Equal).hash();
+
+        let input = r#"
+            checker(X) = AND(
+                Equal(X.pred_id, ::Equal)
+            )
+        "#;
+
+        let module = load_module(input, "test", &params, &[])?;
+        let pred = &module.batch.predicates()[0];
+        let stmt = &pred.statements()[0];
+
+        assert_eq!(
+            stmt.args[1],
+            StatementTmplArg::Literal(Value::from(expected_hash))
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_e2e_intro_predicate_literal() -> Result<(), LangError> {
+        let params = Params::default();
+
+        let expected_hash = Predicate::Intro(IntroPredicateRef {
+            name: "ext_check".to_string(),
+            args_len: 1,
+            verifier_data_hash: EMPTY_HASH,
+        })
+        .hash();
+
+        let input = format!(
+            r#"
+            use intro ext_check(X) from 0x{}
+
+            checker(A) = AND(
+                Equal(A.pred_id, ::ext_check)
+            )
+        "#,
+            EMPTY_HASH.encode_hex::<String>()
+        );
+
+        let module = load_module(&input, "test", &params, &[])?;
+        let pred = &module.batch.predicates()[0];
+        let stmt = &pred.statements()[0];
+
+        assert_eq!(
+            stmt.args[1],
+            StatementTmplArg::Literal(Value::from(expected_hash))
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_e2e_predicate_literal_in_container() -> Result<(), LangError> {
+        let params = Params::default();
+
+        // Create an external module with a predicate
+        let imported_pred =
+            CustomPredicate::and(&params, "target_pred".to_string(), vec![], 1, names(&["A"]))?;
+        let batch = CustomPredicateBatch::new("extmod".to_string(), vec![imported_pred]);
+        let extmod = Arc::new(Module::new(batch.clone(), HashMap::new()));
+        let extmod_hash = extmod.id().encode_hex::<String>();
+
+        let expected_pred_ref = CustomPredicateRef::new(batch.clone(), 0);
+        let expected_custom_hash = Predicate::Custom(expected_pred_ref).hash();
+        let expected_native_hash = Predicate::Native(NativePredicate::Equal).hash();
+
+        // Use predicate literals inside an array and a set
+        let input = format!(
+            r#"
+            use module 0x{} as extmod
+
+            checker(X) = AND(
+                Equal(X.pred_list, [extmod::target_pred, ::Equal])
+                Equal(X.pred_set, #[extmod::target_pred, ::Equal])
+                Equal(X.pred_dict, {{ "custom": extmod::target_pred, "native": ::Equal }})
+            )
+        "#,
+            extmod_hash
+        );
+
+        let module = load_module(&input, "test", &params, &[extmod])?;
+        let pred = &module.batch.predicates()[0];
+
+        // Check the array literal (second arg of first statement)
+        let stmt0 = &pred.statements()[0];
+        let expected_array = Value::from(crate::middleware::containers::Array::new(vec![
+            Value::from(expected_custom_hash),
+            Value::from(expected_native_hash),
+        ]));
+        assert_eq!(stmt0.args[1], StatementTmplArg::Literal(expected_array));
+
+        // Check the set literal (second arg of second statement)
+        let stmt1 = &pred.statements()[1];
+        let expected_set = Value::from(crate::middleware::containers::Set::new(
+            [
+                Value::from(expected_custom_hash),
+                Value::from(expected_native_hash),
+            ]
+            .into_iter()
+            .collect::<std::collections::HashSet<_>>(),
+        ));
+        assert_eq!(stmt1.args[1], StatementTmplArg::Literal(expected_set));
+
+        // Check the dict literal (second arg of third statement)
+        let stmt2 = &pred.statements()[2];
+        let expected_dict = Value::from(crate::middleware::containers::Dictionary::new(
+            HashMap::from([
+                (
+                    crate::middleware::Key::from("custom"),
+                    Value::from(expected_custom_hash),
+                ),
+                (
+                    crate::middleware::Key::from("native"),
+                    Value::from(expected_native_hash),
+                ),
+            ]),
+        ));
+        assert_eq!(stmt2.args[1], StatementTmplArg::Literal(expected_dict));
+
+        Ok(())
     }
 }

--- a/src/lang/module.rs
+++ b/src/lang/module.rs
@@ -11,7 +11,9 @@ use crate::{
     lang::{
         error::BatchingError,
         frontend_ast::{ConjunctionType, CustomPredicateDef},
-        frontend_ast_lower::{lower_statement_arg, resolve_predicate_ref, ResolutionContext},
+        frontend_ast_lower::{
+            lower_statement_arg_with_context, resolve_predicate_ref, ResolutionContext,
+        },
         frontend_ast_split::{SplitChainInfo, SplitResult},
         frontend_ast_validate::SymbolTable,
     },
@@ -372,7 +374,13 @@ fn build_statement_with_resolved_refs(
     let mut builder = StatementTmplBuilder::new(pred_or_wc);
 
     for arg in &stmt.args {
-        builder = builder.arg(lower_statement_arg(arg));
+        let builder_arg =
+            lower_statement_arg_with_context(arg, symbols, &context).map_err(|e| {
+                BatchingError::Internal {
+                    message: format!("Failed to lower argument: {}", e),
+                }
+            })?;
+        builder = builder.arg(builder_arg);
     }
 
     Ok(builder)

--- a/src/lang/parser.rs
+++ b/src/lang/parser.rs
@@ -137,6 +137,8 @@ mod tests {
         assert_inner(&Rule::anchored_key, "someVar[\"key\"]");
         assert_inner(&Rule::literal_value, "true");
         assert_inner(&Rule::literal_value, "PublicKey(abc)");
+        assert_inner(&Rule::literal_value, "foo::bar");
+        assert_inner(&Rule::literal_value, "::Equal");
     }
 
     #[test]
@@ -189,6 +191,7 @@ mod tests {
         assert_parses(Rule::literal_array, "[]");
         assert_parses(Rule::literal_array, "[1, \"two\", true]");
         assert_parses(Rule::literal_array, "[ [1], #[2] ]");
+        assert_parses(Rule::literal_array, "[foo::bar, ::Equal, 1]");
 
         // Set
         assert_parses(Rule::literal_set, "#[]");
@@ -197,6 +200,7 @@ mod tests {
             Rule::literal_set,
             "#[ \"a\", Raw(0x0000000000000000000000000000000000000000000000000000000000000000) ]",
         );
+        assert_parses(Rule::literal_set, "#[foo::bar, ::Equal]");
 
         // Dict
         assert_parses(Rule::literal_dict, "{}");
@@ -206,6 +210,7 @@ mod tests {
             Rule::literal_dict,
             "{ \"raw_val\": Raw(0x0000000000000000000000000000000000000000000000000000000000000000) } ",
         );
+        assert_parses(Rule::literal_dict, "{ \"pred\": foo::bar }");
         assert_fails(Rule::literal_dict, "{ name: \"Alice\" }"); // Key must be string literal with quotes
     }
 


### PR DESCRIPTION
Closes #491.

This introduces predicate literals, of two kinds:
- Unqualified predicate literals, of the form `::pred_name`, which can be used for either native or intro predicates
- Qualified predicate literals, of the form `module::pred_name`, which can be used for external module predicate

Predicates from the local module cannot be referred to, to avoid circularity. Predicate literals can be used anywhere that a regular literal can appear, so it's possible to declare them as part of a set, dictionary, or array literal.

In making this PR I also observed that it's possible to create both intro predicates and custom predicates whose names clash with those of native predicates. I have adjusted the parser to reject such names.