### PR TITLE
Split aux tables based on size

### DIFF
--- a/src/backends/plonky2/circuits/mainpod/mod.rs
+++ b/src/backends/plonky2/circuits/mainpod/mod.rs
@@ -373,22 +373,14 @@ fn append_container_proofs_operation_aux_table_circuit(
         verify_merkle_state_transition_circuit(builder, merkle_transition_proof);
         let entry = MerkleTreeStateTransitionClaimTarget::from(merkle_transition_proof.clone());
 
-        tables.push_general(
-            builder,
-            OperationAuxTableTag::MerkleTransitionProof,
-            &entry,
-        );
+        tables.push_general(builder, OperationAuxTableTag::MerkleTransitionProof, &entry);
     }
     // Medium Merkle state transition proofs: verify op proof (insert/update/delete)
     for merkle_transition_proof in &merkle_transition_proofs.medium {
         verify_merkle_state_transition_circuit(builder, merkle_transition_proof);
         let entry = MerkleTreeStateTransitionClaimTarget::from(merkle_transition_proof.clone());
 
-        tables.push_general(
-            builder,
-            OperationAuxTableTag::MerkleTransitionProof,
-            &entry,
-        );
+        tables.push_general(builder, OperationAuxTableTag::MerkleTransitionProof, &entry);
     }
 }
 

