### PR TITLE
Fix pod builder

### DIFF
--- a/src/backends/plonky2/mainpod/mod.rs
+++ b/src/backends/plonky2/mainpod/mod.rs
@@ -1195,7 +1195,8 @@ pub mod tests {
             cpr,
             [1, 1, 2].into_iter().map(middleware::Value::from).collect(),
         );
-        builder.insert(true, (st, op)).unwrap();
+        builder.insert((st.clone(), op)).unwrap();
+        builder.reveal(&st).unwrap();
         let prover = Prover {};
         builder.prove(&prover).unwrap();
     }

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -137,7 +137,7 @@ pub struct MainPodBuilder {
     pub operations: Vec<Operation>,
     pub public_statements: Vec<Statement>,
     // Internal state
-    dict_contains: Vec<(Value, Value)>, // (root, key)
+    contains: Vec<(RawValue, RawValue)>, // (root, key)
 }
 
 impl fmt::Display for MainPodBuilder {
@@ -171,10 +171,16 @@ impl MainPodBuilder {
             statements: Vec::new(),
             operations: Vec::new(),
             public_statements: Vec::new(),
-            dict_contains: Vec::new(),
+            contains: Vec::new(),
         }
     }
+    pub fn len(&self) -> usize {
+        self.operations.len()
+    }
     pub fn add_pod(&mut self, pod: MainPod) -> Result<()> {
+        for st in &pod.public_statements {
+            self.track_contains(st);
+        }
         self.input_pods.push(pod);
         match self.input_pods.len() > self.params.max_input_pods {
             true => Err(Error::too_many_input_pods(
@@ -184,21 +190,25 @@ impl MainPodBuilder {
             _ => Ok(()),
         }
     }
-    pub fn insert(&mut self, public: bool, st_op: (Statement, Operation)) -> Result<()> {
-        // TODO: Do error handling instead of panic
-        let (st, op) = st_op;
 
-        // If we're adding a Contains statement with literal arguments (an Entry), track it in
-        // `dict_contains` to avoid adding it again via `Self::add_entries_contains`.
+    // If we're adding a Contains statement with literal arguments (an Entry), track it in
+    // `dict_contains` to avoid adding it again via `Self::add_entries_contains`.
+    fn track_contains(&mut self, st: &Statement) {
         if let Statement::Contains(
             ValueRef::Literal(dict),
             ValueRef::Literal(key),
             ValueRef::Literal(_),
         ) = &st
         {
-            let root_key = (dict.clone(), key.clone());
-            self.dict_contains.push(root_key);
+            let root_key = (dict.raw(), key.raw());
+            self.contains.push(root_key);
         }
+    }
+
+    pub fn insert(&mut self, public: bool, st_op: (Statement, Operation)) -> Result<()> {
+        // TODO: Do error handling instead of panic
+        let (st, op) = st_op;
+        self.track_contains(&st);
 
         if public {
             self.public_statements.push(st.clone());
@@ -404,7 +414,7 @@ impl MainPodBuilder {
     }
 
     fn op_statement(
-        &mut self,
+        &self,
         wildcard_values: Vec<(usize, Value)>,
         op: Operation,
     ) -> Result<Statement> {
@@ -630,9 +640,16 @@ impl MainPodBuilder {
                 ValueRef::Literal(v),
             )) = arg
             {
-                let root_key = (dict.clone(), key.clone());
-                if !self.dict_contains.contains(&root_key) {
-                    self.dict_contains.push(root_key);
+                // if format!("{:#}", dict)
+                //     == "Raw(0xfa2ec82b6a771c76abfed381bc011d8a510775cec9744bc2acfb9d2cdd7141ce)"
+                // {
+                //     println!("DBG add_entries_contains");
+                //     println!("  - op: {:?}", op.0);
+                // }
+
+                let root_key = (dict.raw(), key.raw());
+                if !self.contains.contains(&root_key) {
+                    self.contains.push(root_key);
                     self.priv_op(Operation::dict_contains(dict, key, v))?;
                 }
             }
@@ -647,12 +664,40 @@ impl MainPodBuilder {
         wildcard_values: Vec<(usize, Value)>,
         op: Operation,
     ) -> Result<Statement> {
+        // DBG
+        // if op
+        //     .1
+        //     .get(0)
+        //     .map(|a| format!("{:#}", a))
+        //     .unwrap_or("".to_string())
+        //     == "Raw(0xfa2ec82b6a771c76abfed381bc011d8a510775cec9744bc2acfb9d2cdd7141ce)"
+        // {
+        //     let key_raw = match op.1.get(1).unwrap() {
+        //         OperationArg::Literal(v) => v.raw(),
+        //         _ => unreachable!(),
+        //     };
+        //     println!("DBG key: {}, aux: {}", key_raw, op.2);
+        //     match op.2 {
+        //         OperationAux::None => {
+        //             println!("DBG op args:");
+        //             for arg in &op.1 {
+        //                 println!("  - {}", arg);
+        //             }
+        //             println!("{}", std::backtrace::Backtrace::capture());
+        //         }
+        //         _ => {}
+        //     }
+        // }
+
         self.add_entries_contains(&op)?;
         let op = Self::fill_in_aux(Self::lower_op(op)?)?;
         let st = self.op_statement(wildcard_values, op.clone())?;
-        self.insert(public, (st, op))?;
+        // Skip adding the statement and operation if it already exists
+        if self.statements.iter().find(|s| **s == st).is_none() {
+            self.insert(public, (st.clone(), op))?;
+        }
 
-        Ok(self.statements[self.statements.len() - 1].clone())
+        Ok(st)
     }
 
     pub fn reveal(&mut self, st: &Statement) {

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -174,8 +174,8 @@ impl MainPodBuilder {
             contains: Vec::new(),
         }
     }
-    pub fn len(&self) -> usize {
-        self.operations.len()
+    pub fn stmt_len(&self) -> usize {
+        self.statements.len()
     }
     pub fn add_pod(&mut self, pod: MainPod) -> Result<()> {
         for st in &pod.public_statements {
@@ -661,7 +661,7 @@ impl MainPodBuilder {
         let op = Self::fill_in_aux(Self::lower_op(op)?)?;
         let st = self.op_statement(wildcard_values, op.clone())?;
         // Skip adding the statement and operation if it already exists
-        if self.statements.iter().find(|s| **s == st).is_none() {
+        if !self.statements.contains(&st) {
             self.insert(public, (st.clone(), op))?;
         }
 

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -631,7 +631,7 @@ impl MainPodBuilder {
     }
 
     /// For every operation that has Entry statements as arguments we add a Contains statement to
-    /// open the dictionary.
+    /// open the dictionary (unless such Contains already exists).
     fn add_entries_contains(&mut self, op: &Operation) -> Result<()> {
         for arg in &op.1 {
             if let OperationArg::Statement(Statement::Contains(
@@ -640,13 +640,6 @@ impl MainPodBuilder {
                 ValueRef::Literal(v),
             )) = arg
             {
-                // if format!("{:#}", dict)
-                //     == "Raw(0xfa2ec82b6a771c76abfed381bc011d8a510775cec9744bc2acfb9d2cdd7141ce)"
-                // {
-                //     println!("DBG add_entries_contains");
-                //     println!("  - op: {:?}", op.0);
-                // }
-
                 let root_key = (dict.raw(), key.raw());
                 if !self.contains.contains(&root_key) {
                     self.contains.push(root_key);
@@ -664,31 +657,6 @@ impl MainPodBuilder {
         wildcard_values: Vec<(usize, Value)>,
         op: Operation,
     ) -> Result<Statement> {
-        // DBG
-        // if op
-        //     .1
-        //     .get(0)
-        //     .map(|a| format!("{:#}", a))
-        //     .unwrap_or("".to_string())
-        //     == "Raw(0xfa2ec82b6a771c76abfed381bc011d8a510775cec9744bc2acfb9d2cdd7141ce)"
-        // {
-        //     let key_raw = match op.1.get(1).unwrap() {
-        //         OperationArg::Literal(v) => v.raw(),
-        //         _ => unreachable!(),
-        //     };
-        //     println!("DBG key: {}, aux: {}", key_raw, op.2);
-        //     match op.2 {
-        //         OperationAux::None => {
-        //             println!("DBG op args:");
-        //             for arg in &op.1 {
-        //                 println!("  - {}", arg);
-        //             }
-        //             println!("{}", std::backtrace::Backtrace::capture());
-        //         }
-        //         _ => {}
-        //     }
-        // }
-
         self.add_entries_contains(&op)?;
         let op = Self::fill_in_aux(Self::lower_op(op)?)?;
         let st = self.op_statement(wildcard_values, op.clone())?;

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -205,20 +205,11 @@ impl MainPodBuilder {
         }
     }
 
-    pub fn insert(&mut self, public: bool, st_op: (Statement, Operation)) -> Result<()> {
+    pub fn insert(&mut self, st_op: (Statement, Operation)) -> Result<()> {
         // TODO: Do error handling instead of panic
         let (st, op) = st_op;
         self.track_contains(&st);
 
-        if public {
-            self.public_statements.push(st.clone());
-        }
-        if self.public_statements.len() > self.params.max_public_statements {
-            return Err(Error::too_many_public_statements(
-                self.public_statements.len(),
-                self.params.max_public_statements,
-            ));
-        }
         self.statements.push(st);
         self.operations.push(op);
         if self.statements.len() > self.params.max_statements {
@@ -662,14 +653,26 @@ impl MainPodBuilder {
         let st = self.op_statement(wildcard_values, op.clone())?;
         // Skip adding the statement and operation if it already exists
         if !self.statements.contains(&st) {
-            self.insert(public, (st.clone(), op))?;
+            self.insert((st.clone(), op))?;
+        }
+        if public {
+            self.reveal(&st)?;
         }
 
         Ok(st)
     }
 
-    pub fn reveal(&mut self, st: &Statement) {
-        self.public_statements.push(st.clone());
+    pub fn reveal(&mut self, st: &Statement) -> Result<()> {
+        if !self.public_statements.contains(st) {
+            self.public_statements.push(st.clone());
+        }
+        if self.public_statements.len() > self.params.max_public_statements {
+            return Err(Error::too_many_public_statements(
+                self.public_statements.len(),
+                self.params.max_public_statements,
+            ));
+        }
+        Ok(())
     }
 
     pub fn prove(&self, prover: &dyn MainPodProver) -> Result<MainPod> {
@@ -1364,11 +1367,9 @@ pub mod tests {
             OperationAux::None,
         );
         builder
-            .insert(false, (value_of_a.clone(), op_contains.clone()))
+            .insert((value_of_a.clone(), op_contains.clone()))
             .unwrap();
-        builder
-            .insert(false, (value_of_b.clone(), op_contains))
-            .unwrap();
+        builder.insert((value_of_b.clone(), op_contains)).unwrap();
         let st = Statement::equal(
             AnchoredKey::from((&local, "a")),
             AnchoredKey::from((&local, "b")),
@@ -1381,7 +1382,7 @@ pub mod tests {
             ],
             OperationAux::None,
         );
-        builder.insert(false, (st, op)).unwrap();
+        builder.insert((st, op)).unwrap();
 
         let prover = MockProver {};
         let pod = builder.prove(&prover).unwrap();

--- a/src/frontend/multi_pod/cost.rs
+++ b/src/frontend/multi_pod/cost.rs
@@ -23,44 +23,6 @@ impl From<&CustomPredicateRef> for CustomPredicateId {
     }
 }
 
-// /// Unique identifier for an anchored key (dict, key) pair.
-// ///
-// /// When a Contains statement is used as an argument to operations like gt(), eq(), etc.,
-// /// the value is accessed via an "anchored key" - a reference to a specific key in a
-// /// specific dictionary. Each unique anchored key used in a POD requires a Contains
-// /// statement to be present in that POD (auto-inserted by MainPodBuilder if needed).
-// ///
-// /// We use the raw values of the dict and key for comparison, as they uniquely identify
-// /// the anchored key regardless of the specific Value types involved.
-// #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// pub struct AnchoredKeyId {
-//     /// The dictionary root value (raw representation for Ord).
-//     pub dict: RawValue,
-//     /// The key within the dictionary (raw representation for Ord).
-//     pub key: RawValue,
-// }
-//
-// impl AnchoredKeyId {
-//     /// Create a new anchored key ID from raw values.
-//     pub fn new(dict: RawValue, key: RawValue) -> Self {
-//         Self { dict, key }
-//     }
-//
-//     /// Try to extract an anchored key ID from a Contains statement with all literal values.
-//     pub fn from_contains_statement(stmt: &Statement) -> Option<Self> {
-//         if let Statement::Contains(
-//             ValueRef::Literal(dict),
-//             ValueRef::Literal(key),
-//             ValueRef::Literal(_value),
-//         ) = stmt
-//         {
-//             Some(Self::new(dict.raw(), key.raw()))
-//         } else {
-//             None
-//         }
-//     }
-// }
-
 /// Resource costs for a single statement/operation.
 ///
 /// Each field corresponds to a resource with a per-POD limit in `Params`.
@@ -89,13 +51,6 @@ pub struct StatementCost {
     /// Custom predicates used (for custom predicate cardinality constraint).
     /// Limit: `params.max_custom_predicates` distinct custom predicates per POD.
     pub custom_predicates_ids: BTreeSet<CustomPredicateId>,
-    // /// Anchored keys referenced by this operation.
-    // ///
-    // /// When a Contains statement with all literal values is used as an argument,
-    // /// the operation references an "anchored key" (dict, key pair). Each unique
-    // /// anchored key used in a POD incurs an additional Contains statement cost,
-    // /// as MainPodBuilder::add_entries_contains will auto-insert it if not already present.
-    // pub anchored_keys: BTreeSet<AnchoredKeyId>,
 }
 
 impl StatementCost {
@@ -165,18 +120,6 @@ impl StatementCost {
                     .insert(CustomPredicateId::from(cpr));
             }
         }
-
-        // Extract anchored keys from operation arguments.
-        // Any argument that is a Contains statement with all literal values
-        // represents an anchored key reference that will require a Contains
-        // statement in the POD (auto-inserted by MainPodBuilder if needed).
-        // for arg in &op.1 {
-        //     if let OperationArg::Statement(stmt) = arg {
-        //         if let Some(anchored_key) = AnchoredKeyId::from_contains_statement(stmt) {
-        //             cost.anchored_keys.insert(anchored_key);
-        //         }
-        //     }
-        // }
 
         cost
     }

--- a/src/frontend/multi_pod/cost.rs
+++ b/src/frontend/multi_pod/cost.rs
@@ -6,10 +6,8 @@
 use std::collections::BTreeSet;
 
 use crate::{
-    frontend::{Operation, OperationArg},
-    middleware::{
-        CustomPredicateBatch, Hash, NativeOperation, OperationType, RawValue, Statement, ValueRef,
-    },
+    frontend::Operation,
+    middleware::{CustomPredicateBatch, Hash, NativeOperation, OperationType},
 };
 
 /// Unique identifier for a custom predicate batch.
@@ -25,43 +23,43 @@ impl From<&CustomPredicateBatch> for CustomBatchId {
     }
 }
 
-/// Unique identifier for an anchored key (dict, key) pair.
-///
-/// When a Contains statement is used as an argument to operations like gt(), eq(), etc.,
-/// the value is accessed via an "anchored key" - a reference to a specific key in a
-/// specific dictionary. Each unique anchored key used in a POD requires a Contains
-/// statement to be present in that POD (auto-inserted by MainPodBuilder if needed).
-///
-/// We use the raw values of the dict and key for comparison, as they uniquely identify
-/// the anchored key regardless of the specific Value types involved.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct AnchoredKeyId {
-    /// The dictionary root value (raw representation for Ord).
-    pub dict: RawValue,
-    /// The key within the dictionary (raw representation for Ord).
-    pub key: RawValue,
-}
-
-impl AnchoredKeyId {
-    /// Create a new anchored key ID from raw values.
-    pub fn new(dict: RawValue, key: RawValue) -> Self {
-        Self { dict, key }
-    }
-
-    /// Try to extract an anchored key ID from a Contains statement with all literal values.
-    pub fn from_contains_statement(stmt: &Statement) -> Option<Self> {
-        if let Statement::Contains(
-            ValueRef::Literal(dict),
-            ValueRef::Literal(key),
-            ValueRef::Literal(_value),
-        ) = stmt
-        {
-            Some(Self::new(dict.raw(), key.raw()))
-        } else {
-            None
-        }
-    }
-}
+// /// Unique identifier for an anchored key (dict, key) pair.
+// ///
+// /// When a Contains statement is used as an argument to operations like gt(), eq(), etc.,
+// /// the value is accessed via an "anchored key" - a reference to a specific key in a
+// /// specific dictionary. Each unique anchored key used in a POD requires a Contains
+// /// statement to be present in that POD (auto-inserted by MainPodBuilder if needed).
+// ///
+// /// We use the raw values of the dict and key for comparison, as they uniquely identify
+// /// the anchored key regardless of the specific Value types involved.
+// #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// pub struct AnchoredKeyId {
+//     /// The dictionary root value (raw representation for Ord).
+//     pub dict: RawValue,
+//     /// The key within the dictionary (raw representation for Ord).
+//     pub key: RawValue,
+// }
+//
+// impl AnchoredKeyId {
+//     /// Create a new anchored key ID from raw values.
+//     pub fn new(dict: RawValue, key: RawValue) -> Self {
+//         Self { dict, key }
+//     }
+//
+//     /// Try to extract an anchored key ID from a Contains statement with all literal values.
+//     pub fn from_contains_statement(stmt: &Statement) -> Option<Self> {
+//         if let Statement::Contains(
+//             ValueRef::Literal(dict),
+//             ValueRef::Literal(key),
+//             ValueRef::Literal(_value),
+//         ) = stmt
+//         {
+//             Some(Self::new(dict.raw(), key.raw()))
+//         } else {
+//             None
+//         }
+//     }
+// }
 
 /// Resource costs for a single statement/operation.
 ///
@@ -88,17 +86,17 @@ pub struct StatementCost {
     /// Limit: `params.max_public_key_of`
     pub public_key_of: usize,
 
+    // TODO: This needs to be replaced by custom_predicate_ids!
     /// Custom predicate batches used (for batch cardinality constraint).
     /// Limit: `params.max_custom_predicate_batches` distinct batches per POD.
     pub custom_batch_ids: BTreeSet<CustomBatchId>,
-
-    /// Anchored keys referenced by this operation.
-    ///
-    /// When a Contains statement with all literal values is used as an argument,
-    /// the operation references an "anchored key" (dict, key pair). Each unique
-    /// anchored key used in a POD incurs an additional Contains statement cost,
-    /// as MainPodBuilder::add_entries_contains will auto-insert it if not already present.
-    pub anchored_keys: BTreeSet<AnchoredKeyId>,
+    // /// Anchored keys referenced by this operation.
+    // ///
+    // /// When a Contains statement with all literal values is used as an argument,
+    // /// the operation references an "anchored key" (dict, key pair). Each unique
+    // /// anchored key used in a POD incurs an additional Contains statement cost,
+    // /// as MainPodBuilder::add_entries_contains will auto-insert it if not already present.
+    // pub anchored_keys: BTreeSet<AnchoredKeyId>,
 }
 
 impl StatementCost {
@@ -173,13 +171,13 @@ impl StatementCost {
         // Any argument that is a Contains statement with all literal values
         // represents an anchored key reference that will require a Contains
         // statement in the POD (auto-inserted by MainPodBuilder if needed).
-        for arg in &op.1 {
-            if let OperationArg::Statement(stmt) = arg {
-                if let Some(anchored_key) = AnchoredKeyId::from_contains_statement(stmt) {
-                    cost.anchored_keys.insert(anchored_key);
-                }
-            }
-        }
+        // for arg in &op.1 {
+        //     if let OperationArg::Statement(stmt) = arg {
+        //         if let Some(anchored_key) = AnchoredKeyId::from_contains_statement(stmt) {
+        //             cost.anchored_keys.insert(anchored_key);
+        //         }
+        //     }
+        // }
 
         cost
     }

--- a/src/frontend/multi_pod/cost.rs
+++ b/src/frontend/multi_pod/cost.rs
@@ -7,19 +7,19 @@ use std::collections::BTreeSet;
 
 use crate::{
     frontend::Operation,
-    middleware::{CustomPredicateBatch, Hash, NativeOperation, OperationType},
+    middleware::{CustomPredicateRef, Hash, NativeOperation, OperationType, Predicate},
 };
 
-/// Unique identifier for a custom predicate batch.
+/// Unique identifier for a custom predicate in a module.
 ///
-/// Uses the batch's cryptographic hash as identifier. Two batches with the same
+/// Uses the predicate's cryptographic hash as identifier. Two predicates with the same
 /// hash are considered identical for resource counting purposes.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct CustomBatchId(pub Hash);
+pub struct CustomPredicateId(pub Hash);
 
-impl From<&CustomPredicateBatch> for CustomBatchId {
-    fn from(batch: &CustomPredicateBatch) -> Self {
-        Self(batch.id())
+impl From<&CustomPredicateRef> for CustomPredicateId {
+    fn from(predicate: &CustomPredicateRef) -> Self {
+        Self(Predicate::Custom(predicate.clone()).hash())
     }
 }
 
@@ -86,10 +86,9 @@ pub struct StatementCost {
     /// Limit: `params.max_public_key_of`
     pub public_key_of: usize,
 
-    // TODO: This needs to be replaced by custom_predicate_ids!
-    /// Custom predicate batches used (for batch cardinality constraint).
-    /// Limit: `params.max_custom_predicate_batches` distinct batches per POD.
-    pub custom_batch_ids: BTreeSet<CustomBatchId>,
+    /// Custom predicates used (for custom predicate cardinality constraint).
+    /// Limit: `params.max_custom_predicates` distinct custom predicates per POD.
+    pub custom_predicates_ids: BTreeSet<CustomPredicateId>,
     // /// Anchored keys referenced by this operation.
     // ///
     // /// When a Contains statement with all literal values is used as an argument,
@@ -162,8 +161,8 @@ impl StatementCost {
             }
             OperationType::Custom(cpr) => {
                 cost.custom_pred_verifications = 1;
-                cost.custom_batch_ids
-                    .insert(CustomBatchId::from(&*cpr.batch));
+                cost.custom_predicates_ids
+                    .insert(CustomPredicateId::from(cpr));
             }
         }
 

--- a/src/frontend/multi_pod/deps.rs
+++ b/src/frontend/multi_pod/deps.rs
@@ -5,7 +5,6 @@
 
 use std::collections::HashMap;
 
-// use super::cost::AnchoredKeyId;
 use crate::{
     frontend::{Operation, OperationArg},
     middleware::{Hash, Statement},

--- a/src/frontend/multi_pod/deps.rs
+++ b/src/frontend/multi_pod/deps.rs
@@ -100,11 +100,6 @@ impl DependencyGraph {
                             pod_hash,
                             statement: dep_stmt.clone(),
                         }));
-                    // }  else if AnchoredKeyId::from_contains_statement(dep_stmt).is_some() {
-                    //   // Anchored-key Contains args may be implicit requirements that are
-                    //   // auto-materialized by MainPodBuilder. They are handled by anchored-key
-                    //   // resource accounting, not by statement dependency edges.
-                    //   continue;
                     } else {
                         // Statement arguments should either be internal (created earlier)
                         // or from external PODs (except anchored-key implicit Contains).

--- a/src/frontend/multi_pod/deps.rs
+++ b/src/frontend/multi_pod/deps.rs
@@ -128,9 +128,8 @@ impl DependencyGraph {
 mod tests {
     use super::*;
     use crate::{
-        dict,
         frontend::Operation as FrontendOp,
-        middleware::{AnchoredKey, NativeOperation, OperationAux, OperationType, Value, ValueRef},
+        middleware::{NativeOperation, OperationAux, OperationType, Value, ValueRef},
     };
 
     fn equal_stmt(n: i64) -> Statement {
@@ -194,33 +193,5 @@ mod tests {
         assert!(graph.statement_deps[0].is_empty());
         assert_eq!(graph.statement_deps[1], vec![StatementSource::Internal(0)]);
         assert_eq!(graph.statement_deps[2], vec![StatementSource::Internal(0)]);
-    }
-
-    #[test]
-    fn test_anchored_key_contains_arg_is_treated_as_implicit_requirement() {
-        // A literal Contains statement can be used as an anchored-key argument even when
-        // no explicit producer statement exists in internal/external statements, because
-        // MainPodBuilder auto-inserts Contains statements for anchored keys.
-        let dict = dict!({
-            "k" => 7_i64
-        });
-
-        let anchored_contains = Statement::Contains(
-            ValueRef::Literal(Value::from(dict.clone())),
-            ValueRef::Literal(Value::from("k")),
-            ValueRef::Literal(Value::from(7_i64)),
-        );
-        let ak = AnchoredKey::from((&dict, "k"));
-        let produced_statement = Statement::Equal(ValueRef::Key(ak.clone()), ValueRef::Key(ak));
-
-        // Use a typical frontend operation that consumes entry-like args.
-        // We're only testing the dependency graph, not the actual proof, so the operation
-        // just needs to have the right arguments to test what we're looking for.
-        let statements = vec![produced_statement];
-        let operations = vec![FrontendOp::eq(anchored_contains.clone(), anchored_contains)];
-
-        let graph = DependencyGraph::build(&statements, &operations, &HashMap::new());
-
-        assert!(graph.statement_deps[0].is_empty());
     }
 }

--- a/src/frontend/multi_pod/deps.rs
+++ b/src/frontend/multi_pod/deps.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashMap;
 
-use super::cost::AnchoredKeyId;
+// use super::cost::AnchoredKeyId;
 use crate::{
     frontend::{Operation, OperationArg},
     middleware::{Hash, Statement},
@@ -100,11 +100,11 @@ impl DependencyGraph {
                             pod_hash,
                             statement: dep_stmt.clone(),
                         }));
-                    } else if AnchoredKeyId::from_contains_statement(dep_stmt).is_some() {
-                        // Anchored-key Contains args may be implicit requirements that are
-                        // auto-materialized by MainPodBuilder. They are handled by anchored-key
-                        // resource accounting, not by statement dependency edges.
-                        continue;
+                    // }  else if AnchoredKeyId::from_contains_statement(dep_stmt).is_some() {
+                    //   // Anchored-key Contains args may be implicit requirements that are
+                    //   // auto-materialized by MainPodBuilder. They are handled by anchored-key
+                    //   // resource accounting, not by statement dependency edges.
+                    //   continue;
                     } else {
                         // Statement arguments should either be internal (created earlier)
                         // or from external PODs (except anchored-key implicit Contains).

--- a/src/frontend/multi_pod/mod.rs
+++ b/src/frontend/multi_pod/mod.rs
@@ -502,17 +502,29 @@ impl MultiPodBuilder {
         self.op(false, vec![], op)
     }
 
+    // Find the index of a statement that has been added.  Panics if the statement doesn't
+    // exist.
+    fn stmt_index(&self, stmt: &Statement) -> usize {
+        self.builder
+            .statements
+            .iter()
+            .position(|s| s == stmt)
+            .expect("exists")
+    }
+
     pub fn op(
         &mut self,
         public: bool,
         wildcard_values: Vec<(usize, Value)>,
         op: Operation,
     ) -> Result<Statement> {
-        if public {
-            // Index is always new (just added), so push without duplicate check
-            self.output_public_indices.push(self.len());
-        }
         let stmt = self.add_operation(wildcard_values, op)?;
+        if public {
+            let index = self.stmt_index(&stmt);
+            if !self.output_public_indices.contains(&index) {
+                self.output_public_indices.push(self.stmt_index(&stmt));
+            }
+        }
         Ok(stmt)
     }
 
@@ -522,8 +534,6 @@ impl MultiPodBuilder {
         wildcard_values: Vec<(usize, Value)>,
         op: Operation,
     ) -> Result<Statement> {
-        self.operations_wildcard_values
-            .insert(self.len(), wildcard_values.clone());
         // Get or create the cached builder
         //
         // NOTE: We clone input pods here because MainPodBuilder takes ownership.
@@ -534,6 +544,8 @@ impl MultiPodBuilder {
         let stmt = self
             .builder
             .op(false, wildcard_values.clone(), op.clone())?;
+        self.operations_wildcard_values
+            .insert(self.stmt_index(&stmt), wildcard_values.clone());
 
         Ok(stmt)
     }

--- a/src/frontend/multi_pod/mod.rs
+++ b/src/frontend/multi_pod/mod.rs
@@ -784,42 +784,21 @@ mod tests {
         // provide dependencies to the output POD.
         let solved = builder.solve()?;
         let solution = solved.solution();
-        println!("{:#?}", solution);
 
         // Expected: exactly 2 PODs
-        //   - POD 0 (intermediate): statements 0 (contains), 1 (a_out); a_out is public
-        //   - POD 1 (output): statement 2 (b_out); b_out is public
-        // The output POD accesses a_out from POD 0 to satisfy b_out's dependency.
-        // assert_eq!(
-        //     solution.pod_count, 2,
-        //     "Expected exactly 2 PODs for 3-statement chain with max_priv=2"
-        // );
+        //   Solution A:
+        //   - POD 0 (intermediate): public statements 0 (contains)
+        //   - POD 1 (output): inherits statement 0 (contains) from POD0, statement 1 (a_out),
+        //   public statement 2 (b_out)
+        //   Solution B:
+        //   - POD 0 (intermediate): statements 0 (contains), public statement 1 (a_out)
+        //   - POD 1 (output): inherits statement 1 (a_out) from POD0, public statement 2 (b_out)
 
-        // // POD 0 should contain statements 0 and 1 (contains and a_out)
-        // assert!(
-        //     solution.pod_statements[0].contains(&0) && solution.pod_statements[0].contains(&1),
-        //     "POD 0 should contain statements 0 (contains) and 1 (a_out), got {:?}",
-        //     solution.pod_statements[0]
-        // );
-
-        // // Statement 1 (a_out) should be public in POD 0 so POD 1 can access it
-        // assert!(
-        //     solution.pod_public_statements[0].contains(&1),
-        //     "Statement 1 (a_out) should be public in POD 0"
-        // );
-
-        // // POD 1 (output) should contain statement 2 (b_out)
-        // assert!(
-        //     solution.pod_statements[1].contains(&2),
-        //     "POD 1 should contain statement 2 (b_out), got {:?}",
-        //     solution.pod_statements[1]
-        // );
-
-        // // Statement 2 (b_out) should be public in POD 1 (it's output-public)
-        // assert!(
-        //     solution.pod_public_statements[1].contains(&2),
-        //     "Statement 2 (b_out) should be public in output POD"
-        // );
+        // Statement 2 (b_out) should be public in POD 1 (it's output-public)
+        assert!(
+            solution.pod_public_statements[1].contains(&2),
+            "Statement 2 (b_out) should be public in output POD"
+        );
 
         // Prove and verify all PODs
         let prover = MockProver {};

--- a/src/frontend/multi_pod/mod.rs
+++ b/src/frontend/multi_pod/mod.rs
@@ -168,10 +168,6 @@ pub struct MultiPodBuilder {
     options: Options,
     /// External input PODs (already proved).
     input_pods: Vec<MainPod>,
-    /// Statements created by this builder.
-    // statements: Vec<Statement>,
-    /// Operations that produce each statement.
-    // operations: Vec<Operation>,
     /// Optional initial wildcard values for custom operations
     operations_wildcard_values: HashMap<usize, Vec<(usize, Value)>>,
     /// Indices of statements that should be public in output PODs.
@@ -261,76 +257,27 @@ impl SolvedMultiPod {
         let statements_sorted: BTreeSet<usize> = statements_in_this_pod.iter().copied().collect();
         let public_set = &solution.pod_public_statements[pod_idx];
 
-        // TODO: Remove this because we're deduping earlier
-        // Track statements proved locally in this POD for argument remapping.
-        // We index by statement content so duplicate statements can reuse a single
-        // built statement slot in MainPodBuilder.
-        let mut added_statements_by_content: HashMap<Statement, Statement> = HashMap::new();
-
         for &stmt_idx in &statements_sorted {
-            let original_stmt = self.statements[stmt_idx].clone();
-
-            // If this statement content was already built in this POD, reuse it instead
-            // of replaying the operation. If any duplicate is public, reveal the
-            // already-built statement.
-            if let Some(_existing_stmt) = added_statements_by_content.get(&original_stmt) {
-                continue;
-            }
-
-            let mut op = self.operations[stmt_idx].clone();
-            // DBG
-            // if op
-            //     .1
-            //     .get(0)
-            //     .map(|a| format!("{:#}", a))
-            //     .unwrap_or("".to_string())
-            //     == "Raw(0xfa2ec82b6a771c76abfed381bc011d8a510775cec9744bc2acfb9d2cdd7141ce)"
-            // {
-            //     let key_raw = match op.1.get(1).unwrap() {
-            //         OperationArg::Literal(v) => v.raw(),
-            //         _ => unreachable!(),
-            //     };
-            //     println!("DBG (solver) key: {}, aux: {}", key_raw, op.2);
-            // }
+            let op = self.operations[stmt_idx].clone();
             let wildcard_values = self
                 .operations_wildcard_values
                 .get(&stmt_idx)
                 .cloned()
                 .unwrap_or_default();
 
-            // Remap Statement arguments that reference locally-proved statements.
-            // For external dependencies (from input PODs including earlier generated PODs),
-            // the original Statement is used directly - MainPodBuilder will find it in
-            // the input POD's public statements via find_op_arg.
-            for arg in &mut op.1 {
-                if let OperationArg::Statement(ref orig_stmt) = arg {
-                    if let Some(remapped_stmt) = added_statements_by_content.get(orig_stmt) {
-                        *arg = OperationArg::Statement(remapped_stmt.clone());
-                    }
-                }
-            }
-
-            // println!("DBG add op {}", op);
             let stmt = builder.op(false, wildcard_values, op)?;
-
-            added_statements_by_content.insert(original_stmt, stmt);
+            assert_eq!(stmt, self.statements[stmt_idx]); // Sanity check
         }
 
         // For the output pod, make statements public in the original order.
         // Intermediate pods use the solver-selected public set.
         if pod_idx == solution.pod_count - 1 {
             for idx in &self.output_public_indices {
-                let stmt = added_statements_by_content
-                    .get(&self.statements[*idx])
-                    .expect("exists");
-                builder.reveal(stmt);
+                builder.reveal(&self.statements[*idx]);
             }
         } else {
             for idx in public_set {
-                let stmt = added_statements_by_content
-                    .get(&self.statements[*idx])
-                    .expect("exists");
-                builder.reveal(stmt);
+                builder.reveal(&self.statements[*idx]);
             }
         }
 
@@ -463,7 +410,6 @@ impl MultiPodBuilder {
 
     /// Create a new MultiPodBuilder with custom options.
     pub fn new_with_options(params: &Params, vd_set: &VDSet, options: Options) -> Self {
-        // println!("DBG MultiPodBuilder.new");
         let unlimited_params = Params {
             max_statements: usize::MAX / 2,
             max_public_statements: usize::MAX / 2,
@@ -478,8 +424,6 @@ impl MultiPodBuilder {
             options,
             builder,
             input_pods: Vec::new(),
-            // statements: Vec::new(),
-            // operations: Vec::new(),
             operations_wildcard_values: HashMap::new(),
             output_public_indices: Vec::new(),
         }
@@ -582,56 +526,17 @@ impl MultiPodBuilder {
             operations,
             ..
         } = self.builder;
-        // println!("DBG MultiPodBuilder.solve statements:");
-        // for (i, st) in statements.iter().enumerate() {
-        //     println!("  {}: {}", i, st);
-        // }
         // Compute costs for each statement
         let costs: Vec<StatementCost> = operations
             .iter()
             .map(StatementCost::from_operation)
             .collect();
 
-        // Collect all unique anchored keys from the costs
-        // let all_anchored_keys: Vec<AnchoredKeyId> = costs
-        //     .iter()
-        //     .flat_map(|c| c.anchored_keys.iter().cloned())
-        //     .collect::<std::collections::BTreeSet<_>>()
-        //     .into_iter()
-        //     .collect();
-
-        // Build map from anchored key to its producing statement index (if any).
-        // A Contains statement with literal (dict, key, value) "produces" that anchored key.
-        // let mut ak_to_producer: HashMap<AnchoredKeyId, usize> = HashMap::new();
-        // for (stmt_idx, stmt) in statements.iter().enumerate() {
-        //     if let Some(ak) = AnchoredKeyId::from_contains_statement(stmt) {
-        //         // First producer wins (shouldn't have duplicates in practice)
-        //         ak_to_producer.entry(ak).or_insert(stmt_idx);
-        //     }
-        // }
-
-        // Build parallel array: anchored_key_producers[i] = producer for all_anchored_keys[i]
-        // let anchored_key_producers: Vec<Option<usize>> = all_anchored_keys
-        //     .iter()
-        //     .map(|ak| ak_to_producer.get(ak).copied())
-        //     .collect();
-
         // Build external POD statement mapping
         let external_pod_statements = build_external_statement_map(&self.input_pods);
 
         // Build dependency graph
         let deps = DependencyGraph::build(&statements, &operations, &external_pod_statements);
-
-        // // Build statement content groups for deduplication.
-        // // Statements with identical content share a single slot in the POD.
-        // // Keep groups ordered by first occurrence index for deterministic solver input.
-        // let mut first_idx_by_stmt: HashMap<&Statement, usize> = HashMap::new();
-        // let mut groups_by_first_idx: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
-        // for (idx, stmt) in statements.iter().enumerate() {
-        //     let first_idx = *first_idx_by_stmt.entry(stmt).or_insert(idx);
-        //     groups_by_first_idx.entry(first_idx).or_default().push(idx);
-        // }
-        // let statement_content_groups: Vec<Vec<usize>> = groups_by_first_idx.into_values().collect();
 
         // Run solver
         let input = solver::SolverInput {
@@ -641,12 +546,8 @@ impl MultiPodBuilder {
             output_public_indices: &self.output_public_indices,
             params: &self.params,
             max_pods: self.options.max_pods,
-            // all_anchored_keys: &all_anchored_keys,
-            // anchored_key_producers: &anchored_key_producers,
-            // statement_content_groups: &statement_content_groups,
         };
 
-        println!("{:#?}", input);
         let solution = solver::solve(&input)?;
 
         Ok(SolvedMultiPod {

--- a/src/frontend/multi_pod/mod.rs
+++ b/src/frontend/multi_pod/mod.rs
@@ -48,7 +48,7 @@
 //! [`MainPodBuilder`]: crate::frontend::MainPodBuilder
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeSet, HashMap},
     fmt,
 };
 
@@ -61,7 +61,7 @@ mod cost;
 mod deps;
 mod solver;
 
-use cost::{AnchoredKeyId, StatementCost};
+use cost::StatementCost;
 use deps::{DependencyGraph, StatementSource};
 pub use solver::MultiPodSolution;
 
@@ -169,11 +169,11 @@ pub struct MultiPodBuilder {
     /// External input PODs (already proved).
     input_pods: Vec<MainPod>,
     /// Statements created by this builder.
-    statements: Vec<Statement>,
+    // statements: Vec<Statement>,
     /// Operations that produce each statement.
-    operations: Vec<Operation>,
+    // operations: Vec<Operation>,
     /// Optional initial wildcard values for custom operations
-    operations_wildcard_values: Vec<Vec<(usize, Value)>>,
+    operations_wildcard_values: HashMap<usize, Vec<(usize, Value)>>,
     /// Indices of statements that should be public in output PODs.
     /// Uses Vec since max_public_statements is small (≤8); indices are naturally sorted.
     output_public_indices: Vec<usize>,
@@ -193,7 +193,7 @@ pub struct SolvedMultiPod {
     statements: Vec<Statement>,
     operations: Vec<Operation>,
     output_public_indices: Vec<usize>,
-    operations_wildcard_values: Vec<Vec<(usize, Value)>>,
+    operations_wildcard_values: HashMap<usize, Vec<(usize, Value)>>,
     solution: MultiPodSolution,
     deps: DependencyGraph,
 }
@@ -217,6 +217,7 @@ impl SolvedMultiPod {
         let mut pods: Vec<MainPod> = Vec::with_capacity(solution.pod_count);
 
         for pod_idx in 0..solution.pod_count {
+            // println!("DBG SolvedMultiPod.prove pod {}", pod_idx);
             let pod = self.build_single_pod(pod_idx, &pods, prover)?;
             pods.push(pod);
         }
@@ -260,6 +261,7 @@ impl SolvedMultiPod {
         let statements_sorted: BTreeSet<usize> = statements_in_this_pod.iter().copied().collect();
         let public_set = &solution.pod_public_statements[pod_idx];
 
+        // TODO: Remove this because we're deduping earlier
         // Track statements proved locally in this POD for argument remapping.
         // We index by statement content so duplicate statements can reuse a single
         // built statement slot in MainPodBuilder.
@@ -276,7 +278,25 @@ impl SolvedMultiPod {
             }
 
             let mut op = self.operations[stmt_idx].clone();
-            let wildcard_values = self.operations_wildcard_values[stmt_idx].clone();
+            // DBG
+            // if op
+            //     .1
+            //     .get(0)
+            //     .map(|a| format!("{:#}", a))
+            //     .unwrap_or("".to_string())
+            //     == "Raw(0xfa2ec82b6a771c76abfed381bc011d8a510775cec9744bc2acfb9d2cdd7141ce)"
+            // {
+            //     let key_raw = match op.1.get(1).unwrap() {
+            //         OperationArg::Literal(v) => v.raw(),
+            //         _ => unreachable!(),
+            //     };
+            //     println!("DBG (solver) key: {}, aux: {}", key_raw, op.2);
+            // }
+            let wildcard_values = self
+                .operations_wildcard_values
+                .get(&stmt_idx)
+                .cloned()
+                .unwrap_or_default();
 
             // Remap Statement arguments that reference locally-proved statements.
             // For external dependencies (from input PODs including earlier generated PODs),
@@ -290,6 +310,7 @@ impl SolvedMultiPod {
                 }
             }
 
+            // println!("DBG add op {}", op);
             let stmt = builder.op(false, wildcard_values, op)?;
 
             added_statements_by_content.insert(original_stmt, stmt);
@@ -442,6 +463,7 @@ impl MultiPodBuilder {
 
     /// Create a new MultiPodBuilder with custom options.
     pub fn new_with_options(params: &Params, vd_set: &VDSet, options: Options) -> Self {
+        // println!("DBG MultiPodBuilder.new");
         let unlimited_params = Params {
             max_statements: usize::MAX / 2,
             max_public_statements: usize::MAX / 2,
@@ -456,9 +478,9 @@ impl MultiPodBuilder {
             options,
             builder,
             input_pods: Vec::new(),
-            statements: Vec::new(),
-            operations: Vec::new(),
-            operations_wildcard_values: Vec::new(),
+            // statements: Vec::new(),
+            // operations: Vec::new(),
+            operations_wildcard_values: HashMap::new(),
             output_public_indices: Vec::new(),
         }
     }
@@ -486,11 +508,11 @@ impl MultiPodBuilder {
         wildcard_values: Vec<(usize, Value)>,
         op: Operation,
     ) -> Result<Statement> {
-        let stmt = self.add_operation(wildcard_values, op)?;
         if public {
             // Index is always new (just added), so push without duplicate check
-            self.output_public_indices.push(self.statements.len() - 1);
+            self.output_public_indices.push(self.len());
         }
+        let stmt = self.add_operation(wildcard_values, op)?;
         Ok(stmt)
     }
 
@@ -500,6 +522,8 @@ impl MultiPodBuilder {
         wildcard_values: Vec<(usize, Value)>,
         op: Operation,
     ) -> Result<Statement> {
+        self.operations_wildcard_values
+            .insert(self.len(), wildcard_values.clone());
         // Get or create the cached builder
         //
         // NOTE: We clone input pods here because MainPodBuilder takes ownership.
@@ -511,10 +535,6 @@ impl MultiPodBuilder {
             .builder
             .op(false, wildcard_values.clone(), op.clone())?;
 
-        self.statements.push(stmt.clone());
-        self.operations.push(op);
-        self.operations_wildcard_values.push(wildcard_values);
-
         Ok(stmt)
     }
 
@@ -523,7 +543,7 @@ impl MultiPodBuilder {
     /// Returns an error if the statement was not found in the builder.
     /// Calling this multiple times on the same statement is idempotent.
     pub fn reveal(&mut self, stmt: &Statement) -> Result<()> {
-        if let Some(idx) = self.statements.iter().position(|s| s == stmt) {
+        if let Some(idx) = self.builder.statements.iter().position(|s| s == stmt) {
             if !self.output_public_indices.contains(&idx) {
                 self.output_public_indices.push(idx);
             }
@@ -536,8 +556,8 @@ impl MultiPodBuilder {
     }
 
     /// Get the number of statements.
-    pub fn num_statements(&self) -> usize {
-        self.statements.len()
+    pub fn len(&self) -> usize {
+        self.builder.len()
     }
 
     /// Solve the packing problem and return a solved builder ready for proving.
@@ -545,76 +565,84 @@ impl MultiPodBuilder {
     /// This runs the MILP solver to find the optimal POD assignment.
     /// Consumes the builder and returns a [`SolvedMultiPod`] that can be proved.
     pub fn solve(self) -> Result<SolvedMultiPod> {
+        let MainPodBuilder {
+            statements,
+            operations,
+            ..
+        } = self.builder;
+        // println!("DBG MultiPodBuilder.solve statements:");
+        // for (i, st) in statements.iter().enumerate() {
+        //     println!("  {}: {}", i, st);
+        // }
         // Compute costs for each statement
-        let costs: Vec<StatementCost> = self
-            .operations
+        let costs: Vec<StatementCost> = operations
             .iter()
             .map(StatementCost::from_operation)
             .collect();
 
         // Collect all unique anchored keys from the costs
-        let all_anchored_keys: Vec<AnchoredKeyId> = costs
-            .iter()
-            .flat_map(|c| c.anchored_keys.iter().cloned())
-            .collect::<std::collections::BTreeSet<_>>()
-            .into_iter()
-            .collect();
+        // let all_anchored_keys: Vec<AnchoredKeyId> = costs
+        //     .iter()
+        //     .flat_map(|c| c.anchored_keys.iter().cloned())
+        //     .collect::<std::collections::BTreeSet<_>>()
+        //     .into_iter()
+        //     .collect();
 
         // Build map from anchored key to its producing statement index (if any).
         // A Contains statement with literal (dict, key, value) "produces" that anchored key.
-        let mut ak_to_producer: HashMap<AnchoredKeyId, usize> = HashMap::new();
-        for (stmt_idx, stmt) in self.statements.iter().enumerate() {
-            if let Some(ak) = AnchoredKeyId::from_contains_statement(stmt) {
-                // First producer wins (shouldn't have duplicates in practice)
-                ak_to_producer.entry(ak).or_insert(stmt_idx);
-            }
-        }
+        // let mut ak_to_producer: HashMap<AnchoredKeyId, usize> = HashMap::new();
+        // for (stmt_idx, stmt) in statements.iter().enumerate() {
+        //     if let Some(ak) = AnchoredKeyId::from_contains_statement(stmt) {
+        //         // First producer wins (shouldn't have duplicates in practice)
+        //         ak_to_producer.entry(ak).or_insert(stmt_idx);
+        //     }
+        // }
 
         // Build parallel array: anchored_key_producers[i] = producer for all_anchored_keys[i]
-        let anchored_key_producers: Vec<Option<usize>> = all_anchored_keys
-            .iter()
-            .map(|ak| ak_to_producer.get(ak).copied())
-            .collect();
+        // let anchored_key_producers: Vec<Option<usize>> = all_anchored_keys
+        //     .iter()
+        //     .map(|ak| ak_to_producer.get(ak).copied())
+        //     .collect();
 
         // Build external POD statement mapping
         let external_pod_statements = build_external_statement_map(&self.input_pods);
 
         // Build dependency graph
-        let deps =
-            DependencyGraph::build(&self.statements, &self.operations, &external_pod_statements);
+        let deps = DependencyGraph::build(&statements, &operations, &external_pod_statements);
 
-        // Build statement content groups for deduplication.
-        // Statements with identical content share a single slot in the POD.
-        // Keep groups ordered by first occurrence index for deterministic solver input.
-        let mut first_idx_by_stmt: HashMap<&Statement, usize> = HashMap::new();
-        let mut groups_by_first_idx: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
-        for (idx, stmt) in self.statements.iter().enumerate() {
-            let first_idx = *first_idx_by_stmt.entry(stmt).or_insert(idx);
-            groups_by_first_idx.entry(first_idx).or_default().push(idx);
-        }
-        let statement_content_groups: Vec<Vec<usize>> = groups_by_first_idx.into_values().collect();
+        // // Build statement content groups for deduplication.
+        // // Statements with identical content share a single slot in the POD.
+        // // Keep groups ordered by first occurrence index for deterministic solver input.
+        // let mut first_idx_by_stmt: HashMap<&Statement, usize> = HashMap::new();
+        // let mut groups_by_first_idx: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
+        // for (idx, stmt) in statements.iter().enumerate() {
+        //     let first_idx = *first_idx_by_stmt.entry(stmt).or_insert(idx);
+        //     groups_by_first_idx.entry(first_idx).or_default().push(idx);
+        // }
+        // let statement_content_groups: Vec<Vec<usize>> = groups_by_first_idx.into_values().collect();
 
         // Run solver
         let input = solver::SolverInput {
-            num_statements: self.statements.len(),
+            num_statements: statements.len(),
             costs: &costs,
             deps: &deps,
             output_public_indices: &self.output_public_indices,
             params: &self.params,
             max_pods: self.options.max_pods,
-            all_anchored_keys: &all_anchored_keys,
-            anchored_key_producers: &anchored_key_producers,
-            statement_content_groups: &statement_content_groups,
+            // all_anchored_keys: &all_anchored_keys,
+            // anchored_key_producers: &anchored_key_producers,
+            // statement_content_groups: &statement_content_groups,
         };
 
+        println!("{:#?}", input);
         let solution = solver::solve(&input)?;
 
         Ok(SolvedMultiPod {
             params: self.params,
             vd_set: self.vd_set,
             input_pods: self.input_pods,
-            statements: self.statements,
-            operations: self.operations,
+            statements: statements,
+            operations: operations,
             output_public_indices: self.output_public_indices,
             operations_wildcard_values: self.operations_wildcard_values,
             solution,
@@ -843,41 +871,42 @@ mod tests {
         // provide dependencies to the output POD.
         let solved = builder.solve()?;
         let solution = solved.solution();
+        println!("{:#?}", solution);
 
         // Expected: exactly 2 PODs
         //   - POD 0 (intermediate): statements 0 (contains), 1 (a_out); a_out is public
         //   - POD 1 (output): statement 2 (b_out); b_out is public
         // The output POD accesses a_out from POD 0 to satisfy b_out's dependency.
-        assert_eq!(
-            solution.pod_count, 2,
-            "Expected exactly 2 PODs for 3-statement chain with max_priv=2"
-        );
+        // assert_eq!(
+        //     solution.pod_count, 2,
+        //     "Expected exactly 2 PODs for 3-statement chain with max_priv=2"
+        // );
 
-        // POD 0 should contain statements 0 and 1 (contains and a_out)
-        assert!(
-            solution.pod_statements[0].contains(&0) && solution.pod_statements[0].contains(&1),
-            "POD 0 should contain statements 0 (contains) and 1 (a_out), got {:?}",
-            solution.pod_statements[0]
-        );
+        // // POD 0 should contain statements 0 and 1 (contains and a_out)
+        // assert!(
+        //     solution.pod_statements[0].contains(&0) && solution.pod_statements[0].contains(&1),
+        //     "POD 0 should contain statements 0 (contains) and 1 (a_out), got {:?}",
+        //     solution.pod_statements[0]
+        // );
 
-        // Statement 1 (a_out) should be public in POD 0 so POD 1 can access it
-        assert!(
-            solution.pod_public_statements[0].contains(&1),
-            "Statement 1 (a_out) should be public in POD 0"
-        );
+        // // Statement 1 (a_out) should be public in POD 0 so POD 1 can access it
+        // assert!(
+        //     solution.pod_public_statements[0].contains(&1),
+        //     "Statement 1 (a_out) should be public in POD 0"
+        // );
 
-        // POD 1 (output) should contain statement 2 (b_out)
-        assert!(
-            solution.pod_statements[1].contains(&2),
-            "POD 1 should contain statement 2 (b_out), got {:?}",
-            solution.pod_statements[1]
-        );
+        // // POD 1 (output) should contain statement 2 (b_out)
+        // assert!(
+        //     solution.pod_statements[1].contains(&2),
+        //     "POD 1 should contain statement 2 (b_out), got {:?}",
+        //     solution.pod_statements[1]
+        // );
 
-        // Statement 2 (b_out) should be public in POD 1 (it's output-public)
-        assert!(
-            solution.pod_public_statements[1].contains(&2),
-            "Statement 2 (b_out) should be public in output POD"
-        );
+        // // Statement 2 (b_out) should be public in POD 1 (it's output-public)
+        // assert!(
+        //     solution.pod_public_statements[1].contains(&2),
+        //     "Statement 2 (b_out) should be public in output POD"
+        // );
 
         // Prove and verify all PODs
         let prover = MockProver {};

--- a/src/frontend/multi_pod/mod.rs
+++ b/src/frontend/multi_pod/mod.rs
@@ -213,7 +213,6 @@ impl SolvedMultiPod {
         let mut pods: Vec<MainPod> = Vec::with_capacity(solution.pod_count);
 
         for pod_idx in 0..solution.pod_count {
-            // println!("DBG SolvedMultiPod.prove pod {}", pod_idx);
             let pod = self.build_single_pod(pod_idx, &pods, prover)?;
             pods.push(pod);
         }
@@ -273,11 +272,11 @@ impl SolvedMultiPod {
         // Intermediate pods use the solver-selected public set.
         if pod_idx == solution.pod_count - 1 {
             for idx in &self.output_public_indices {
-                builder.reveal(&self.statements[*idx]);
+                builder.reveal(&self.statements[*idx])?;
             }
         } else {
             for idx in public_set {
-                builder.reveal(&self.statements[*idx]);
+                builder.reveal(&self.statements[*idx])?;
             }
         }
 
@@ -285,7 +284,7 @@ impl SolvedMultiPod {
         // for this POD. These do not require local proving in this POD.
         for ext_premise_idx in &solution.pod_public_external_premises[pod_idx] {
             let ext_premise = &solution.external_premises[*ext_premise_idx];
-            builder.reveal(&ext_premise.statement);
+            builder.reveal(&ext_premise.statement)?;
         }
 
         // Step 4: Prove the POD
@@ -466,7 +465,7 @@ impl MultiPodBuilder {
         if public {
             let index = self.stmt_index(&stmt);
             if !self.output_public_indices.contains(&index) {
-                self.output_public_indices.push(self.stmt_index(&stmt));
+                self.output_public_indices.push(index);
             }
         }
         Ok(stmt)

--- a/src/frontend/multi_pod/mod.rs
+++ b/src/frontend/multi_pod/mod.rs
@@ -53,7 +53,7 @@ use std::{
 };
 
 use crate::{
-    frontend::{MainPod, MainPodBuilder, Operation, OperationArg},
+    frontend::{MainPod, MainPodBuilder, Operation},
     middleware::{Hash, MainPodProver, Params, Statement, VDSet, Value},
 };
 
@@ -512,8 +512,8 @@ impl MultiPodBuilder {
     }
 
     /// Get the number of statements.
-    pub fn len(&self) -> usize {
-        self.builder.len()
+    pub fn stmt_len(&self) -> usize {
+        self.builder.stmt_len()
     }
 
     /// Solve the packing problem and return a solved builder ready for proving.
@@ -554,8 +554,8 @@ impl MultiPodBuilder {
             params: self.params,
             vd_set: self.vd_set,
             input_pods: self.input_pods,
-            statements: statements,
-            operations: operations,
+            statements,
+            operations,
             output_public_indices: self.output_public_indices,
             operations_wildcard_values: self.operations_wildcard_values,
             solution,

--- a/src/frontend/multi_pod/solver.rs
+++ b/src/frontend/multi_pod/solver.rs
@@ -52,7 +52,7 @@ use itertools::Itertools;
 use super::Result;
 use crate::{
     frontend::multi_pod::{
-        cost::{CustomBatchId, StatementCost},
+        cost::{CustomPredicateId, StatementCost},
         deps::{DependencyGraph, ExternalDependency, StatementSource},
     },
     middleware::{Hash, Params},
@@ -385,11 +385,11 @@ pub fn solve(input: &SolverInput) -> Result<MultiPodSolution> {
         )));
     }
 
-    // Collect all unique custom batch IDs used
-    let all_batches: Vec<CustomBatchId> = input
+    // Collect all unique custom predicate IDs used
+    let all_custom_predicates: Vec<CustomPredicateId> = input
         .costs
         .iter()
-        .flat_map(|c| c.custom_batch_ids.iter().cloned())
+        .flat_map(|c| c.custom_predicates_ids.iter().cloned())
         .unique()
         .collect();
 
@@ -416,7 +416,11 @@ pub fn solve(input: &SolverInput) -> Result<MultiPodSolution> {
     }
 
     let dep_stats = dependency_stats(input.deps);
-    let batch_memberships: usize = input.costs.iter().map(|c| c.custom_batch_ids.len()).sum();
+    let batch_memberships: usize = input
+        .costs
+        .iter()
+        .map(|c| c.custom_predicates_ids.len())
+        .sum();
     // let anchored_key_memberships: usize = input.costs.iter().map(|c| c.anchored_keys.len()).sum();
     let debug_ctx = SolveDebugContext {
         dep_stats,
@@ -462,13 +466,13 @@ pub fn solve(input: &SolverInput) -> Result<MultiPodSolution> {
 
         log::debug!(
             "MILP summary: statements={} output_public={} \
-             batches={} deps_internal_edges={} deps_external_edges={} external_input_pods={} \
+             custom_predicates={} deps_internal_edges={} deps_external_edges={} external_input_pods={} \
              external_premises={} search_min_pods={} max_pods={}",
             n,
             num_output_public,
             // input.statement_content_groups.len(),
             // input.all_anchored_keys.len(),
-            all_batches.len(),
+            all_custom_predicates.len(),
             dep_stats.internal_edges,
             dep_stats.external_edges,
             external_pods.len(),
@@ -511,7 +515,7 @@ pub fn solve(input: &SolverInput) -> Result<MultiPodSolution> {
         if let Some(solution) = try_solve_with_pods(
             input,
             target_pods,
-            &all_batches,
+            &all_custom_predicates,
             &external_pods,
             &external_premises,
             &debug_ctx,
@@ -538,7 +542,7 @@ pub fn solve(input: &SolverInput) -> Result<MultiPodSolution> {
 fn try_solve_with_pods(
     input: &SolverInput,
     target_pods: usize,
-    all_batches: &[CustomBatchId],
+    all_custom_predicates: &[CustomPredicateId],
     external_pods: &[Hash],
     external_premises: &[ExternalDependency],
     debug_ctx: &SolveDebugContext,
@@ -572,8 +576,8 @@ fn try_solve_with_pods(
         .map(|_| vars.add(variable().binary()))
         .collect();
 
-    // batch_used[b][p] - custom batch b is used in POD p
-    let batch_used: Vec<Vec<Variable>> = (0..all_batches.len())
+    // custom_predicates[b][p] - custom predicate b is used in POD p
+    let custom_predicate_used: Vec<Vec<Variable>> = (0..all_custom_predicates.len())
         .map(|_| {
             (0..target_pods)
                 .map(|_| vars.add(variable().binary()))
@@ -647,7 +651,7 @@ fn try_solve_with_pods(
         let estimate = ModelSizeEstimate::for_target_pods(
             input,
             target_pods,
-            all_batches.len(),
+            all_custom_predicates.len(),
             external_pods.len(),
             external_premises.len(),
             debug_ctx,
@@ -814,16 +818,15 @@ fn try_solve_with_pods(
     // }
 
     for p in 0..target_pods {
-        // 6a: Unique statement count (unique content groups + anchored key Contains)
-        // Statements with identical content share a slot, so we count content groups, not indices.
+        // 6a: Statement count
         // // Anchored key Contains statements are auto-inserted by MainPodBuilder when needed.
         // // The total must not exceed max_priv_statements (= max_statements - max_public_statements).
-        let unique_stmt_sum: Expression = (0..n).map(|g| prove[g][p]).sum();
+        let stmt_sum: Expression = (0..n).map(|g| prove[g][p]).sum();
         // let anchored_key_sum: Expression = (0..input.all_anchored_keys.len())
         //     .map(|ak| anchored_key_used[ak][p])
         //     .sum();
         model.add_constraint(constraint!(
-            unique_stmt_sum <= (input.params.max_priv_statements() as f64) * pod_used[p]
+            stmt_sum <= (input.params.max_priv_statements() as f64) * pod_used[p]
         ));
 
         // 6b: Public statement count (internal public statements + forwarded external premises)
@@ -882,19 +885,31 @@ fn try_solve_with_pods(
     }
 
     // Constraint 7: Batch cardinality
-    // batch_used[b][p] >= prove[s][p] for all s that use batch b (batch is used if any statement uses it)
-    // batch_used[b][p] <= sum of prove[s][p] for all s using batch b (batch is 0 if no statements use it)
-    for (b, batch_id) in all_batches.iter().enumerate() {
+    // custom_predicate_used[b][p] >= prove[s][p] for all s that use custom predicate b (custom
+    // predicate is used if any statement uses it)
+    // custom_predicate_used[b][p] <= sum of prove[s][p] for all s using custom predicate b (custom
+    // predicate is 0 if no statements use it)
+    for (b, predicate_id) in all_custom_predicates.iter().enumerate() {
         for p in 0..target_pods {
             let mut sum: Expression = 0.into();
             for s in 0..n {
-                if input.costs[s].custom_batch_ids.contains(batch_id) {
-                    model.add_constraint(constraint!(batch_used[b][p] >= prove[s][p]));
+                if input.costs[s].custom_predicates_ids.contains(predicate_id) {
+                    model.add_constraint(constraint!(custom_predicate_used[b][p] >= prove[s][p]));
                     sum += prove[s][p];
                 }
             }
-            model.add_constraint(constraint!(batch_used[b][p] <= sum));
+            model.add_constraint(constraint!(custom_predicate_used[b][p] <= sum));
         }
+    }
+
+    // Custom predicate count per POD
+    for p in 0..target_pods {
+        let custom_predicate_sum: Expression = (0..all_custom_predicates.len())
+            .map(|b| custom_predicate_used[b][p])
+            .sum();
+        model.add_constraint(constraint!(
+            custom_predicate_sum <= (input.params.max_custom_predicates as f64) * pod_used[p]
+        ));
     }
 
     // Constraint 7b: Anchored key tracking

--- a/src/frontend/multi_pod/solver.rs
+++ b/src/frontend/multi_pod/solver.rs
@@ -52,7 +52,7 @@ use itertools::Itertools;
 use super::Result;
 use crate::{
     frontend::multi_pod::{
-        cost::{AnchoredKeyId, CustomBatchId, StatementCost},
+        cost::{CustomBatchId, StatementCost},
         deps::{DependencyGraph, ExternalDependency, StatementSource},
     },
     middleware::{Hash, Params},
@@ -95,7 +95,7 @@ struct DependencyStats {
 struct SolveDebugContext {
     dep_stats: DependencyStats,
     batch_memberships: usize,
-    anchored_key_memberships: usize,
+    // anchored_key_memberships: usize,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -105,10 +105,10 @@ struct ModelSizeEstimate {
     vars_public_external: usize,
     vars_pod_used: usize,
     vars_batch_used: usize,
-    vars_anchored_key_used: usize,
+    // vars_anchored_key_used: usize,
     vars_uses_input: usize,
     vars_uses_external: usize,
-    vars_content_group_used: usize,
+    // vars_content_group_used: usize,
     vars_total: usize,
     c1_coverage: usize,
     c2_output_public: usize,
@@ -120,7 +120,7 @@ struct ModelSizeEstimate {
     c6_pre_content_group: usize,
     c6_resource_limits: usize,
     c7_batch_cardinality: usize,
-    c7b_anchored_key_tracking: usize,
+    // c7b_anchored_key_tracking: usize,
     c8a_internal_inputs: usize,
     c8b_external_dep_inputs: usize,
     c8c_external_forward_inputs: usize,
@@ -141,8 +141,8 @@ impl ModelSizeEstimate {
         debug_ctx: &SolveDebugContext,
     ) -> Self {
         let n = input.num_statements;
-        let num_groups = input.statement_content_groups.len();
-        let num_anchored_keys = input.all_anchored_keys.len();
+        // let num_groups = input.statement_content_groups.len();
+        // let num_anchored_keys = input.all_anchored_keys.len();
         let triangular_k = target_pods * target_pods.saturating_sub(1) / 2;
 
         let vars_prove = n * target_pods;
@@ -150,19 +150,19 @@ impl ModelSizeEstimate {
         let vars_public_external = external_premises_len * target_pods;
         let vars_pod_used = target_pods;
         let vars_batch_used = all_batches_len * target_pods;
-        let vars_anchored_key_used = num_anchored_keys * target_pods;
+        // let vars_anchored_key_used = num_anchored_keys * target_pods;
         let vars_uses_input = triangular_k;
         let vars_uses_external = external_pods_len * target_pods;
-        let vars_content_group_used = num_groups * target_pods;
+        // let vars_content_group_used = num_groups * target_pods;
         let vars_total = vars_prove
             + vars_public
             + vars_public_external
             + vars_pod_used
             + vars_batch_used
-            + vars_anchored_key_used
+            // + vars_anchored_key_used
             + vars_uses_input
-            + vars_uses_external
-            + vars_content_group_used;
+            + vars_uses_external;
+        // + vars_content_group_used;
 
         let c1_coverage = n;
         let c2_output_public = input.output_public_indices.len();
@@ -171,12 +171,12 @@ impl ModelSizeEstimate {
         let c4_pod_existence = n * target_pods;
         let c5_internal_dependencies = debug_ctx.dep_stats.internal_edges * target_pods;
         let c5_external_dependencies = debug_ctx.dep_stats.external_edges * target_pods;
-        let c6_pre_content_group = (n * target_pods) + (num_groups * target_pods);
+        let c6_pre_content_group = n * target_pods; // + (num_groups * target_pods);
         let c6_resource_limits = 7 * target_pods;
         let c7_batch_cardinality =
             (debug_ctx.batch_memberships * target_pods) + (all_batches_len * target_pods);
-        let c7b_anchored_key_tracking =
-            (debug_ctx.anchored_key_memberships * target_pods) + (num_anchored_keys * target_pods);
+        // let c7b_anchored_key_tracking =
+        //     (debug_ctx.anchored_key_memberships * target_pods) + (num_anchored_keys * target_pods);
         let c8a_internal_inputs = debug_ctx.dep_stats.internal_edges * triangular_k;
         let c8b_external_dep_inputs = debug_ctx.dep_stats.external_edges * triangular_k;
         let c8c_external_forward_inputs = external_premises_len * triangular_k;
@@ -194,7 +194,7 @@ impl ModelSizeEstimate {
             + c6_pre_content_group
             + c6_resource_limits
             + c7_batch_cardinality
-            + c7b_anchored_key_tracking
+            // + c7b_anchored_key_tracking
             + c8a_internal_inputs
             + c8b_external_dep_inputs
             + c8c_external_forward_inputs
@@ -209,10 +209,10 @@ impl ModelSizeEstimate {
             vars_public_external,
             vars_pod_used,
             vars_batch_used,
-            vars_anchored_key_used,
+            // vars_anchored_key_used,
             vars_uses_input,
             vars_uses_external,
-            vars_content_group_used,
+            // vars_content_group_used,
             vars_total,
             c1_coverage,
             c2_output_public,
@@ -224,7 +224,7 @@ impl ModelSizeEstimate {
             c6_pre_content_group,
             c6_resource_limits,
             c7_batch_cardinality,
-            c7b_anchored_key_tracking,
+            // c7b_anchored_key_tracking,
             c8a_internal_inputs,
             c8b_external_dep_inputs,
             c8c_external_forward_inputs,
@@ -300,6 +300,7 @@ pub struct MultiPodSolution {
 }
 
 /// Input to the MILP solver.
+#[derive(Debug)]
 pub struct SolverInput<'a> {
     /// Number of statements.
     pub num_statements: usize,
@@ -318,28 +319,26 @@ pub struct SolverInput<'a> {
 
     /// Maximum number of PODs the solver will consider.
     pub max_pods: usize,
+    // /// All unique anchored keys referenced by any statement.
+    // ///
+    // /// Each unique (dict, key) pair that is used as an anchored key reference
+    // /// in any operation. When a Contains statement with literal values is used
+    // /// as an argument, it creates an anchored key reference.
+    // pub all_anchored_keys: &'a [AnchoredKeyId],
 
-    /// All unique anchored keys referenced by any statement.
-    ///
-    /// Each unique (dict, key) pair that is used as an anchored key reference
-    /// in any operation. When a Contains statement with literal values is used
-    /// as an argument, it creates an anchored key reference.
-    pub all_anchored_keys: &'a [AnchoredKeyId],
-
-    /// For each anchored key, the statement index that produces it (if any).
-    ///
-    /// When a Contains statement with literal (dict, key, value) args is explicitly
-    /// added, it "produces" that anchored key. If the producer is in the same POD
-    /// as statements using the anchored key, no auto-insertion is needed.
-    /// `anchored_key_producers[i]` corresponds to `all_anchored_keys[i]`.
-    pub anchored_key_producers: &'a [Option<usize>],
-
-    /// Statement content groups for deduplication.
-    ///
-    /// Each inner Vec contains statement indices that have identical content.
-    /// When multiple statements with the same content are proved in the same POD,
-    /// they only use one statement slot (the POD deduplicates identical statements).
-    pub statement_content_groups: &'a [Vec<usize>],
+    // /// For each anchored key, the statement index that produces it (if any).
+    // ///
+    // /// When a Contains statement with literal (dict, key, value) args is explicitly
+    // /// added, it "produces" that anchored key. If the producer is in the same POD
+    // /// as statements using the anchored key, no auto-insertion is needed.
+    // /// `anchored_key_producers[i]` corresponds to `all_anchored_keys[i]`.
+    // pub anchored_key_producers: &'a [Option<usize>],
+    // /// Statement content groups for deduplication.
+    // ///
+    // /// Each inner Vec contains statement indices that have identical content.
+    // /// When multiple statements with the same content are proved in the same POD,
+    // /// they only use one statement slot (the POD deduplicates identical statements).
+    // pub statement_content_groups: &'a [Vec<usize>],
 }
 
 /// Solve the MILP problem to find optimal POD packing.
@@ -418,17 +417,16 @@ pub fn solve(input: &SolverInput) -> Result<MultiPodSolution> {
 
     let dep_stats = dependency_stats(input.deps);
     let batch_memberships: usize = input.costs.iter().map(|c| c.custom_batch_ids.len()).sum();
-    let anchored_key_memberships: usize = input.costs.iter().map(|c| c.anchored_keys.len()).sum();
+    // let anchored_key_memberships: usize = input.costs.iter().map(|c| c.anchored_keys.len()).sum();
     let debug_ctx = SolveDebugContext {
         dep_stats,
         batch_memberships,
-        anchored_key_memberships,
+        // anchored_key_memberships,
     };
 
     if log::log_enabled!(log::Level::Debug) {
         let resource_totals = ResourceTotals::from_costs(input.costs);
-        let lb_statement_groups =
-            lower_bound_from_total(input.statement_content_groups.len(), max_stmts_per_pod);
+        let lb_statement_groups = lower_bound_from_total(input.num_statements, max_stmts_per_pod);
         let lb_merkle = lower_bound_from_total(
             resource_totals.merkle_proofs,
             input.params.max_merkle_proofs_containers,
@@ -463,13 +461,13 @@ pub fn solve(input: &SolverInput) -> Result<MultiPodSolution> {
             .expect("non-empty lower-bound candidate list");
 
         log::debug!(
-            "MILP summary: statements={} output_public={} content_groups={} anchored_keys={} \
+            "MILP summary: statements={} output_public={} \
              batches={} deps_internal_edges={} deps_external_edges={} external_input_pods={} \
              external_premises={} search_min_pods={} max_pods={}",
             n,
             num_output_public,
-            input.statement_content_groups.len(),
-            input.all_anchored_keys.len(),
+            // input.statement_content_groups.len(),
+            // input.all_anchored_keys.len(),
             all_batches.len(),
             dep_stats.internal_edges,
             dep_stats.external_edges,
@@ -481,14 +479,14 @@ pub fn solve(input: &SolverInput) -> Result<MultiPodSolution> {
         log::debug!(
             "MILP resource totals: merkle_proofs={} merkle_state_transitions={} \
              custom_pred_verifications={} signed_by={} public_key_of={} \
-             batch_memberships={} anchored_key_memberships={}",
+             batch_memberships={}",
             resource_totals.merkle_proofs,
             resource_totals.merkle_state_transitions,
             resource_totals.custom_pred_verifications,
             resource_totals.signed_by,
             resource_totals.public_key_of,
             batch_memberships,
-            anchored_key_memberships
+            // anchored_key_memberships
         );
         log::debug!(
             "MILP lower bounds (pods): statements_raw={} statements_dedup={} merkle_proofs={} \
@@ -588,13 +586,13 @@ fn try_solve_with_pods(
     // that POD must have a Contains statement for that (dict, key) pair.
     // MainPodBuilder::add_entries_contains auto-inserts these, and we must account
     // for them in the statement count.
-    let anchored_key_used: Vec<Vec<Variable>> = (0..input.all_anchored_keys.len())
-        .map(|_| {
-            (0..target_pods)
-                .map(|_| vars.add(variable().binary()))
-                .collect()
-        })
-        .collect();
+    // let anchored_key_used: Vec<Vec<Variable>> = (0..input.all_anchored_keys.len())
+    //     .map(|_| {
+    //         (0..target_pods)
+    //             .map(|_| vars.add(variable().binary()))
+    //             .collect()
+    //     })
+    //     .collect();
 
     // uses_input[p][pp] - POD p uses POD pp as an input (pp < p)
     // We only create variables for pp < p
@@ -636,14 +634,14 @@ fn try_solve_with_pods(
     // content_group_used[g][p] - content group g has at least one statement proved in POD p
     // When multiple statements have identical content, they share a slot in the POD.
     // This variable tracks whether at least one statement from each content group is proved.
-    let num_groups = input.statement_content_groups.len();
-    let content_group_used: Vec<Vec<Variable>> = (0..num_groups)
-        .map(|_| {
-            (0..target_pods)
-                .map(|_| vars.add(variable().binary()))
-                .collect()
-        })
-        .collect();
+    // let num_groups = input.statement_content_groups.len();
+    // let content_group_used: Vec<Vec<Variable>> = (0..num_groups)
+    //     .map(|_| {
+    //         (0..target_pods)
+    //             .map(|_| vars.add(variable().binary()))
+    //             .collect()
+    //     })
+    //     .collect();
 
     if log::log_enabled!(log::Level::Debug) {
         let estimate = ModelSizeEstimate::for_target_pods(
@@ -656,8 +654,8 @@ fn try_solve_with_pods(
         );
         log::debug!(
             "MILP(k={}) model estimate vars_total={} [prove={} public={} pod_used={} \
-             public_external={} batch_used={} anchored_key_used={} uses_input={} \
-             uses_external={} content_group_used={}]",
+             public_external={} batch_used={} uses_input={} \
+             uses_external={}]",
             target_pods,
             estimate.vars_total,
             estimate.vars_prove,
@@ -665,14 +663,14 @@ fn try_solve_with_pods(
             estimate.vars_pod_used,
             estimate.vars_public_external,
             estimate.vars_batch_used,
-            estimate.vars_anchored_key_used,
+            // estimate.vars_anchored_key_used,
             estimate.vars_uses_input,
             estimate.vars_uses_external,
-            estimate.vars_content_group_used
+            // estimate.vars_content_group_used
         );
         log::debug!(
             "MILP(k={}) model estimate constraints_total={} [c1={} c2={} c2b={} c3={} c4={} \
-             c5i={} c5e={} c6_pre={} c6_limits={} c7={} c7b={} c8a={} c8b={} c8c={} \
+             c5i={} c5e={} c6_pre={} c6_limits={} c7={} c8a={} c8b={} c8c={} \
              c8d={} c9={} c10={} c10b={}]",
             target_pods,
             estimate.constraints_total,
@@ -686,7 +684,7 @@ fn try_solve_with_pods(
             estimate.c6_pre_content_group,
             estimate.c6_resource_limits,
             estimate.c7_batch_cardinality,
-            estimate.c7b_anchored_key_tracking,
+            // estimate.c7b_anchored_key_tracking,
             estimate.c8a_internal_inputs,
             estimate.c8b_external_dep_inputs,
             estimate.c8c_external_forward_inputs,
@@ -803,30 +801,29 @@ fn try_solve_with_pods(
     // 6a-pre: Content group tracking for statement deduplication
     // When multiple statement indices have identical content, they share a single slot in the POD.
     // content_group_used[g][p] = 1 iff at least one statement from group g is proved in POD p.
-    for (g, group) in input.statement_content_groups.iter().enumerate() {
-        for p in 0..target_pods {
-            // Lower bound: if any statement in the group is proved, the group is used
-            for &s in group {
-                model.add_constraint(constraint!(content_group_used[g][p] >= prove[s][p]));
-            }
-            // Upper bound: if no statements in the group are proved, the group is not used
-            let group_prove_sum: Expression = group.iter().map(|&s| prove[s][p]).sum();
-            model.add_constraint(constraint!(content_group_used[g][p] <= group_prove_sum));
-        }
-    }
+    // for (g, group) in input.statement_content_groups.iter().enumerate() {
+    //     for p in 0..target_pods {
+    //         // Lower bound: if any statement in the group is proved, the group is used
+    //         for &s in group {
+    //             model.add_constraint(constraint!(content_group_used[g][p] >= prove[s][p]));
+    //         }
+    //         // Upper bound: if no statements in the group are proved, the group is not used
+    //         let group_prove_sum: Expression = group.iter().map(|&s| prove[s][p]).sum();
+    //         model.add_constraint(constraint!(content_group_used[g][p] <= group_prove_sum));
+    //     }
+    // }
 
     for p in 0..target_pods {
         // 6a: Unique statement count (unique content groups + anchored key Contains)
         // Statements with identical content share a slot, so we count content groups, not indices.
-        // Anchored key Contains statements are auto-inserted by MainPodBuilder when needed.
-        // The total must not exceed max_priv_statements (= max_statements - max_public_statements).
-        let unique_stmt_sum: Expression = (0..num_groups).map(|g| content_group_used[g][p]).sum();
-        let anchored_key_sum: Expression = (0..input.all_anchored_keys.len())
-            .map(|ak| anchored_key_used[ak][p])
-            .sum();
+        // // Anchored key Contains statements are auto-inserted by MainPodBuilder when needed.
+        // // The total must not exceed max_priv_statements (= max_statements - max_public_statements).
+        let unique_stmt_sum: Expression = (0..n).map(|g| prove[g][p]).sum();
+        // let anchored_key_sum: Expression = (0..input.all_anchored_keys.len())
+        //     .map(|ak| anchored_key_used[ak][p])
+        //     .sum();
         model.add_constraint(constraint!(
-            unique_stmt_sum + anchored_key_sum
-                <= (input.params.max_priv_statements() as f64) * pod_used[p]
+            unique_stmt_sum <= (input.params.max_priv_statements() as f64) * pod_used[p]
         ));
 
         // 6b: Public statement count (internal public statements + forwarded external premises)
@@ -914,39 +911,39 @@ fn try_solve_with_pods(
     //   - Lower: anchored_key_used[ak][p] >= prove[s][p] for all s using ak
     //   - Upper: anchored_key_used[ak][p] <= sum of prove[s][p] for all s using ak
     //   Auto-insertion is always needed when any user is present.
-    for (ak_idx, ak) in input.all_anchored_keys.iter().enumerate() {
-        let producer = input.anchored_key_producers[ak_idx];
+    // for (ak_idx, ak) in input.all_anchored_keys.iter().enumerate() {
+    //     let producer = input.anchored_key_producers[ak_idx];
 
-        for p in 0..target_pods {
-            let mut user_sum: Expression = 0.into();
-            for s in 0..n {
-                if input.costs[s].anchored_keys.contains(ak) {
-                    if let Some(prod_idx) = producer {
-                        // Producer exists: only count overhead if producer not in this POD
-                        model.add_constraint(constraint!(
-                            anchored_key_used[ak_idx][p] >= prove[s][p] - prove[prod_idx][p]
-                        ));
-                    } else {
-                        // No producer: always need auto-insertion if user is present
-                        model.add_constraint(constraint!(
-                            anchored_key_used[ak_idx][p] >= prove[s][p]
-                        ));
-                    }
-                    user_sum += prove[s][p];
-                }
-            }
+    //     for p in 0..target_pods {
+    //         let mut user_sum: Expression = 0.into();
+    //         for s in 0..n {
+    //             if input.costs[s].anchored_keys.contains(ak) {
+    //                 if let Some(prod_idx) = producer {
+    //                     // Producer exists: only count overhead if producer not in this POD
+    //                     model.add_constraint(constraint!(
+    //                         anchored_key_used[ak_idx][p] >= prove[s][p] - prove[prod_idx][p]
+    //                     ));
+    //                 } else {
+    //                     // No producer: always need auto-insertion if user is present
+    //                     model.add_constraint(constraint!(
+    //                         anchored_key_used[ak_idx][p] >= prove[s][p]
+    //                     ));
+    //                 }
+    //                 user_sum += prove[s][p];
+    //             }
+    //         }
 
-            if let Some(prod_idx) = producer {
-                // If producer is in POD, no auto-insertion needed (overhead = 0)
-                model.add_constraint(constraint!(
-                    anchored_key_used[ak_idx][p] <= 1 - prove[prod_idx][p]
-                ));
-            } else {
-                // No producer: overhead is bounded by whether any user is present
-                model.add_constraint(constraint!(anchored_key_used[ak_idx][p] <= user_sum));
-            }
-        }
-    }
+    //         if let Some(prod_idx) = producer {
+    //             // If producer is in POD, no auto-insertion needed (overhead = 0)
+    //             model.add_constraint(constraint!(
+    //                 anchored_key_used[ak_idx][p] <= 1 - prove[prod_idx][p]
+    //             ));
+    //         } else {
+    //             // No producer: overhead is bounded by whether any user is present
+    //             model.add_constraint(constraint!(anchored_key_used[ak_idx][p] <= user_sum));
+    //         }
+    //     }
+    // }
 
     // Constraint 8a: Internal input POD tracking using uses_input.
     // If s is proved in p and depends on internal d exposed by pp, then pp must be counted
@@ -1147,9 +1144,9 @@ mod tests {
             output_public_indices: &[],
             params: &params,
             max_pods: 20,
-            all_anchored_keys: &[],
-            anchored_key_producers: &[],
-            statement_content_groups: &[],
+            // all_anchored_keys: &[],
+            // anchored_key_producers: &[],
+            // statement_content_groups: &[],
         };
 
         let result = solve(&input);
@@ -1195,7 +1192,7 @@ mod tests {
         };
 
         let costs = vec![StatementCost::default(), StatementCost::default()];
-        let statement_content_groups = vec![vec![0], vec![1]];
+        // let statement_content_groups = vec![vec![0], vec![1]];
         let output_public = vec![1];
 
         let input = SolverInput {
@@ -1205,9 +1202,9 @@ mod tests {
             output_public_indices: &output_public,
             params: &params,
             max_pods: 4,
-            all_anchored_keys: &[],
-            anchored_key_producers: &[],
-            statement_content_groups: &statement_content_groups,
+            // all_anchored_keys: &[],
+            // anchored_key_producers: &[],
+            // statement_content_groups: &statement_content_groups,
         };
 
         let solution = solve(&input).expect("solver should find a feasible forwarding layout");

--- a/src/frontend/multi_pod/solver.rs
+++ b/src/frontend/multi_pod/solver.rs
@@ -544,19 +544,6 @@ fn try_solve_with_pods(
         })
         .collect();
 
-    // anchored_key_used[ak][p] - anchored key ak is used in POD p
-    // When a statement references an anchored key (via a Contains statement argument),
-    // that POD must have a Contains statement for that (dict, key) pair.
-    // MainPodBuilder::add_entries_contains auto-inserts these, and we must account
-    // for them in the statement count.
-    // let anchored_key_used: Vec<Vec<Variable>> = (0..input.all_anchored_keys.len())
-    //     .map(|_| {
-    //         (0..target_pods)
-    //             .map(|_| vars.add(variable().binary()))
-    //             .collect()
-    //     })
-    //     .collect();
-
     // uses_input[p][pp] - POD p uses POD pp as an input (pp < p)
     // We only create variables for pp < p
     let uses_input: Vec<Vec<Variable>> = (0..target_pods)

--- a/src/frontend/multi_pod/solver.rs
+++ b/src/frontend/multi_pod/solver.rs
@@ -95,7 +95,6 @@ struct DependencyStats {
 struct SolveDebugContext {
     dep_stats: DependencyStats,
     batch_memberships: usize,
-    // anchored_key_memberships: usize,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -105,10 +104,8 @@ struct ModelSizeEstimate {
     vars_public_external: usize,
     vars_pod_used: usize,
     vars_batch_used: usize,
-    // vars_anchored_key_used: usize,
     vars_uses_input: usize,
     vars_uses_external: usize,
-    // vars_content_group_used: usize,
     vars_total: usize,
     c1_coverage: usize,
     c2_output_public: usize,
@@ -120,7 +117,6 @@ struct ModelSizeEstimate {
     c6_pre_content_group: usize,
     c6_resource_limits: usize,
     c7_batch_cardinality: usize,
-    // c7b_anchored_key_tracking: usize,
     c8a_internal_inputs: usize,
     c8b_external_dep_inputs: usize,
     c8c_external_forward_inputs: usize,
@@ -141,8 +137,6 @@ impl ModelSizeEstimate {
         debug_ctx: &SolveDebugContext,
     ) -> Self {
         let n = input.num_statements;
-        // let num_groups = input.statement_content_groups.len();
-        // let num_anchored_keys = input.all_anchored_keys.len();
         let triangular_k = target_pods * target_pods.saturating_sub(1) / 2;
 
         let vars_prove = n * target_pods;
@@ -150,19 +144,15 @@ impl ModelSizeEstimate {
         let vars_public_external = external_premises_len * target_pods;
         let vars_pod_used = target_pods;
         let vars_batch_used = all_batches_len * target_pods;
-        // let vars_anchored_key_used = num_anchored_keys * target_pods;
         let vars_uses_input = triangular_k;
         let vars_uses_external = external_pods_len * target_pods;
-        // let vars_content_group_used = num_groups * target_pods;
         let vars_total = vars_prove
             + vars_public
             + vars_public_external
             + vars_pod_used
             + vars_batch_used
-            // + vars_anchored_key_used
             + vars_uses_input
             + vars_uses_external;
-        // + vars_content_group_used;
 
         let c1_coverage = n;
         let c2_output_public = input.output_public_indices.len();
@@ -171,12 +161,10 @@ impl ModelSizeEstimate {
         let c4_pod_existence = n * target_pods;
         let c5_internal_dependencies = debug_ctx.dep_stats.internal_edges * target_pods;
         let c5_external_dependencies = debug_ctx.dep_stats.external_edges * target_pods;
-        let c6_pre_content_group = n * target_pods; // + (num_groups * target_pods);
+        let c6_pre_content_group = n * target_pods;
         let c6_resource_limits = 7 * target_pods;
         let c7_batch_cardinality =
             (debug_ctx.batch_memberships * target_pods) + (all_batches_len * target_pods);
-        // let c7b_anchored_key_tracking =
-        //     (debug_ctx.anchored_key_memberships * target_pods) + (num_anchored_keys * target_pods);
         let c8a_internal_inputs = debug_ctx.dep_stats.internal_edges * triangular_k;
         let c8b_external_dep_inputs = debug_ctx.dep_stats.external_edges * triangular_k;
         let c8c_external_forward_inputs = external_premises_len * triangular_k;
@@ -194,7 +182,6 @@ impl ModelSizeEstimate {
             + c6_pre_content_group
             + c6_resource_limits
             + c7_batch_cardinality
-            // + c7b_anchored_key_tracking
             + c8a_internal_inputs
             + c8b_external_dep_inputs
             + c8c_external_forward_inputs
@@ -209,10 +196,8 @@ impl ModelSizeEstimate {
             vars_public_external,
             vars_pod_used,
             vars_batch_used,
-            // vars_anchored_key_used,
             vars_uses_input,
             vars_uses_external,
-            // vars_content_group_used,
             vars_total,
             c1_coverage,
             c2_output_public,
@@ -224,7 +209,6 @@ impl ModelSizeEstimate {
             c6_pre_content_group,
             c6_resource_limits,
             c7_batch_cardinality,
-            // c7b_anchored_key_tracking,
             c8a_internal_inputs,
             c8b_external_dep_inputs,
             c8c_external_forward_inputs,
@@ -319,26 +303,6 @@ pub struct SolverInput<'a> {
 
     /// Maximum number of PODs the solver will consider.
     pub max_pods: usize,
-    // /// All unique anchored keys referenced by any statement.
-    // ///
-    // /// Each unique (dict, key) pair that is used as an anchored key reference
-    // /// in any operation. When a Contains statement with literal values is used
-    // /// as an argument, it creates an anchored key reference.
-    // pub all_anchored_keys: &'a [AnchoredKeyId],
-
-    // /// For each anchored key, the statement index that produces it (if any).
-    // ///
-    // /// When a Contains statement with literal (dict, key, value) args is explicitly
-    // /// added, it "produces" that anchored key. If the producer is in the same POD
-    // /// as statements using the anchored key, no auto-insertion is needed.
-    // /// `anchored_key_producers[i]` corresponds to `all_anchored_keys[i]`.
-    // pub anchored_key_producers: &'a [Option<usize>],
-    // /// Statement content groups for deduplication.
-    // ///
-    // /// Each inner Vec contains statement indices that have identical content.
-    // /// When multiple statements with the same content are proved in the same POD,
-    // /// they only use one statement slot (the POD deduplicates identical statements).
-    // pub statement_content_groups: &'a [Vec<usize>],
 }
 
 /// Solve the MILP problem to find optimal POD packing.
@@ -421,11 +385,9 @@ pub fn solve(input: &SolverInput) -> Result<MultiPodSolution> {
         .iter()
         .map(|c| c.custom_predicates_ids.len())
         .sum();
-    // let anchored_key_memberships: usize = input.costs.iter().map(|c| c.anchored_keys.len()).sum();
     let debug_ctx = SolveDebugContext {
         dep_stats,
         batch_memberships,
-        // anchored_key_memberships,
     };
 
     if log::log_enabled!(log::Level::Debug) {
@@ -470,8 +432,6 @@ pub fn solve(input: &SolverInput) -> Result<MultiPodSolution> {
              external_premises={} search_min_pods={} max_pods={}",
             n,
             num_output_public,
-            // input.statement_content_groups.len(),
-            // input.all_anchored_keys.len(),
             all_custom_predicates.len(),
             dep_stats.internal_edges,
             dep_stats.external_edges,
@@ -490,7 +450,6 @@ pub fn solve(input: &SolverInput) -> Result<MultiPodSolution> {
             resource_totals.signed_by,
             resource_totals.public_key_of,
             batch_memberships,
-            // anchored_key_memberships
         );
         log::debug!(
             "MILP lower bounds (pods): statements_raw={} statements_dedup={} merkle_proofs={} \
@@ -635,18 +594,6 @@ fn try_solve_with_pods(
         .map(|(i, ext)| (ext.clone(), i))
         .collect();
 
-    // content_group_used[g][p] - content group g has at least one statement proved in POD p
-    // When multiple statements have identical content, they share a slot in the POD.
-    // This variable tracks whether at least one statement from each content group is proved.
-    // let num_groups = input.statement_content_groups.len();
-    // let content_group_used: Vec<Vec<Variable>> = (0..num_groups)
-    //     .map(|_| {
-    //         (0..target_pods)
-    //             .map(|_| vars.add(variable().binary()))
-    //             .collect()
-    //     })
-    //     .collect();
-
     if log::log_enabled!(log::Level::Debug) {
         let estimate = ModelSizeEstimate::for_target_pods(
             input,
@@ -667,10 +614,8 @@ fn try_solve_with_pods(
             estimate.vars_pod_used,
             estimate.vars_public_external,
             estimate.vars_batch_used,
-            // estimate.vars_anchored_key_used,
             estimate.vars_uses_input,
             estimate.vars_uses_external,
-            // estimate.vars_content_group_used
         );
         log::debug!(
             "MILP(k={}) model estimate constraints_total={} [c1={} c2={} c2b={} c3={} c4={} \
@@ -688,7 +633,6 @@ fn try_solve_with_pods(
             estimate.c6_pre_content_group,
             estimate.c6_resource_limits,
             estimate.c7_batch_cardinality,
-            // estimate.c7b_anchored_key_tracking,
             estimate.c8a_internal_inputs,
             estimate.c8b_external_dep_inputs,
             estimate.c8c_external_forward_inputs,
@@ -800,31 +744,9 @@ fn try_solve_with_pods(
         }
     }
 
-    // Constraint 6: Resource limits per POD
-    //
-    // 6a-pre: Content group tracking for statement deduplication
-    // When multiple statement indices have identical content, they share a single slot in the POD.
-    // content_group_used[g][p] = 1 iff at least one statement from group g is proved in POD p.
-    // for (g, group) in input.statement_content_groups.iter().enumerate() {
-    //     for p in 0..target_pods {
-    //         // Lower bound: if any statement in the group is proved, the group is used
-    //         for &s in group {
-    //             model.add_constraint(constraint!(content_group_used[g][p] >= prove[s][p]));
-    //         }
-    //         // Upper bound: if no statements in the group are proved, the group is not used
-    //         let group_prove_sum: Expression = group.iter().map(|&s| prove[s][p]).sum();
-    //         model.add_constraint(constraint!(content_group_used[g][p] <= group_prove_sum));
-    //     }
-    // }
-
     for p in 0..target_pods {
         // 6a: Statement count
-        // // Anchored key Contains statements are auto-inserted by MainPodBuilder when needed.
-        // // The total must not exceed max_priv_statements (= max_statements - max_public_statements).
         let stmt_sum: Expression = (0..n).map(|g| prove[g][p]).sum();
-        // let anchored_key_sum: Expression = (0..input.all_anchored_keys.len())
-        //     .map(|ak| anchored_key_used[ak][p])
-        //     .sum();
         model.add_constraint(constraint!(
             stmt_sum <= (input.params.max_priv_statements() as f64) * pod_used[p]
         ));
@@ -911,54 +833,6 @@ fn try_solve_with_pods(
             custom_predicate_sum <= (input.params.max_custom_predicates as f64) * pod_used[p]
         ));
     }
-
-    // Constraint 7b: Anchored key tracking
-    //
-    // anchored_key_used[ak][p] = 1 when auto-insertion of a Contains is needed for anchored key ak in POD p.
-    // This happens when: some statement using ak is in POD p, AND the producing Contains is NOT in POD p.
-    //
-    // If a Contains statement explicitly produces ak (anchored_key_producers[ak] = Some(prod_idx)):
-    //   - Lower: anchored_key_used[ak][p] >= prove[s][p] - prove[prod_idx][p] for all s using ak
-    //   - Upper: anchored_key_used[ak][p] <= 1 - prove[prod_idx][p]
-    //   This ensures overhead is 0 when the producer is in the same POD.
-    //
-    // If no Contains produces ak (anchored_key_producers[ak] = None):
-    //   - Lower: anchored_key_used[ak][p] >= prove[s][p] for all s using ak
-    //   - Upper: anchored_key_used[ak][p] <= sum of prove[s][p] for all s using ak
-    //   Auto-insertion is always needed when any user is present.
-    // for (ak_idx, ak) in input.all_anchored_keys.iter().enumerate() {
-    //     let producer = input.anchored_key_producers[ak_idx];
-
-    //     for p in 0..target_pods {
-    //         let mut user_sum: Expression = 0.into();
-    //         for s in 0..n {
-    //             if input.costs[s].anchored_keys.contains(ak) {
-    //                 if let Some(prod_idx) = producer {
-    //                     // Producer exists: only count overhead if producer not in this POD
-    //                     model.add_constraint(constraint!(
-    //                         anchored_key_used[ak_idx][p] >= prove[s][p] - prove[prod_idx][p]
-    //                     ));
-    //                 } else {
-    //                     // No producer: always need auto-insertion if user is present
-    //                     model.add_constraint(constraint!(
-    //                         anchored_key_used[ak_idx][p] >= prove[s][p]
-    //                     ));
-    //                 }
-    //                 user_sum += prove[s][p];
-    //             }
-    //         }
-
-    //         if let Some(prod_idx) = producer {
-    //             // If producer is in POD, no auto-insertion needed (overhead = 0)
-    //             model.add_constraint(constraint!(
-    //                 anchored_key_used[ak_idx][p] <= 1 - prove[prod_idx][p]
-    //             ));
-    //         } else {
-    //             // No producer: overhead is bounded by whether any user is present
-    //             model.add_constraint(constraint!(anchored_key_used[ak_idx][p] <= user_sum));
-    //         }
-    //     }
-    // }
 
     // Constraint 8a: Internal input POD tracking using uses_input.
     // If s is proved in p and depends on internal d exposed by pp, then pp must be counted
@@ -1159,9 +1033,6 @@ mod tests {
             output_public_indices: &[],
             params: &params,
             max_pods: 20,
-            // all_anchored_keys: &[],
-            // anchored_key_producers: &[],
-            // statement_content_groups: &[],
         };
 
         let result = solve(&input);
@@ -1207,7 +1078,6 @@ mod tests {
         };
 
         let costs = vec![StatementCost::default(), StatementCost::default()];
-        // let statement_content_groups = vec![vec![0], vec![1]];
         let output_public = vec![1];
 
         let input = SolverInput {
@@ -1217,9 +1087,6 @@ mod tests {
             output_public_indices: &output_public,
             params: &params,
             max_pods: 4,
-            // all_anchored_keys: &[],
-            // anchored_key_producers: &[],
-            // statement_content_groups: &statement_content_groups,
         };
 
         let solution = solve(&input).expect("solver should find a feasible forwarding layout");

--- a/src/middleware/db/mem.rs
+++ b/src/middleware/db/mem.rs
@@ -43,10 +43,10 @@ impl DB for MemDB {
         let mut values = self.values.write().expect("lock not poisoned");
         let value_raw = value.raw();
         if let Some(old_value) = values.get(&value_raw) {
-            let is_raw = old_value.is_raw();
+            let old_is_raw = old_value.is_raw();
             // If we had a non-RawValue stored don't overwrite it (specially not with a
             // RawValue).   Also skip redundant RawValue overwrite.
-            if !is_raw || (is_raw && value.is_raw()) {
+            if !old_is_raw || value.is_raw() {
                 return Ok(());
             }
         }

--- a/src/middleware/db/mem.rs
+++ b/src/middleware/db/mem.rs
@@ -43,8 +43,10 @@ impl DB for MemDB {
         let mut values = self.values.write().expect("lock not poisoned");
         let value_raw = value.raw();
         if let Some(old_value) = values.get(&value_raw) {
-            // If we had a non-raw value stored never overwrite it with a raw value
-            if !old_value.is_raw() && value.is_raw() {
+            let is_raw = old_value.is_raw();
+            // If we had a non-RawValue stored don't overwrite it (specially not with a
+            // RawValue).   Also skip redundant RawValue overwrite.
+            if !is_raw || (is_raw && value.is_raw()) {
                 return Ok(());
             }
         }


### PR DESCRIPTION
This PR includes several fixes and code simplifications:
- MainPodBuilder
  - Fix: It was not tracking Contains statements inherited via input pods (via public statements) when automatically generating Contains statements for Entry arguments.
  - Enhancement: Deduplicate statements
- MultiPodBuilder
    - Simplify: Remove the "statement groups" logic and instead deduplicate statements in the MainPodBuilder (which is much simpler to do)
    - Remove the "anchored key" explicit dependency tracking and instead rely on regular dependency tracking by using all the implicit operations and statements generated by MainPodBuilder as input to the solver.
    - Fix: Count and constrain custom predicates used in a pod instead of batches used