--- a/src/backends/plonky2/circuits/mainpod/mod.rs
+++ b/src/backends/plonky2/circuits/mainpod/mod.rs
@@ -205,8 +205,8 @@ enum OperationAuxTableTag {
 // This is distinct from `OperationAuxTableTag`: the table tag labels the physical
 // row segment, while this kind separates semantic query shapes that share a row tag,
 // such as `Contains`/`NotContains` or transition `Insert`/`Update`/`Delete`.
-// Custom verification uses `CustomPredicateVerifyQueryTarget::hash`; its row tag is
-// sufficient because its input shape is structurally unique among aux kinds.
+// Custom verification (see `hash_custom_predicate_verify_query`) carries no query kind; its row
+// tag is sufficient because its input shape is structurally unique among aux kinds.
 #[derive(Copy, Clone)]
 enum OperationAuxQueryKind {
     MerkleContains = 1,
@@ -314,6 +314,23 @@ fn hash_pair_query(
         kind,
         x.elements.into_iter().chain(y.elements).collect(),
     )
+}
+
+// Custom verification doesn't go through `operation_aux_query_hash`: its row tag is sufficient
+// because its input shape is structurally unique among aux kinds, so no query-kind prefix is
+// needed.
+fn hash_custom_predicate_verify_query(
+    builder: &mut CircuitBuilder,
+    statement: StatementTarget,
+    op_type: OperationTypeTarget,
+    op_args: Vec<StatementTarget>,
+) -> HashOutTarget {
+    CustomPredicateVerifyQueryTarget {
+        statement,
+        op_type,
+        op_args,
+    }
+    .hash(builder)
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -584,12 +601,12 @@ fn build_operation_aux_table_circuit(
         let out_query_hash = entry.custom_predicate.hash(builder);
         builder.connect_array(table_query_hash.elements, out_query_hash.elements);
 
-        let query = CustomPredicateVerifyQueryTarget {
-            statement,                      // output
-            op_type,                        // output
-            op_args: entry.op_args.clone(), // input
-        };
-        let query_hash = query.hash(builder);
+        let query_hash = hash_custom_predicate_verify_query(
+            builder,
+            statement,             // output
+            op_type,               // output
+            entry.op_args.clone(), // input
+        );
         table.push(
             builder,
             OperationAuxTableTag::CustomPredVerify as u32,
@@ -1048,12 +1065,12 @@ fn verify_custom_circuit(
     let (aux_tag_ok, resolved_query_hash) =
         aux.as_type::<HashOutTarget>(builder, OperationAuxTableTag::CustomPredVerify as u32);
 
-    let query = CustomPredicateVerifyQueryTarget {
-        statement: st.clone(),
-        op_type: op_type.clone(),
-        op_args: resolved_op_args.to_vec(),
-    };
-    let query_hash = query.hash(builder);
+    let query_hash = hash_custom_predicate_verify_query(
+        builder,
+        st.clone(),
+        op_type.clone(),
+        resolved_op_args.to_vec(),
+    );
     let query_ok = builder.is_equal_flattenable(&resolved_query_hash, &query_hash);
     let ok = builder.all([aux_tag_ok, query_ok]);
     measure_gates_end!(builder, measure);

--- a/src/backends/plonky2/circuits/mainpod/mod.rs
+++ b/src/backends/plonky2/circuits/mainpod/mod.rs
@@ -23,7 +23,7 @@ use crate::{
             common::{
                 CircuitBuilderPod, CustomPredicateEntryTarget, CustomPredicateInBatchTarget,
                 CustomPredicateTarget, CustomPredicateVerifyEntryTarget,
-                CustomPredicateVerifyQueryTarget, Flattenable, InputPodEntryTarget,
+                CustomPredicateVerifyQueryTarget, Flattenable, IndexTarget, InputPodEntryTarget,
                 MerkleClaimTarget, MerkleTreeStateTransitionClaimTarget, OperationTarget,
                 OperationTypeTarget, PredicateHashOrWildcardTarget, PredicateTarget,
                 StatementArgTarget, StatementTarget, StatementTmplArgTarget, StatementTmplTarget,
@@ -201,13 +201,56 @@ enum OperationAuxTableTag {
     SignedBy = 6,
 }
 
+/// Two index-aligned aux tables: the wide `general` table for non-custom claims, and a narrow
+/// `custom_pred_verify_hashes` table that holds only the hash of each custom predicate
+/// verification query. Splitting custom queries out of the general table shrinks the dominant
+/// per-row width from `CustomPredicateVerifyQueryTarget::size()` to the next-largest payload.
+struct OperationAuxTables {
+    general: MuxTableTarget,
+    custom_pred_verify_hashes: MuxTableTarget,
+}
+
+impl OperationAuxTables {
+    fn push_general<T: Flattenable>(
+        &mut self,
+        builder: &mut CircuitBuilder,
+        tag: OperationAuxTableTag,
+        entry: &T,
+    ) {
+        self.general.push(builder, tag as u32, entry);
+        self.custom_pred_verify_hashes.push_flattened(
+            builder,
+            OperationAuxTableTag::None as u32,
+            &[],
+        );
+    }
+
+    fn push_custom_hash(&mut self, builder: &mut CircuitBuilder, hash: &HashOutTarget) {
+        self.custom_pred_verify_hashes.push(
+            builder,
+            OperationAuxTableTag::CustomPredVerify as u32,
+            hash,
+        );
+        self.general
+            .push_flattened(builder, OperationAuxTableTag::None as u32, &[]);
+    }
+
+    fn push_none(&mut self, builder: &mut CircuitBuilder) {
+        self.general
+            .push_flattened(builder, OperationAuxTableTag::None as u32, &[]);
+        self.custom_pred_verify_hashes.push_flattened(
+            builder,
+            OperationAuxTableTag::None as u32,
+            &[],
+        );
+    }
+}
+
 fn max_operation_aux_entry_len(params: &Params) -> usize {
     [
         (params.containers.state_ops.max_total() > 0).then(|| MerkleClaimTarget::size(params)),
         (params.containers.transition_ops.max_total() > 0)
             .then(|| MerkleTreeStateTransitionClaimTarget::size(params)),
-        (params.max_custom_predicate_verification_ops > 0)
-            .then(|| CustomPredicateVerifyQueryTarget::size(params)),
         (params.max_open_input_statement_ops > 0).then(|| StatementTarget::size(params)),
         (params.max_public_key_ops > 0).then(|| SecKeyPubKeyTarget::size(params)),
         (params.max_signed_by_ops > 0).then(|| MsgPubKeyTarget::size(params)),
@@ -306,7 +349,7 @@ impl OpenInputStatementTarget {
 
 fn append_container_proofs_operation_aux_table_circuit(
     builder: &mut CircuitBuilder,
-    table: &mut MuxTableTarget,
+    tables: &mut OperationAuxTables,
     merkle_proofs: &MerkleProofsTarget,
     merkle_transition_proofs: &MerkleTransitionProofsTarget,
 ) {
@@ -315,14 +358,14 @@ fn append_container_proofs_operation_aux_table_circuit(
         verify_merkle_proof_existence_circuit(builder, merkle_proof);
         let entry = MerkleClaimTarget::from_proof_existence(builder, merkle_proof.clone());
 
-        table.push(builder, OperationAuxTableTag::MerkleProof as u32, &entry);
+        tables.push_general(builder, OperationAuxTableTag::MerkleProof, &entry);
     }
     // Medium MerkleProofs: verify container merkle proofs (inclusion/non-inclusion)
     for merkle_proof in &merkle_proofs.medium {
         verify_merkle_proof_circuit(builder, merkle_proof);
         let entry = MerkleClaimTarget::from(merkle_proof.clone());
 
-        table.push(builder, OperationAuxTableTag::MerkleProof as u32, &entry);
+        tables.push_general(builder, OperationAuxTableTag::MerkleProof, &entry);
     }
 
     // Small Merkle state transition proofs: verify op proof (only update)
@@ -330,9 +373,9 @@ fn append_container_proofs_operation_aux_table_circuit(
         verify_merkle_state_transition_circuit(builder, merkle_transition_proof);
         let entry = MerkleTreeStateTransitionClaimTarget::from(merkle_transition_proof.clone());
 
-        table.push(
+        tables.push_general(
             builder,
-            OperationAuxTableTag::MerkleTransitionProof as u32,
+            OperationAuxTableTag::MerkleTransitionProof,
             &entry,
         );
     }
@@ -341,9 +384,9 @@ fn append_container_proofs_operation_aux_table_circuit(
         verify_merkle_state_transition_circuit(builder, merkle_transition_proof);
         let entry = MerkleTreeStateTransitionClaimTarget::from(merkle_transition_proof.clone());
 
-        table.push(
+        tables.push_general(
             builder,
-            OperationAuxTableTag::MerkleTransitionProof as u32,
+            OperationAuxTableTag::MerkleTransitionProof,
             &entry,
         );
     }
@@ -352,7 +395,7 @@ fn append_container_proofs_operation_aux_table_circuit(
 fn append_open_input_statements_aux_table_circuit(
     params: &Params,
     builder: &mut CircuitBuilder,
-    table: &mut MuxTableTarget,
+    tables: &mut OperationAuxTables,
     input_pod_table: &[InputPodEntryTarget],
     open_input_statements: &[OpenInputStatementTarget],
 ) {
@@ -389,11 +432,7 @@ fn append_open_input_statements_aux_table_circuit(
             is_intro,
             &pod.vd_hash,
         );
-        table.push(
-            builder,
-            OperationAuxTableTag::OpenInputStatement as u32,
-            &st,
-        );
+        tables.push_general(builder, OperationAuxTableTag::OpenInputStatement, &st);
         measure_gates_end!(builder, measure);
     }
 }
@@ -405,7 +444,7 @@ fn build_operation_aux_table_circuit(
     custom_predicate_table: &[HashOutTarget],
     input_pod_table: &[InputPodEntryTarget],
     input: &AuxTableInputTargets,
-) -> Result<MuxTableTarget> {
+) -> Result<OperationAuxTables> {
     let measure = measure_gates_begin!(builder, "BuildOpAuxTbl");
     assert_eq!(
         params.max_custom_predicate_verification_ops,
@@ -420,14 +459,17 @@ fn build_operation_aux_table_circuit(
         input.merkle_proofs.medium.len()
     );
     let max_entry_len = max_operation_aux_entry_len(params);
-    let mut table = MuxTableTarget::new(params, max_entry_len);
+    let mut tables = OperationAuxTables {
+        general: MuxTableTarget::new(params, max_entry_len),
+        custom_pred_verify_hashes: MuxTableTarget::new(params, HashOutTarget::size(params)),
+    };
 
     // None
-    table.push_flattened(builder, OperationAuxTableTag::None as u32, &[]);
+    tables.push_none(builder);
 
     append_container_proofs_operation_aux_table_circuit(
         builder,
-        &mut table,
+        &mut tables,
         &input.merkle_proofs,
         &input.merkle_transition_proofs,
     );
@@ -435,12 +477,13 @@ fn build_operation_aux_table_circuit(
     append_open_input_statements_aux_table_circuit(
         params,
         builder,
-        &mut table,
+        &mut tables,
         input_pod_table,
         &input.open_input_statements,
     );
 
-    // CustomPredVerify: verify custom predicate statements verification against operations
+    // CustomPredVerify: hash the verification query and store it in the dedicated narrow table;
+    // the general table gets a None entry at the same index to keep both tables aligned.
     for entry in &input.custom_predicate_verifications {
         let measure = measure_gates_begin!(builder, "CustomPredVerify");
         // Verify the custom predicate operation
@@ -466,11 +509,8 @@ fn build_operation_aux_table_circuit(
             op_type,                        // output
             op_args: entry.op_args.clone(), // input
         };
-        table.push(
-            builder,
-            OperationAuxTableTag::CustomPredVerify as u32,
-            &query,
-        );
+        let query_hash = query.hash(builder);
+        tables.push_custom_hash(builder, &query_hash);
         measure_gates_end!(builder, measure);
     }
 
@@ -499,7 +539,7 @@ fn build_operation_aux_table_circuit(
 
         let entry: SecKeyPubKeyTarget = HashPairTarget(sk_hash, pk_hash);
 
-        table.push(builder, OperationAuxTableTag::PublicKeyOf as u32, &entry);
+        tables.push_general(builder, OperationAuxTableTag::PublicKeyOf, &entry);
         measure_gates_end!(builder, measure);
     }
 
@@ -527,12 +567,16 @@ fn build_operation_aux_table_circuit(
         );
         let entry: MsgPubKeyTarget = HashPairTarget(HashOutTarget::from(signed_by.msg), pk_hash);
 
-        table.push(builder, OperationAuxTableTag::SignedBy as u32, &entry);
+        tables.push_general(builder, OperationAuxTableTag::SignedBy, &entry);
         measure_gates_end!(builder, measure);
     }
 
+    let expected_table_size = mainpod::OperationAux::table_size(params);
+    assert_eq!(tables.general.len(), expected_table_size);
+    assert_eq!(tables.custom_pred_verify_hashes.len(), expected_table_size);
+
     measure_gates_end!(builder, measure);
-    Ok(table)
+    Ok(tables)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -543,7 +587,7 @@ fn verify_operation_circuit(
     op: &OperationTarget,
     prev_statement_flatteneds: &[Vec<Target>],
     prev_statement_hashes: &[HashOutTarget],
-    aux_table: &MuxTableTarget,
+    aux_tables: &OperationAuxTables,
 ) -> Result<()> {
     let measure = measure_gates_begin!(builder, "OpVerifyPriv");
     let _true = builder._true();
@@ -570,7 +614,8 @@ fn verify_operation_circuit(
 
     // The aux table always has a fixed zero entry, so we check if there are more than 1 entries to
     // trigger the unhashing.
-    let resolved_aux = (aux_table.len() > 1).then(|| aux_table.get(builder, &op.aux_index));
+    let resolved_aux =
+        (aux_tables.general.len() > 1).then(|| aux_tables.general.get(builder, &op.aux_index));
 
     // Op checks to carry out. Each 'verify_X_circuit' should be thought of as operation check
     // restricted to the op of type X, where the returned target is `false` if the input targets
@@ -661,15 +706,6 @@ fn verify_operation_circuit(
                 ),
             ]);
         }
-        if params.max_custom_predicate_verification_ops > 0 {
-            op_checks.push(verify_custom_circuit(
-                builder,
-                st,
-                &op.op_type,
-                &resolved_aux,
-                &cache.op_args,
-            ));
-        }
         if params.max_open_input_statement_ops > 0 {
             op_checks.extend_from_slice(&[verify_open_input_statement_circuit(
                 builder,
@@ -678,6 +714,17 @@ fn verify_operation_circuit(
                 &resolved_aux,
             )]);
         }
+    }
+    // Custom predicate verifications use the dedicated hash table and need no general aux row.
+    if params.max_custom_predicate_verification_ops > 0 {
+        op_checks.push(verify_custom_circuit(
+            builder,
+            st,
+            &op.op_type,
+            &op.aux_index,
+            &cache.op_args,
+            &aux_tables.custom_pred_verify_hashes,
+        ));
     }
 
     let ok = builder.any(op_checks);
@@ -1000,23 +1047,22 @@ fn verify_custom_circuit(
     builder: &mut CircuitBuilder,
     st: &StatementTarget,
     op_type: &OperationTypeTarget,
-    aux: &TableEntryTarget,
+    aux_index: &IndexTarget,
     resolved_op_args: &[StatementTarget],
+    custom_pred_verify_hashes: &MuxTableTarget,
 ) -> BoolTarget {
     let measure = measure_gates_begin!(builder, "OpCustom");
-    let (aux_tag_ok, resolved_query) = aux.as_type::<CustomPredicateVerifyQueryTarget>(
-        builder,
-        OperationAuxTableTag::CustomPredVerify as u32,
-    );
+    let resolved_hash_entry = custom_pred_verify_hashes.get(builder, aux_index);
+    let (aux_tag_ok, resolved_query_hash) = resolved_hash_entry
+        .as_type::<HashOutTarget>(builder, OperationAuxTableTag::CustomPredVerify as u32);
 
-    let query_ok = builder.is_equal_flattenable(
-        &resolved_query,
-        &CustomPredicateVerifyQueryTarget {
-            statement: st.clone(),
-            op_type: op_type.clone(),
-            op_args: resolved_op_args.to_vec(),
-        },
-    );
+    let query = CustomPredicateVerifyQueryTarget {
+        statement: st.clone(),
+        op_type: op_type.clone(),
+        op_args: resolved_op_args.to_vec(),
+    };
+    let query_hash = query.hash(builder);
+    let query_ok = builder.is_equal_flattenable(&resolved_query_hash, &query_hash);
     let ok = builder.all([aux_tag_ok, query_ok]);
     measure_gates_end!(builder, measure);
     ok
@@ -1894,7 +1940,7 @@ fn verify_main_pod_circuit(
     let custom_predicate_table =
         build_custom_predicate_table_circuit(params, builder, &main_pod.custom_predicates)?;
 
-    let aux_table = build_operation_aux_table_circuit(
+    let aux_tables = build_operation_aux_table_circuit(
         params,
         builder,
         &custom_predicate_table,
@@ -1953,7 +1999,7 @@ fn verify_main_pod_circuit(
             op,
             prev_statement_flatteneds,
             prev_statement_hashes,
-            &aux_table,
+            &aux_tables,
         )?;
         let measure = measure_gates_begin!(builder, "PubSt");
         let st_hash = statement_hashes[i];

--- a/src/backends/plonky2/circuits/mainpod/mod.rs
+++ b/src/backends/plonky2/circuits/mainpod/mod.rs
@@ -23,7 +23,7 @@ use crate::{
             common::{
                 CircuitBuilderPod, CustomPredicateEntryTarget, CustomPredicateInBatchTarget,
                 CustomPredicateTarget, CustomPredicateVerifyEntryTarget,
-                CustomPredicateVerifyQueryTarget, Flattenable, IndexTarget, InputPodEntryTarget,
+                CustomPredicateVerifyQueryTarget, Flattenable, InputPodEntryTarget,
                 MerkleClaimTarget, MerkleTreeStateTransitionClaimTarget, OperationTarget,
                 OperationTypeTarget, PredicateHashOrWildcardTarget, PredicateTarget,
                 StatementArgTarget, StatementTarget, StatementTmplArgTarget, StatementTmplTarget,
@@ -201,87 +201,120 @@ enum OperationAuxTableTag {
     SignedBy = 6,
 }
 
-/// Two index-aligned aux tables: the wide `general` table for non-custom claims, and a narrow
-/// `custom_pred_verify_hashes` table that holds only the hash of each custom predicate
-/// verification query. Splitting custom queries out of the general table shrinks the dominant
-/// per-row width from `CustomPredicateVerifyQueryTarget::size()` to the next-largest payload.
-struct OperationAuxTables {
-    general: MuxTableTarget,
-    custom_pred_verify_hashes: MuxTableTarget,
-}
-
-impl OperationAuxTables {
-    fn push_general<T: Flattenable>(
-        &mut self,
-        builder: &mut CircuitBuilder,
-        tag: OperationAuxTableTag,
-        entry: &T,
-    ) {
-        self.general.push(builder, tag as u32, entry);
-        self.custom_pred_verify_hashes.push_flattened(
-            builder,
-            OperationAuxTableTag::None as u32,
-            &[],
-        );
-    }
-
-    fn push_custom_hash(&mut self, builder: &mut CircuitBuilder, hash: &HashOutTarget) {
-        self.custom_pred_verify_hashes.push(
-            builder,
-            OperationAuxTableTag::CustomPredVerify as u32,
-            hash,
-        );
-        self.general
-            .push_flattened(builder, OperationAuxTableTag::None as u32, &[]);
-    }
-
-    fn push_none(&mut self, builder: &mut CircuitBuilder) {
-        self.general
-            .push_flattened(builder, OperationAuxTableTag::None as u32, &[]);
-        self.custom_pred_verify_hashes.push_flattened(
-            builder,
-            OperationAuxTableTag::None as u32,
-            &[],
-        );
-    }
-}
-
-fn max_operation_aux_entry_len(params: &Params) -> usize {
-    [
-        (params.containers.state_ops.max_total() > 0).then(|| MerkleClaimTarget::size(params)),
-        (params.containers.transition_ops.max_total() > 0)
-            .then(|| MerkleTreeStateTransitionClaimTarget::size(params)),
-        (params.max_open_input_statement_ops > 0).then(|| StatementTarget::size(params)),
-        (params.max_public_key_ops > 0).then(|| SecKeyPubKeyTarget::size(params)),
-        (params.max_signed_by_ops > 0).then(|| MsgPubKeyTarget::size(params)),
-    ]
-    .into_iter()
-    .flatten()
-    .max()
-    .unwrap_or(0)
-}
-
+// Domain-separation tag prepended to the hashed query input for each aux kind.
+// This is distinct from `OperationAuxTableTag`: the table tag labels the physical
+// row segment, while this kind separates semantic query shapes that share a row tag,
+// such as `Contains`/`NotContains` or transition `Insert`/`Update`/`Delete`.
+// Custom verification uses `CustomPredicateVerifyQueryTarget::hash`; its row tag is
+// sufficient because its input shape is structurally unique among aux kinds.
 #[derive(Copy, Clone)]
-struct HashPairTarget(HashOutTarget, HashOutTarget);
-
-impl Flattenable for HashPairTarget {
-    fn flatten(&self) -> Vec<Target> {
-        self.0.elements.into_iter().chain(self.1.elements).collect()
-    }
-    fn from_flattened(params: &Params, vs: &[Target]) -> Self {
-        assert_eq!(vs.len(), Self::size(params));
-        Self(
-            HashOutTarget::try_from(&vs[..4]).expect("len = 4"),
-            HashOutTarget::try_from(&vs[4..]).expect("len = 4"),
-        )
-    }
-    fn size(_params: &Params) -> usize {
-        8
-    }
+enum OperationAuxQueryKind {
+    MerkleContains = 1,
+    MerkleNotContains = 2,
+    MerkleTransition = 3,
+    MerkleDelete = 4,
+    OpenInputStatement = 5,
+    PublicKeyOf = 6,
+    SignedBy = 7,
 }
 
-type SecKeyPubKeyTarget = HashPairTarget; // (secret_key, public_key)
-type MsgPubKeyTarget = HashPairTarget; // (message, public_key)
+fn operation_aux_query_hash(
+    builder: &mut CircuitBuilder,
+    kind: OperationAuxQueryKind,
+    mut fields: Vec<Target>,
+) -> HashOutTarget {
+    fields.insert(0, builder.constant(F::from_canonical_u8(kind as u8)));
+    builder.hash_n_to_hash_no_pad::<PoseidonHash>(fields)
+}
+
+fn hash_merkle_contains_query(
+    builder: &mut CircuitBuilder,
+    root: HashOutTarget,
+    key: ValueTarget,
+    value: ValueTarget,
+) -> HashOutTarget {
+    operation_aux_query_hash(
+        builder,
+        OperationAuxQueryKind::MerkleContains,
+        root.elements
+            .into_iter()
+            .chain(key.elements)
+            .chain(value.elements)
+            .collect(),
+    )
+}
+
+fn hash_merkle_not_contains_query(
+    builder: &mut CircuitBuilder,
+    root: HashOutTarget,
+    key: ValueTarget,
+) -> HashOutTarget {
+    operation_aux_query_hash(
+        builder,
+        OperationAuxQueryKind::MerkleNotContains,
+        root.elements.into_iter().chain(key.elements).collect(),
+    )
+}
+
+fn hash_merkle_transition_query(
+    builder: &mut CircuitBuilder,
+    op: Target,
+    old_root: HashOutTarget,
+    new_root: HashOutTarget,
+    key: ValueTarget,
+    value: ValueTarget,
+) -> HashOutTarget {
+    operation_aux_query_hash(
+        builder,
+        OperationAuxQueryKind::MerkleTransition,
+        iter::once(op)
+            .chain(old_root.elements)
+            .chain(new_root.elements)
+            .chain(key.elements)
+            .chain(value.elements)
+            .collect(),
+    )
+}
+
+fn hash_merkle_delete_query(
+    builder: &mut CircuitBuilder,
+    old_root: HashOutTarget,
+    new_root: HashOutTarget,
+    key: ValueTarget,
+) -> HashOutTarget {
+    // Delete's value is constrained by the state-transition proof, not by the aux hash.
+    operation_aux_query_hash(
+        builder,
+        OperationAuxQueryKind::MerkleDelete,
+        old_root
+            .elements
+            .into_iter()
+            .chain(new_root.elements)
+            .chain(key.elements)
+            .collect(),
+    )
+}
+
+fn hash_statement_query(builder: &mut CircuitBuilder, st: &StatementTarget) -> HashOutTarget {
+    operation_aux_query_hash(
+        builder,
+        OperationAuxQueryKind::OpenInputStatement,
+        st.flatten(),
+    )
+}
+
+fn hash_pair_query(
+    builder: &mut CircuitBuilder,
+    kind: OperationAuxQueryKind,
+    x: HashOutTarget,
+    y: HashOutTarget,
+) -> HashOutTarget {
+    operation_aux_query_hash(
+        builder,
+        kind,
+        x.elements.into_iter().chain(y.elements).collect(),
+    )
+}
 
 #[derive(Clone, Serialize, Deserialize)]
 struct SignedByTarget {
@@ -348,8 +381,9 @@ impl OpenInputStatementTarget {
 }
 
 fn append_container_proofs_operation_aux_table_circuit(
+    params: &Params,
     builder: &mut CircuitBuilder,
-    tables: &mut OperationAuxTables,
+    table: &mut MuxTableTarget,
     merkle_proofs: &MerkleProofsTarget,
     merkle_transition_proofs: &MerkleTransitionProofsTarget,
 ) {
@@ -357,37 +391,90 @@ fn append_container_proofs_operation_aux_table_circuit(
     for merkle_proof in &merkle_proofs.small {
         verify_merkle_proof_existence_circuit(builder, merkle_proof);
         let entry = MerkleClaimTarget::from_proof_existence(builder, merkle_proof.clone());
+        let query_hash = hash_merkle_contains_query(builder, entry.root, entry.key, entry.value);
 
-        tables.push_general(builder, OperationAuxTableTag::MerkleProof, &entry);
+        table.push(
+            builder,
+            OperationAuxTableTag::MerkleProof as u32,
+            &query_hash,
+        );
     }
     // Medium MerkleProofs: verify container merkle proofs (inclusion/non-inclusion)
     for merkle_proof in &merkle_proofs.medium {
         verify_merkle_proof_circuit(builder, merkle_proof);
         let entry = MerkleClaimTarget::from(merkle_proof.clone());
+        let contains_query_hash =
+            hash_merkle_contains_query(builder, entry.root, entry.key, entry.value);
+        let not_contains_query_hash =
+            hash_merkle_not_contains_query(builder, entry.root, entry.key);
+        let query_hash = builder.select_flattenable(
+            params,
+            entry.existence,
+            &contains_query_hash,
+            &not_contains_query_hash,
+        );
 
-        tables.push_general(builder, OperationAuxTableTag::MerkleProof, &entry);
+        table.push(
+            builder,
+            OperationAuxTableTag::MerkleProof as u32,
+            &query_hash,
+        );
     }
 
     // Small Merkle state transition proofs: verify op proof (only update)
     for merkle_transition_proof in &merkle_transition_proofs.small {
         verify_merkle_state_transition_circuit(builder, merkle_transition_proof);
         let entry = MerkleTreeStateTransitionClaimTarget::from(merkle_transition_proof.clone());
+        let query_hash = hash_merkle_transition_query(
+            builder,
+            entry.op,
+            entry.old_root,
+            entry.new_root,
+            entry.op_key,
+            entry.op_value,
+        );
 
-        tables.push_general(builder, OperationAuxTableTag::MerkleTransitionProof, &entry);
+        table.push(
+            builder,
+            OperationAuxTableTag::MerkleTransitionProof as u32,
+            &query_hash,
+        );
     }
     // Medium Merkle state transition proofs: verify op proof (insert/update/delete)
     for merkle_transition_proof in &merkle_transition_proofs.medium {
         verify_merkle_state_transition_circuit(builder, merkle_transition_proof);
         let entry = MerkleTreeStateTransitionClaimTarget::from(merkle_transition_proof.clone());
+        let transition_query_hash = hash_merkle_transition_query(
+            builder,
+            entry.op,
+            entry.old_root,
+            entry.new_root,
+            entry.op_key,
+            entry.op_value,
+        );
+        let delete_query_hash =
+            hash_merkle_delete_query(builder, entry.old_root, entry.new_root, entry.op_key);
+        let delete_op = builder.constant(F::from_canonical_u8(MerkleTreeOp::Delete as u8));
+        let is_delete = builder.is_equal(entry.op, delete_op);
+        let query_hash = builder.select_flattenable(
+            params,
+            is_delete,
+            &delete_query_hash,
+            &transition_query_hash,
+        );
 
-        tables.push_general(builder, OperationAuxTableTag::MerkleTransitionProof, &entry);
+        table.push(
+            builder,
+            OperationAuxTableTag::MerkleTransitionProof as u32,
+            &query_hash,
+        );
     }
 }
 
 fn append_open_input_statements_aux_table_circuit(
     params: &Params,
     builder: &mut CircuitBuilder,
-    tables: &mut OperationAuxTables,
+    table: &mut MuxTableTarget,
     input_pod_table: &[InputPodEntryTarget],
     open_input_statements: &[OpenInputStatementTarget],
 ) {
@@ -424,7 +511,12 @@ fn append_open_input_statements_aux_table_circuit(
             is_intro,
             &pod.vd_hash,
         );
-        tables.push_general(builder, OperationAuxTableTag::OpenInputStatement, &st);
+        let query_hash = hash_statement_query(builder, &st);
+        table.push(
+            builder,
+            OperationAuxTableTag::OpenInputStatement as u32,
+            &query_hash,
+        );
         measure_gates_end!(builder, measure);
     }
 }
@@ -436,7 +528,7 @@ fn build_operation_aux_table_circuit(
     custom_predicate_table: &[HashOutTarget],
     input_pod_table: &[InputPodEntryTarget],
     input: &AuxTableInputTargets,
-) -> Result<OperationAuxTables> {
+) -> Result<MuxTableTarget> {
     let measure = measure_gates_begin!(builder, "BuildOpAuxTbl");
     assert_eq!(
         params.max_custom_predicate_verification_ops,
@@ -450,18 +542,15 @@ fn build_operation_aux_table_circuit(
         params.containers.state_ops.max_medium,
         input.merkle_proofs.medium.len()
     );
-    let max_entry_len = max_operation_aux_entry_len(params);
-    let mut tables = OperationAuxTables {
-        general: MuxTableTarget::new(params, max_entry_len),
-        custom_pred_verify_hashes: MuxTableTarget::new(params, HashOutTarget::size(params)),
-    };
+    let mut table = MuxTableTarget::new(params, HashOutTarget::size(params));
 
     // None
-    tables.push_none(builder);
+    table.push_flattened(builder, OperationAuxTableTag::None as u32, &[]);
 
     append_container_proofs_operation_aux_table_circuit(
+        params,
         builder,
-        &mut tables,
+        &mut table,
         &input.merkle_proofs,
         &input.merkle_transition_proofs,
     );
@@ -469,13 +558,12 @@ fn build_operation_aux_table_circuit(
     append_open_input_statements_aux_table_circuit(
         params,
         builder,
-        &mut tables,
+        &mut table,
         input_pod_table,
         &input.open_input_statements,
     );
 
-    // CustomPredVerify: hash the verification query and store it in the dedicated narrow table;
-    // the general table gets a None entry at the same index to keep both tables aligned.
+    // CustomPredVerify: store only the hash of the verification query in the aux table.
     for entry in &input.custom_predicate_verifications {
         let measure = measure_gates_begin!(builder, "CustomPredVerify");
         // Verify the custom predicate operation
@@ -502,7 +590,11 @@ fn build_operation_aux_table_circuit(
             op_args: entry.op_args.clone(), // input
         };
         let query_hash = query.hash(builder);
-        tables.push_custom_hash(builder, &query_hash);
+        table.push(
+            builder,
+            OperationAuxTableTag::CustomPredVerify as u32,
+            &query_hash,
+        );
         measure_gates_end!(builder, measure);
     }
 
@@ -529,9 +621,18 @@ fn build_operation_aux_table_circuit(
             pk.x.components.into_iter().chain(pk.u.components).collect(),
         );
 
-        let entry: SecKeyPubKeyTarget = HashPairTarget(sk_hash, pk_hash);
+        let query_hash = hash_pair_query(
+            builder,
+            OperationAuxQueryKind::PublicKeyOf,
+            pk_hash,
+            sk_hash,
+        );
 
-        tables.push_general(builder, OperationAuxTableTag::PublicKeyOf, &entry);
+        table.push(
+            builder,
+            OperationAuxTableTag::PublicKeyOf as u32,
+            &query_hash,
+        );
         measure_gates_end!(builder, measure);
     }
 
@@ -557,18 +658,22 @@ fn build_operation_aux_table_circuit(
                 .chain(signed_by.pk.u.components)
                 .collect(),
         );
-        let entry: MsgPubKeyTarget = HashPairTarget(HashOutTarget::from(signed_by.msg), pk_hash);
+        let query_hash = hash_pair_query(
+            builder,
+            OperationAuxQueryKind::SignedBy,
+            HashOutTarget::from(signed_by.msg),
+            pk_hash,
+        );
 
-        tables.push_general(builder, OperationAuxTableTag::SignedBy, &entry);
+        table.push(builder, OperationAuxTableTag::SignedBy as u32, &query_hash);
         measure_gates_end!(builder, measure);
     }
 
     let expected_table_size = mainpod::OperationAux::table_size(params);
-    assert_eq!(tables.general.len(), expected_table_size);
-    assert_eq!(tables.custom_pred_verify_hashes.len(), expected_table_size);
+    assert_eq!(table.len(), expected_table_size);
 
     measure_gates_end!(builder, measure);
-    Ok(tables)
+    Ok(table)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -579,7 +684,7 @@ fn verify_operation_circuit(
     op: &OperationTarget,
     prev_statement_flatteneds: &[Vec<Target>],
     prev_statement_hashes: &[HashOutTarget],
-    aux_tables: &OperationAuxTables,
+    aux_table: &MuxTableTarget,
 ) -> Result<()> {
     let measure = measure_gates_begin!(builder, "OpVerifyPriv");
     let _true = builder._true();
@@ -606,8 +711,7 @@ fn verify_operation_circuit(
 
     // The aux table always has a fixed zero entry, so we check if there are more than 1 entries to
     // trigger the unhashing.
-    let resolved_aux =
-        (aux_tables.general.len() > 1).then(|| aux_tables.general.get(builder, &op.aux_index));
+    let resolved_aux = (aux_table.len() > 1).then(|| aux_table.get(builder, &op.aux_index));
 
     // Op checks to carry out. Each 'verify_X_circuit' should be thought of as operation check
     // restricted to the op of type X, where the returned target is `false` if the input targets
@@ -706,17 +810,15 @@ fn verify_operation_circuit(
                 &resolved_aux,
             )]);
         }
-    }
-    // Custom predicate verifications use the dedicated hash table and need no general aux row.
-    if params.max_custom_predicate_verification_ops > 0 {
-        op_checks.push(verify_custom_circuit(
-            builder,
-            st,
-            &op.op_type,
-            &op.aux_index,
-            &cache.op_args,
-            &aux_tables.custom_pred_verify_hashes,
-        ));
+        if params.max_custom_predicate_verification_ops > 0 {
+            op_checks.push(verify_custom_circuit(
+                builder,
+                st,
+                &op.op_type,
+                &resolved_aux,
+                &cache.op_args,
+            ));
+        }
     }
 
     let ok = builder.any(op_checks);
@@ -739,27 +841,19 @@ fn verify_contains_from_entries_circuit(
     cache: &StatementCachePriv,
 ) -> BoolTarget {
     let measure = measure_gates_begin!(builder, "OpContainsFromEntries");
-    let (aux_tag_ok, resolved_merkle_claim) =
-        aux.as_type::<MerkleClaimTarget>(builder, OperationAuxTableTag::MerkleProof as u32);
+    let (aux_tag_ok, resolved_query_hash) =
+        aux.as_type::<HashOutTarget>(builder, OperationAuxTableTag::MerkleProof as u32);
     let op_code_ok = op_type.has_native(builder, NativeOperation::ContainsFromEntries);
 
     let (arg_types_ok, [merkle_root_value, key_value, value_value]) =
         cache.first_n_args_as_values();
-
-    // Check Merkle proof (verified elsewhere) against op args.
-    let merkle_proof_checks = [
-        /* ...and it must be an existence proof. */
-        resolved_merkle_claim.existence,
-        /* ...for the root-key-value triple in the resolved op args. */
-        builder.is_equal_slice(
-            &merkle_root_value.elements,
-            &resolved_merkle_claim.root.elements,
-        ),
-        builder.is_equal_slice(&key_value.elements, &resolved_merkle_claim.key.elements),
-        builder.is_equal_slice(&value_value.elements, &resolved_merkle_claim.value.elements),
-    ];
-
-    let merkle_proof_ok = builder.all(merkle_proof_checks);
+    let expected_query_hash = hash_merkle_contains_query(
+        builder,
+        HashOutTarget::from(merkle_root_value),
+        key_value,
+        value_value,
+    );
+    let merkle_proof_ok = builder.is_equal_flattenable(&resolved_query_hash, &expected_query_hash);
 
     // Check output statement
     let arg1_expected = cache.equations[0].lhs.clone();
@@ -787,25 +881,14 @@ fn verify_not_contains_from_entries_circuit(
     cache: &StatementCachePriv,
 ) -> BoolTarget {
     let measure = measure_gates_begin!(builder, "OpNotContainsFromEntries");
-    let (aux_tag_ok, resolved_merkle_claim) =
-        aux.as_type::<MerkleClaimTarget>(builder, OperationAuxTableTag::MerkleProof as u32);
+    let (aux_tag_ok, resolved_query_hash) =
+        aux.as_type::<HashOutTarget>(builder, OperationAuxTableTag::MerkleProof as u32);
     let op_code_ok = op_type.has_native(builder, NativeOperation::NotContainsFromEntries);
 
     let (arg_types_ok, [merkle_root_value, key_value]) = cache.first_n_args_as_values();
-
-    // Check Merkle proof (verified elsewhere) against op args.
-    let merkle_proof_checks = [
-        /* ...and it must be a nonexistence proof. */
-        builder.not(resolved_merkle_claim.existence),
-        /* ...for the root-key pair in the resolved op args. */
-        builder.is_equal_slice(
-            &merkle_root_value.elements,
-            &resolved_merkle_claim.root.elements,
-        ),
-        builder.is_equal_slice(&key_value.elements, &resolved_merkle_claim.key.elements),
-    ];
-
-    let merkle_proof_ok = builder.all(merkle_proof_checks);
+    let expected_query_hash =
+        hash_merkle_not_contains_query(builder, HashOutTarget::from(merkle_root_value), key_value);
+    let merkle_proof_ok = builder.is_equal_flattenable(&resolved_query_hash, &expected_query_hash);
 
     // Check output statement
     let arg1_expected = cache.equations[0].lhs.clone();
@@ -832,51 +915,23 @@ fn verify_merkle_insert_circuit(
     cache: &StatementCachePriv,
 ) -> BoolTarget {
     let measure = measure_gates_begin!(builder, "MerkleInsertOp");
-    let (aux_tag_ok, resolved_merkle_tree_state_transition_claim) =
-        aux.as_type::<MerkleTreeStateTransitionClaimTarget>(
-            builder,
-            OperationAuxTableTag::MerkleTransitionProof as u32,
-        );
+    let (aux_tag_ok, resolved_query_hash) =
+        aux.as_type::<HashOutTarget>(builder, OperationAuxTableTag::MerkleTransitionProof as u32);
     let op_code_ok = op_type.has_native(builder, NativeOperation::ContainerInsertFromEntries);
 
     let (arg_types_ok, [old_root_value, op_key_value, op_value_value, new_root_value]) =
         cache.first_n_args_as_values();
 
     let expected_merkle_op = builder.constant(F::from_canonical_u8(MerkleTreeOp::Insert as u8));
-
-    // Check Merkle proof (verified elsewhere) against op args.
-    let merkle_proof_checks = [
-        /* ...and it must be an insertion proof. */
-        builder.is_equal(
-            resolved_merkle_tree_state_transition_claim.op,
-            expected_merkle_op,
-        ),
-        /* ...for the root-key-value combination in the resolved op args. */
-        builder.is_equal_slice(
-            &old_root_value.elements,
-            &resolved_merkle_tree_state_transition_claim
-                .old_root
-                .elements,
-        ),
-        builder.is_equal_slice(
-            &new_root_value.elements,
-            &resolved_merkle_tree_state_transition_claim
-                .new_root
-                .elements,
-        ),
-        builder.is_equal_slice(
-            &op_key_value.elements,
-            &resolved_merkle_tree_state_transition_claim.op_key.elements,
-        ),
-        builder.is_equal_slice(
-            &op_value_value.elements,
-            &resolved_merkle_tree_state_transition_claim
-                .op_value
-                .elements,
-        ),
-    ];
-
-    let merkle_proof_ok = builder.all(merkle_proof_checks);
+    let expected_query_hash = hash_merkle_transition_query(
+        builder,
+        expected_merkle_op,
+        HashOutTarget::from(old_root_value),
+        HashOutTarget::from(new_root_value),
+        op_key_value,
+        op_value_value,
+    );
+    let merkle_proof_ok = builder.is_equal_flattenable(&resolved_query_hash, &expected_query_hash);
 
     // Check output statement
     let arg1_expected = cache.equations[0].lhs.clone();
@@ -905,51 +960,23 @@ fn verify_merkle_update_circuit(
     cache: &StatementCachePriv,
 ) -> BoolTarget {
     let measure = measure_gates_begin!(builder, "MerkleUpdateOp");
-    let (aux_tag_ok, resolved_merkle_tree_state_transition_claim) =
-        aux.as_type::<MerkleTreeStateTransitionClaimTarget>(
-            builder,
-            OperationAuxTableTag::MerkleTransitionProof as u32,
-        );
+    let (aux_tag_ok, resolved_query_hash) =
+        aux.as_type::<HashOutTarget>(builder, OperationAuxTableTag::MerkleTransitionProof as u32);
     let op_code_ok = op_type.has_native(builder, NativeOperation::ContainerUpdateFromEntries);
 
     let (arg_types_ok, [old_root_value, op_key_value, op_value_value, new_root_value]) =
         cache.first_n_args_as_values();
 
     let expected_merkle_op = builder.constant(F::from_canonical_u8(MerkleTreeOp::Update as u8));
-
-    // Check Merkle proof (verified elsewhere) against op args.
-    let merkle_proof_checks = [
-        /* ...and it must be an update proof. */
-        builder.is_equal(
-            resolved_merkle_tree_state_transition_claim.op,
-            expected_merkle_op,
-        ),
-        /* ...for the root-key-value combination in the resolved op args. */
-        builder.is_equal_slice(
-            &old_root_value.elements,
-            &resolved_merkle_tree_state_transition_claim
-                .old_root
-                .elements,
-        ),
-        builder.is_equal_slice(
-            &new_root_value.elements,
-            &resolved_merkle_tree_state_transition_claim
-                .new_root
-                .elements,
-        ),
-        builder.is_equal_slice(
-            &op_key_value.elements,
-            &resolved_merkle_tree_state_transition_claim.op_key.elements,
-        ),
-        builder.is_equal_slice(
-            &op_value_value.elements,
-            &resolved_merkle_tree_state_transition_claim
-                .op_value
-                .elements,
-        ),
-    ];
-
-    let merkle_proof_ok = builder.all(merkle_proof_checks);
+    let expected_query_hash = hash_merkle_transition_query(
+        builder,
+        expected_merkle_op,
+        HashOutTarget::from(old_root_value),
+        HashOutTarget::from(new_root_value),
+        op_key_value,
+        op_value_value,
+    );
+    let merkle_proof_ok = builder.is_equal_flattenable(&resolved_query_hash, &expected_query_hash);
 
     // Check output statement
     let arg1_expected = cache.equations[0].lhs.clone();
@@ -978,45 +1005,20 @@ fn verify_merkle_delete_circuit(
     cache: &StatementCachePriv,
 ) -> BoolTarget {
     let measure = measure_gates_begin!(builder, "MerkleDeleteOp");
-    let (aux_tag_ok, resolved_merkle_tree_state_transition_claim) =
-        aux.as_type::<MerkleTreeStateTransitionClaimTarget>(
-            builder,
-            OperationAuxTableTag::MerkleTransitionProof as u32,
-        );
+    let (aux_tag_ok, resolved_query_hash) =
+        aux.as_type::<HashOutTarget>(builder, OperationAuxTableTag::MerkleTransitionProof as u32);
     let op_code_ok = op_type.has_native(builder, NativeOperation::ContainerDeleteFromEntries);
 
     let (arg_types_ok, [old_root_value, op_key_value, new_root_value]) =
         cache.first_n_args_as_values();
 
-    let expected_merkle_op = builder.constant(F::from_canonical_u8(MerkleTreeOp::Delete as u8));
-
-    // Check Merkle proof (verified elsewhere) against op args.
-    let merkle_proof_checks = [
-        /* ...and it must be a deletion proof. */
-        builder.is_equal(
-            resolved_merkle_tree_state_transition_claim.op,
-            expected_merkle_op,
-        ),
-        /* ...for the root-key combination in the resolved op args. */
-        builder.is_equal_slice(
-            &old_root_value.elements,
-            &resolved_merkle_tree_state_transition_claim
-                .old_root
-                .elements,
-        ),
-        builder.is_equal_slice(
-            &new_root_value.elements,
-            &resolved_merkle_tree_state_transition_claim
-                .new_root
-                .elements,
-        ),
-        builder.is_equal_slice(
-            &op_key_value.elements,
-            &resolved_merkle_tree_state_transition_claim.op_key.elements,
-        ),
-    ];
-
-    let merkle_proof_ok = builder.all(merkle_proof_checks);
+    let expected_query_hash = hash_merkle_delete_query(
+        builder,
+        HashOutTarget::from(old_root_value),
+        HashOutTarget::from(new_root_value),
+        op_key_value,
+    );
+    let merkle_proof_ok = builder.is_equal_flattenable(&resolved_query_hash, &expected_query_hash);
 
     // Check output statement
     let arg1_expected = cache.equations[0].lhs.clone();
@@ -1039,14 +1041,12 @@ fn verify_custom_circuit(
     builder: &mut CircuitBuilder,
     st: &StatementTarget,
     op_type: &OperationTypeTarget,
-    aux_index: &IndexTarget,
+    aux: &TableEntryTarget,
     resolved_op_args: &[StatementTarget],
-    custom_pred_verify_hashes: &MuxTableTarget,
 ) -> BoolTarget {
     let measure = measure_gates_begin!(builder, "OpCustom");
-    let resolved_hash_entry = custom_pred_verify_hashes.get(builder, aux_index);
-    let (aux_tag_ok, resolved_query_hash) = resolved_hash_entry
-        .as_type::<HashOutTarget>(builder, OperationAuxTableTag::CustomPredVerify as u32);
+    let (aux_tag_ok, resolved_query_hash) =
+        aux.as_type::<HashOutTarget>(builder, OperationAuxTableTag::CustomPredVerify as u32);
 
     let query = CustomPredicateVerifyQueryTarget {
         statement: st.clone(),
@@ -1067,10 +1067,11 @@ fn verify_open_input_statement_circuit(
     aux: &TableEntryTarget,
 ) -> BoolTarget {
     let measure = measure_gates_begin!(builder, "OpOpenInputSt");
-    let (aux_tag_ok, resolved_statement) =
-        aux.as_type::<StatementTarget>(builder, OperationAuxTableTag::OpenInputStatement as u32);
+    let (aux_tag_ok, resolved_query_hash) =
+        aux.as_type::<HashOutTarget>(builder, OperationAuxTableTag::OpenInputStatement as u32);
     let op_code_ok = op_type.has_native(builder, NativeOperation::OpenInputStatement);
-    let query_ok = builder.is_equal_flattenable(&resolved_statement, st);
+    let expected_query_hash = hash_statement_query(builder, st);
+    let query_ok = builder.is_equal_flattenable(&resolved_query_hash, &expected_query_hash);
 
     let ok = builder.all([op_code_ok, aux_tag_ok, query_ok]);
     measure_gates_end!(builder, measure);
@@ -1236,16 +1237,21 @@ fn verify_public_key_from_entries_circuit(
     cache: &StatementCachePriv,
 ) -> BoolTarget {
     let measure = measure_gates_begin!(builder, "OpPublicKey");
-    let (aux_tag_ok, resolved_sk_pk) =
-        aux.as_type::<SecKeyPubKeyTarget>(builder, OperationAuxTableTag::PublicKeyOf as u32);
+    let (aux_tag_ok, resolved_query_hash) =
+        aux.as_type::<HashOutTarget>(builder, OperationAuxTableTag::PublicKeyOf as u32);
 
     let op_code_ok = op_type.has_native(builder, NativeOperation::PublicKeyFromEntries);
     let (arg_types_ok, [arg1_value, arg2_value]) = cache.first_n_args_as_values();
     let sk_hash = arg1_value;
     let pk_hash = arg2_value;
 
-    let sk_ok = builder.is_equal_slice(&sk_hash.elements, &resolved_sk_pk.0.elements);
-    let pk_ok = builder.is_equal_slice(&pk_hash.elements, &resolved_sk_pk.1.elements);
+    let expected_query_hash = hash_pair_query(
+        builder,
+        OperationAuxQueryKind::PublicKeyOf,
+        HashOutTarget::from(pk_hash),
+        HashOutTarget::from(sk_hash),
+    );
+    let query_ok = builder.is_equal_flattenable(&resolved_query_hash, &expected_query_hash);
 
     let arg1_expected = cache.equations[0].lhs.clone();
     let arg2_expected = cache.equations[1].lhs.clone();
@@ -1257,7 +1263,7 @@ fn verify_public_key_from_entries_circuit(
     );
     let st_ok = builder.is_equal_flattenable(st, &expected_statement);
 
-    let ok = builder.all([op_code_ok, aux_tag_ok, arg_types_ok, pk_ok, sk_ok, st_ok]);
+    let ok = builder.all([op_code_ok, aux_tag_ok, arg_types_ok, query_ok, st_ok]);
     measure_gates_end!(builder, measure);
     ok
 }
@@ -1271,8 +1277,8 @@ fn verify_signed_by_circuit(
     cache: &StatementCachePriv,
 ) -> BoolTarget {
     let measure = measure_gates_begin!(builder, "OpSignedBy");
-    let (aux_tag_ok, resolved_msg_pk) =
-        aux.as_type::<MsgPubKeyTarget>(builder, OperationAuxTableTag::SignedBy as u32);
+    let (aux_tag_ok, resolved_query_hash) =
+        aux.as_type::<HashOutTarget>(builder, OperationAuxTableTag::SignedBy as u32);
 
     let op_code_ok = op_type.has_native(builder, NativeOperation::SignedByFromEntries);
     let (arg_types_ok, [arg1_value, arg2_value]) = cache.first_n_args_as_values();
@@ -1280,8 +1286,13 @@ fn verify_signed_by_circuit(
     let msg = arg1_value;
     let pk_hash = arg2_value;
 
-    let msg_ok = builder.is_equal_slice(&msg.elements, &resolved_msg_pk.0.elements);
-    let pk_ok = builder.is_equal_slice(&pk_hash.elements, &resolved_msg_pk.1.elements);
+    let expected_query_hash = hash_pair_query(
+        builder,
+        OperationAuxQueryKind::SignedBy,
+        HashOutTarget::from(msg),
+        HashOutTarget::from(pk_hash),
+    );
+    let query_ok = builder.is_equal_flattenable(&resolved_query_hash, &expected_query_hash);
 
     let arg1_expected = cache.equations[0].lhs.clone();
     let arg2_expected = cache.equations[1].lhs.clone();
@@ -1293,7 +1304,7 @@ fn verify_signed_by_circuit(
     );
     let st_ok = builder.is_equal_flattenable(st, &expected_statement);
 
-    let ok = builder.all([op_code_ok, aux_tag_ok, arg_types_ok, msg_ok, pk_ok, st_ok]);
+    let ok = builder.all([op_code_ok, aux_tag_ok, arg_types_ok, query_ok, st_ok]);
     measure_gates_end!(builder, measure);
     ok
 }

--- a/src/backends/plonky2/circuits/mainpod/tests.rs
+++ b/src/backends/plonky2/circuits/mainpod/tests.rs
@@ -12,7 +12,10 @@ use crate::{
     backends::plonky2::{
         basetypes::C,
         circuits::common::tests::I64_TEST_PAIRS,
-        mainpod::{OperationArg, OperationAux, Size},
+        mainpod::{
+            extract_custom_predicate_verifications, extract_custom_predicates, OperationArg,
+            OperationAux, Size,
+        },
         primitives::{
             ec::schnorr::SecretKey,
             merkletree::{MerkleClaimAndProof, MerkleTree, MerkleTreeStateTransitionProof},
@@ -1626,6 +1629,444 @@ fn test_normalize_st_tmpl_self_predicate_hash() -> Result<()> {
     let data = builder.build::<C>();
     let proof = data.prove(pw)?;
     data.verify(proof)?;
+
+    Ok(())
+}
+
+fn custom_pred_verify_hash_table_lookup(index: usize, expected_hash: HashOut) -> Result<()> {
+    let params = Params::default();
+    let config = CircuitConfig::standard_recursion_config();
+    let mut builder = CircuitBuilder::new(config);
+
+    let mut custom_pred_verify_hashes = MuxTableTarget::new(&params, HashOutTarget::size(&params));
+    let hash0 = builder.constant_hash(HashOut {
+        elements: [F(11), F(12), F(13), F(14)],
+    });
+    let hash1 = builder.constant_hash(HashOut {
+        elements: [F(21), F(22), F(23), F(24)],
+    });
+    custom_pred_verify_hashes.push_flattened(
+        &mut builder,
+        OperationAuxTableTag::CustomPredVerify as u32,
+        &hash0.elements,
+    );
+    custom_pred_verify_hashes.push_flattened(
+        &mut builder,
+        OperationAuxTableTag::CustomPredVerify as u32,
+        &hash1.elements,
+    );
+
+    let index_target = IndexTarget::new_virtual(2, &mut builder);
+    let resolved_hash_entry = custom_pred_verify_hashes.get(&mut builder, &index_target);
+    let (aux_tag_ok, resolved_query_hash) = resolved_hash_entry
+        .as_type::<HashOutTarget>(&mut builder, OperationAuxTableTag::CustomPredVerify as u32);
+    let expected_hash_target = builder.constant_hash(expected_hash);
+    builder.assert_one(aux_tag_ok.target);
+    builder.connect_hashes(resolved_query_hash, expected_hash_target);
+
+    let mut pw = PartialWitness::<F>::new();
+    index_target.set_targets(&mut pw, index)?;
+    let data = builder.build::<C>();
+    let proof = data.prove(pw)?;
+    data.verify(proof)?;
+    Ok(())
+}
+
+#[test]
+fn test_custom_pred_verify_hash_table_index_selection() {
+    let hash0 = HashOut {
+        elements: [F(11), F(12), F(13), F(14)],
+    };
+    custom_pred_verify_hash_table_lookup(0, hash0).unwrap();
+    assert!(custom_pred_verify_hash_table_lookup(1, hash0).is_err());
+}
+
+/// Drives `verify_custom_circuit` against a custom_pred_verify_hashes table whose
+/// only real entry stores the hash of `(stored_st, stored_op_type, stored_op_args)`.
+/// The verify-side query is `(verify_st, verify_op_type, verify_op_args)` and points
+/// at row `aux_index_value`. The proof should succeed iff both queries agree and the
+/// index lands on the real row.
+fn helper_verify_custom_mutation(
+    stored_st: &Statement,
+    stored_op_type: &OperationType,
+    stored_op_args: &[Statement],
+    verify_st: &Statement,
+    verify_op_type: &OperationType,
+    verify_op_args: &[Statement],
+    aux_index_value: usize,
+) -> Result<()> {
+    let params = Params::default();
+    let pad = |v: &[Statement]| {
+        assert!(v.len() <= BASE_PARAMS.max_operation_args);
+        let mut padded = v.to_vec();
+        while padded.len() < BASE_PARAMS.max_operation_args {
+            padded.push(Statement::None);
+        }
+        padded
+    };
+    let stored_op_args = pad(stored_op_args);
+    let verify_op_args = pad(verify_op_args);
+
+    let config = CircuitConfig::standard_recursion_config();
+    let mut builder = CircuitBuilder::new(config);
+
+    let stored_st_target = builder.add_virtual_statement(false);
+    let stored_op_type_target = builder.add_virtual_operation_type();
+    let stored_op_args_target: Vec<_> = (0..BASE_PARAMS.max_operation_args)
+        .map(|_| builder.add_virtual_statement(false))
+        .collect();
+    let stored_hash = CustomPredicateVerifyQueryTarget {
+        statement: stored_st_target.clone(),
+        op_type: stored_op_type_target.clone(),
+        op_args: stored_op_args_target.clone(),
+    }
+    .hash(&mut builder);
+
+    let mut tbl = MuxTableTarget::new(&params, HashOutTarget::size(&params));
+    tbl.push_flattened(&mut builder, OperationAuxTableTag::None as u32, &[]);
+    tbl.push(
+        &mut builder,
+        OperationAuxTableTag::CustomPredVerify as u32,
+        &stored_hash,
+    );
+
+    let verify_st_target = builder.add_virtual_statement(false);
+    let verify_op_type_target = builder.add_virtual_operation_type();
+    let verify_op_args_target: Vec<_> = (0..BASE_PARAMS.max_operation_args)
+        .map(|_| builder.add_virtual_statement(false))
+        .collect();
+    let aux_index = IndexTarget::new_virtual(2, &mut builder);
+
+    let ok = verify_custom_circuit(
+        &mut builder,
+        &verify_st_target,
+        &verify_op_type_target,
+        &aux_index,
+        &verify_op_args_target,
+        &tbl,
+    );
+    builder.assert_one(ok.target);
+
+    let mut pw = PartialWitness::<F>::new();
+    stored_st_target.set_targets(&mut pw, &stored_st.clone().into())?;
+    stored_op_type_target.set_targets(&mut pw, stored_op_type)?;
+    for (t, s) in stored_op_args_target.iter().zip(stored_op_args.iter()) {
+        t.set_targets(&mut pw, &s.clone().into())?;
+    }
+    verify_st_target.set_targets(&mut pw, &verify_st.clone().into())?;
+    verify_op_type_target.set_targets(&mut pw, verify_op_type)?;
+    for (t, s) in verify_op_args_target.iter().zip(verify_op_args.iter()) {
+        t.set_targets(&mut pw, &s.clone().into())?;
+    }
+    aux_index.set_targets(&mut pw, aux_index_value)?;
+
+    let data = builder.build::<C>();
+    let proof = data.prove(pw)?;
+    data.verify(proof)?;
+    Ok(())
+}
+
+/// Builds the test predicate `p(id, secret_id) = AND(Equal(id["score"], 42),
+/// Equal(secret_id["key"], id["score"]))` and returns the public ref to predicate 0.
+fn make_score_key_predicate(params: &Params) -> frontend::Result<CustomPredicateRef> {
+    use NativePredicate as NP;
+    use StatementTmplBuilder as STB;
+    let mut cpb = CustomPredicateBatchBuilder::new(params.clone(), "batch".into());
+    let stb0 = STB::new_from_pred(NP::Equal)
+        .arg(("id", "score"))
+        .arg(literal(42));
+    let stb1 = STB::new_from_pred(NP::Equal)
+        .arg(("secret_id", "key"))
+        .arg(("id", "score"));
+    cpb.predicate_and("p", &["id"], &["secret_id"], &[stb0, stb1])?;
+    let batch = cpb.finish()?;
+    Ok(CustomPredicateRef::new(batch, 0))
+}
+
+#[test]
+fn test_verify_custom_circuit_hash_binding() -> frontend::Result<()> {
+    let params = Params::default();
+    let cp = make_score_key_predicate(&params)?;
+
+    let dict = Hash([F(1), F(2), F(3), F(4)]);
+    let secret_dict = Hash([F(6), F(7), F(8), F(9)]);
+    let op_args = vec![
+        Statement::equal(AnchoredKey::new(dict, Key::from("score")), Value::from(42)),
+        Statement::equal(
+            AnchoredKey::new(secret_dict, Key::from("key")),
+            AnchoredKey::new(dict, Key::from("score")),
+        ),
+    ];
+    let st = Statement::Custom(cp.clone(), vec![value_ref(Value::from(dict)), value_ref(0)]);
+    let op_type = OperationType::Custom(cp);
+
+    // Positive: identical inputs at the real row.
+    helper_verify_custom_mutation(&st, &op_type, &op_args, &st, &op_type, &op_args, 1).unwrap();
+
+    // aux_index points at the None row -> aux_tag_ok must fail.
+    assert!(
+        helper_verify_custom_mutation(&st, &op_type, &op_args, &st, &op_type, &op_args, 0).is_err()
+    );
+
+    // Swap two op_args -> hash includes positions, must fail.
+    let mut swapped = op_args.clone();
+    swapped.swap(0, 1);
+    assert!(
+        helper_verify_custom_mutation(&st, &op_type, &op_args, &st, &op_type, &swapped, 1).is_err()
+    );
+
+    // Mutate one op_arg's literal -> hash diverges, must fail.
+    let mut bad_arg = op_args.clone();
+    bad_arg[0] = Statement::equal(
+        AnchoredKey::new(dict, Key::from("score")),
+        Value::from(0xbad),
+    );
+    assert!(
+        helper_verify_custom_mutation(&st, &op_type, &op_args, &st, &op_type, &bad_arg, 1).is_err()
+    );
+
+    // Mutate the statement -> hash diverges, must fail.
+    assert!(helper_verify_custom_mutation(
+        &st,
+        &op_type,
+        &op_args,
+        &Statement::None,
+        &op_type,
+        &op_args,
+        1,
+    )
+    .is_err());
+
+    Ok(())
+}
+
+/// Drives `verify_operation_circuit` against a real custom-predicate aux scenario.
+/// Builds the predicates table and the split aux tables via the production
+/// `build_operation_aux_table_circuit`. Tests vary `aux` to point the operation at
+/// different rows in the aux table.
+#[allow(clippy::too_many_arguments)]
+fn helper_verify_operation_through_aux_table(
+    params: &Params,
+    custom_predicates: &[CustomPredicateRef],
+    custom_predicate_verifications: &[CustomPredicateVerification],
+    st: mainpod::Statement,
+    op_type: OperationType,
+    op_args_indices: Vec<OperationArg>,
+    prev_statements: Vec<mainpod::Statement>,
+    aux: OperationAux,
+) -> Result<()> {
+    assert_eq!(custom_predicates.len(), params.max_custom_predicates);
+    assert_eq!(
+        custom_predicate_verifications.len(),
+        params.max_custom_predicate_verifications
+    );
+
+    let config = CircuitConfig::standard_recursion_config();
+    let mut builder = CircuitBuilder::new(config);
+
+    let st_target = builder.add_virtual_statement(false);
+    let op_target = builder.add_virtual_operation(params);
+    let prev_statements_target: Vec<_> = (0..prev_statements.len())
+        .map(|_| builder.add_virtual_statement(false))
+        .collect();
+    let prev_statement_flatteneds_target: Vec<Vec<Target>> = prev_statements_target
+        .iter()
+        .map(|st| st.flatten())
+        .collect();
+    let prev_statement_hashes_target: Vec<_> = prev_statement_flatteneds_target
+        .iter()
+        .map(|flat| builder.hash_n_to_hash_no_pad::<PoseidonHash>(flat.clone()))
+        .collect();
+
+    let custom_predicates_target: Vec<_> = (0..params.max_custom_predicates)
+        .map(|_| CustomPredicateInBatchTarget::new_virtual(&mut builder))
+        .collect();
+    let custom_predicate_verifications_target: Vec<_> = (0..params
+        .max_custom_predicate_verifications)
+        .map(|_| CustomPredicateVerifyEntryTarget::new_virtual(params, &mut builder))
+        .collect();
+
+    let custom_predicate_table =
+        build_custom_predicate_table_circuit(params, &mut builder, &custom_predicates_target)?;
+
+    // Construct an AuxTableInputTargets that has only the custom_predicate_verifications populated;
+    // the other capacities are zero in this test's params, so the other vectors stay empty.
+    let aux_table_input = AuxTableInputTargets {
+        merkle_proofs: MerkleProofsTarget::new_virtual(params, &mut builder),
+        merkle_transition_proofs: MerkleTransitionProofsTarget::new_virtual(params, &mut builder),
+        open_input_statements: (0..params.max_open_input_statements)
+            .map(|_| OpenInputStatementTarget::new_virtual(&mut builder))
+            .collect(),
+        public_key_of_sks: (0..params.max_public_key_of)
+            .map(|_| builder.add_virtual_biguint320_target())
+            .collect(),
+        signed_bys: (0..params.max_signed_by)
+            .map(|_| SignedByTarget::new_virtual(&mut builder))
+            .collect(),
+        custom_predicate_verifications: custom_predicate_verifications_target.clone(),
+    };
+
+    let aux_tables = build_operation_aux_table_circuit(
+        params,
+        &mut builder,
+        &custom_predicate_table,
+        &[],
+        &aux_table_input,
+    )?;
+
+    verify_operation_circuit(
+        params,
+        &mut builder,
+        &st_target,
+        &op_target,
+        &prev_statement_flatteneds_target,
+        &prev_statement_hashes_target,
+        &aux_tables,
+    )?;
+
+    let op = mainpod::Operation(op_type, op_args_indices, aux);
+
+    let mut pw = PartialWitness::<F>::new();
+    st_target.set_targets(&mut pw, &st)?;
+    op_target.set_targets(&mut pw, params, &op)?;
+    for (t, s) in prev_statements_target.iter().zip(prev_statements.iter()) {
+        t.set_targets(&mut pw, s)?;
+    }
+    for (cp_target, cpr) in custom_predicates_target
+        .iter()
+        .zip(custom_predicates.iter())
+    {
+        let mtp = cpr
+            .batch
+            .mt()
+            .prove(&Value::from(cpr.index as i64).raw())
+            .expect("predicate index exists in batch MT")
+            .1;
+        cp_target.set_targets(&mut pw, cpr, &mtp)?;
+    }
+    for (cpv_target, cpv) in custom_predicate_verifications_target
+        .iter()
+        .zip(custom_predicate_verifications.iter())
+    {
+        cpv_target.set_targets(&mut pw, params, cpv)?;
+    }
+
+    let data = builder.build::<C>();
+    let proof = data.prove(pw)?;
+    data.verify(proof)?;
+    Ok(())
+}
+
+#[test]
+fn test_verify_operation_custom_aux_index_binding() -> frontend::Result<()> {
+    let params = Params {
+        max_input_pods: 0,
+        max_open_input_statements: 0,
+        max_custom_predicates: 1,
+        max_custom_predicate_verifications: 2,
+        max_custom_predicate_wildcards: 4,
+        max_public_key_of: 0,
+        max_signed_by: 0,
+        containers: middleware::ParamsContainers {
+            state: middleware::ParamsMerkleProofs {
+                max_small: 0,
+                max_medium: 0,
+            },
+            transition: middleware::ParamsMerkleProofs {
+                max_small: 0,
+                max_medium: 0,
+            },
+            ..middleware::ParamsContainers::default()
+        },
+        ..Params::default()
+    };
+    let cp = make_score_key_predicate(&params)?;
+
+    // Two distinct scenarios that both validate the predicate, so each produces a different
+    // CustomPredVerify row in the aux table (different op_args -> different stored hash).
+    let scenario = |id_seed: F, secret_seed: F| -> (Statement, Vec<Statement>) {
+        let id = Hash([id_seed, F(2), F(3), F(4)]);
+        let secret = Hash([secret_seed, F(7), F(8), F(9)]);
+        let op_args = vec![
+            Statement::equal(AnchoredKey::new(id, Key::from("score")), Value::from(42)),
+            Statement::equal(
+                AnchoredKey::new(secret, Key::from("key")),
+                AnchoredKey::new(id, Key::from("score")),
+            ),
+        ];
+        let st = Statement::Custom(cp.clone(), vec![value_ref(Value::from(id))]);
+        (st, op_args)
+    };
+    let (st_a, op_args_a) = scenario(F(1), F(6));
+    let (st_b, op_args_b) = scenario(F(11), F(16));
+
+    // Use the production extraction routines so the test exercises the same wildcard
+    // derivation and aux-index assignment as MainPodBuilder.
+    let mid_ops = vec![
+        crate::middleware::Operation::Custom(cp.clone(), op_args_a.clone()),
+        crate::middleware::Operation::Custom(cp.clone(), op_args_b),
+    ];
+    let mid_sts = vec![st_a.clone(), st_b];
+    let custom_predicates = extract_custom_predicates(&params, &mid_ops)?;
+    let mut aux_list = vec![OperationAux::None; mid_ops.len()];
+    let custom_predicate_verifications = extract_custom_predicate_verifications(
+        &params,
+        &mut aux_list,
+        &mid_ops,
+        &mid_sts,
+        &custom_predicates,
+    )?;
+
+    // prev_statements[0] = Statement::None so that op_arg padding (OperationArg::None,
+    // which resolves to Index(0)) matches the Statement::None padding inside the cpv entry.
+    let prev_statements: Vec<mainpod::Statement> = std::iter::once(Statement::None)
+        .chain(op_args_a.iter().cloned())
+        .map(|s| s.into())
+        .collect();
+    let st_a_mp: mainpod::Statement = st_a.into();
+    let op_type = OperationType::Custom(cp);
+    let op_args_indices = vec![OperationArg::Index(1), OperationArg::Index(2)];
+
+    // Positive: aux points at the real custom row.
+    helper_verify_operation_through_aux_table(
+        &params,
+        &custom_predicates,
+        &custom_predicate_verifications,
+        st_a_mp.clone(),
+        op_type.clone(),
+        op_args_indices.clone(),
+        prev_statements.clone(),
+        OperationAux::CustomPredVerifyIndex(0),
+    )
+    .unwrap();
+
+    // Mutation: aux points at the leading None row (non-custom slot).
+    // The custom_pred_verify_hashes entry there has the None tag, so aux_tag_ok fails.
+    assert!(helper_verify_operation_through_aux_table(
+        &params,
+        &custom_predicates,
+        &custom_predicate_verifications,
+        st_a_mp.clone(),
+        op_type.clone(),
+        op_args_indices.clone(),
+        prev_statements.clone(),
+        OperationAux::None,
+    )
+    .is_err());
+
+    // Mutation: aux points at the other custom row, whose stored hash binds different op_args.
+    // aux_tag_ok passes, query_ok fails.
+    assert!(helper_verify_operation_through_aux_table(
+        &params,
+        &custom_predicates,
+        &custom_predicate_verifications,
+        st_a_mp,
+        op_type,
+        op_args_indices,
+        prev_statements,
+        OperationAux::CustomPredVerifyIndex(1),
+    )
+    .is_err());
 
     Ok(())
 }

--- a/src/backends/plonky2/circuits/mainpod/tests.rs
+++ b/src/backends/plonky2/circuits/mainpod/tests.rs
@@ -156,7 +156,7 @@ fn operation_verify(
         signed_bys: signed_by_targets,
         custom_predicate_verifications: Vec::new(),
     };
-    let aux_table =
+    let aux_tables =
         build_operation_aux_table_circuit(&params, &mut builder, &[], &[], &aux_table_inputs)?;
 
     verify_operation_circuit(
@@ -166,7 +166,7 @@ fn operation_verify(
         &op_target,
         &prev_statement_flatteneds_target,
         &prev_statement_hashes_target,
-        &aux_table,
+        &aux_tables,
     )?;
 
     let mut pw = PartialWitness::<F>::new();

--- a/src/backends/plonky2/circuits/mainpod/tests.rs
+++ b/src/backends/plonky2/circuits/mainpod/tests.rs
@@ -11,7 +11,7 @@ use super::*;
 use crate::{
     backends::plonky2::{
         basetypes::C,
-        circuits::common::tests::I64_TEST_PAIRS,
+        circuits::common::{tests::I64_TEST_PAIRS, IndexTarget},
         mainpod::{
             extract_custom_predicate_verifications, extract_custom_predicates, OperationArg,
             OperationAux, Size,
@@ -1681,8 +1681,60 @@ fn test_custom_pred_verify_hash_table_index_selection() {
     assert!(custom_pred_verify_hash_table_lookup(1, hash0).is_err());
 }
 
-/// Drives `verify_custom_circuit` against a custom_pred_verify_hashes table whose
-/// only real entry stores the hash of `(stored_st, stored_op_type, stored_op_args)`.
+fn prove_connected_aux_query_hashes(
+    hash_pair: impl FnOnce(
+        &mut crate::backends::plonky2::basetypes::CircuitBuilder,
+    ) -> (HashOutTarget, HashOutTarget),
+) -> Result<()> {
+    let config = CircuitConfig::standard_recursion_config();
+    let mut builder = crate::backends::plonky2::basetypes::CircuitBuilder::new(config);
+    let (left, right) = hash_pair(&mut builder);
+    builder.connect_hashes(left, right);
+
+    let pw = PartialWitness::<F>::new();
+    let data = builder.build::<C>();
+    let proof = data.prove(pw)?;
+    data.verify(proof)?;
+    Ok(())
+}
+
+#[test]
+fn test_aux_query_hash_distinguishes_contains_from_not_contains() {
+    assert!(prove_connected_aux_query_hashes(|builder| {
+        let root = builder.constant_hash(HashOut {
+            elements: [F(1), F(2), F(3), F(4)],
+        });
+        let key = builder.constant_value(RawValue::from(42));
+        let value = builder.constant_value(RawValue::from(0));
+        let contains_hash = hash_merkle_contains_query(builder, root, key, value);
+        let not_contains_hash = hash_merkle_not_contains_query(builder, root, key);
+        (contains_hash, not_contains_hash)
+    })
+    .is_err());
+}
+
+#[test]
+fn test_aux_query_hash_distinguishes_transition_delete_from_delete_shape() {
+    assert!(prove_connected_aux_query_hashes(|builder| {
+        let old_root = builder.constant_hash(HashOut {
+            elements: [F(11), F(12), F(13), F(14)],
+        });
+        let new_root = builder.constant_hash(HashOut {
+            elements: [F(21), F(22), F(23), F(24)],
+        });
+        let key = builder.constant_value(RawValue::from(7));
+        let value = builder.constant_value(RawValue::from(0));
+        let delete_op = builder.constant(F::from_canonical_u8(MerkleTreeOp::Delete as u8));
+        let transition_hash =
+            hash_merkle_transition_query(builder, delete_op, old_root, new_root, key, value);
+        let delete_hash = hash_merkle_delete_query(builder, old_root, new_root, key);
+        (transition_hash, delete_hash)
+    })
+    .is_err());
+}
+
+/// Drives `verify_custom_circuit` against an aux table whose only real entry stores
+/// the hash of `(stored_st, stored_op_type, stored_op_args)`.
 /// The verify-side query is `(verify_st, verify_op_type, verify_op_args)` and points
 /// at row `aux_index_value`. The proof should succeed iff both queries agree and the
 /// index lands on the real row.
@@ -1736,14 +1788,14 @@ fn helper_verify_custom_mutation(
         .map(|_| builder.add_virtual_statement(false))
         .collect();
     let aux_index = IndexTarget::new_virtual(2, &mut builder);
+    let resolved_aux = tbl.get(&mut builder, &aux_index);
 
     let ok = verify_custom_circuit(
         &mut builder,
         &verify_st_target,
         &verify_op_type_target,
-        &aux_index,
+        &resolved_aux,
         &verify_op_args_target,
-        &tbl,
     );
     builder.assert_one(ok.target);
 
@@ -1858,7 +1910,7 @@ fn helper_verify_operation_through_aux_table(
     assert_eq!(custom_predicates.len(), params.max_custom_predicates);
     assert_eq!(
         custom_predicate_verifications.len(),
-        params.max_custom_predicate_verifications
+        params.max_custom_predicate_verification_ops
     );
 
     let config = CircuitConfig::standard_recursion_config();
@@ -1882,7 +1934,7 @@ fn helper_verify_operation_through_aux_table(
         .map(|_| CustomPredicateInBatchTarget::new_virtual(&mut builder))
         .collect();
     let custom_predicate_verifications_target: Vec<_> = (0..params
-        .max_custom_predicate_verifications)
+        .max_custom_predicate_verification_ops)
         .map(|_| CustomPredicateVerifyEntryTarget::new_virtual(params, &mut builder))
         .collect();
 
@@ -1894,13 +1946,13 @@ fn helper_verify_operation_through_aux_table(
     let aux_table_input = AuxTableInputTargets {
         merkle_proofs: MerkleProofsTarget::new_virtual(params, &mut builder),
         merkle_transition_proofs: MerkleTransitionProofsTarget::new_virtual(params, &mut builder),
-        open_input_statements: (0..params.max_open_input_statements)
+        open_input_statements: (0..params.max_open_input_statement_ops)
             .map(|_| OpenInputStatementTarget::new_virtual(&mut builder))
             .collect(),
-        public_key_of_sks: (0..params.max_public_key_of)
+        public_key_sks: (0..params.max_public_key_ops)
             .map(|_| builder.add_virtual_biguint320_target())
             .collect(),
-        signed_bys: (0..params.max_signed_by)
+        signed_bys: (0..params.max_signed_by_ops)
             .map(|_| SignedByTarget::new_virtual(&mut builder))
             .collect(),
         custom_predicate_verifications: custom_predicate_verifications_target.clone(),
@@ -1961,18 +2013,18 @@ fn helper_verify_operation_through_aux_table(
 fn test_verify_operation_custom_aux_index_binding() -> frontend::Result<()> {
     let params = Params {
         max_input_pods: 0,
-        max_open_input_statements: 0,
+        max_open_input_statement_ops: 0,
         max_custom_predicates: 1,
-        max_custom_predicate_verifications: 2,
+        max_custom_predicate_verification_ops: 2,
         max_custom_predicate_wildcards: 4,
-        max_public_key_of: 0,
-        max_signed_by: 0,
+        max_public_key_ops: 0,
+        max_signed_by_ops: 0,
         containers: middleware::ParamsContainers {
-            state: middleware::ParamsMerkleProofs {
+            state_ops: middleware::ParamsMerkleProofs {
                 max_small: 0,
                 max_medium: 0,
             },
-            transition: middleware::ParamsMerkleProofs {
+            transition_ops: middleware::ParamsMerkleProofs {
                 max_small: 0,
                 max_medium: 0,
             },
@@ -2041,7 +2093,7 @@ fn test_verify_operation_custom_aux_index_binding() -> frontend::Result<()> {
     .unwrap();
 
     // Mutation: aux points at the leading None row (non-custom slot).
-    // The custom_pred_verify_hashes entry there has the None tag, so aux_tag_ok fails.
+    // The aux entry there has the None tag, so aux_tag_ok fails.
     assert!(helper_verify_operation_through_aux_table(
         &params,
         &custom_predicates,

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -1030,11 +1030,11 @@ impl Default for Params {
     fn default() -> Self {
         Self {
             max_input_pods: 2,
-            max_statements: 48,
+            max_statements: 52,
             max_public_statements: 20,
             max_open_input_statement_ops: 20,
-            max_custom_predicates: 10,
-            max_custom_predicate_verification_ops: 10,
+            max_custom_predicates: 16,
+            max_custom_predicate_verification_ops: 16,
             max_custom_predicate_wildcards: 8,
             containers: ParamsContainers::default(),
             max_depth_mt_vds: 6, // up to 64 (2^6) different pod circuits


### PR DESCRIPTION
The aux table holds supporting data for certain operations, including Merkle container and state transition ops, `SignedBy`, `PublicKeyOf`, and custom predicate operations. It has a fixed row size, based on the largest possible value. Most aux table entries are quite small - `MerkleTreeStateTransitionClaimTarget` is 18 field elements, and all others are smaller. However, `CustomPredicateVerifyQueryTarget` is 314 field elements. Because of this outlier, the table rows are much larger than is needed for typical cases, making lookups more expensive than they need to be.

This change stores only a query hash in the aux table, for every operation kind:

- The aux table now carries a single query hash per row (`HashOutTarget`, 4 field elements) instead of a full entry, so the row size is the same for every operation and no longer driven by the `CustomPredicateVerifyQueryTarget` outlier — narrower rows, fewer Poseidon constraints per lookup.
- At table-build time each operation hashes its query inputs into that one entry: Merkle `Contains` / `NotContains`, state transition, `OpenInputStatement`, `PublicKeyOf`, `SignedBy`, and CustomPredVerify.
- Each verify circuit looks up the stored hash and compares it to a freshly-computed hash of the operation's inputs (e.g. `verify_custom_circuit` hashes (statement, op_type, op_args)), instead of unhashing a wide row and doing flattened equality.

The hashed input is prefixed with a domain-separation tag (`OperationAuxQueryKind`), distinct from the row tag (`OperationAuxTableTag`): the row tag labels the physical table segment, while the query kind separates semantic shapes that share a row tag, such as `Contains` / `NotContains` or transition Insert / Update / Delete.