### PR TITLE
Remove legacy wildcard key support

### DIFF
--- a/src/backends/plonky2/circuits/common.rs
+++ b/src/backends/plonky2/circuits/common.rs
@@ -448,39 +448,6 @@ impl PredicateTarget {
     }
 }
 
-/// Mirrors `middleware::KeyOrWildcard`
-#[derive(Clone)]
-pub struct LiteralOrWildcardTarget {
-    pub elements: [Target; VALUE_SIZE],
-}
-
-impl LiteralOrWildcardTarget {
-    fn from_slice(v: &[Target]) -> Self {
-        Self {
-            elements: v.try_into().expect("len is VALUE_SIZE"),
-        }
-    }
-    /// cases: ((is_key, key), (is_wildcard, wildcard_index))
-    pub fn cases(
-        &self,
-        builder: &mut CircuitBuilder,
-    ) -> ((BoolTarget, ValueTarget), (BoolTarget, Target)) {
-        let zero = builder.zero();
-        let is_zero_tail: Vec<_> = (1..4)
-            .map(|i| builder.is_equal(self.elements[i], zero))
-            .collect();
-        let is_wildcard = is_zero_tail
-            .into_iter()
-            .reduce(|acc, x| builder.and(acc, x))
-            .expect("len > 1");
-        let is_key = builder.not(is_wildcard);
-        let key = ValueTarget::from_slice(&self.elements);
-        let wildcard_index = self.elements[0];
-
-        ((is_key, key), (is_wildcard, wildcard_index))
-    }
-}
-
 #[derive(Clone, Serialize, Deserialize)]
 pub struct StatementTmplArgTarget {
     #[serde(with = "serde_arrays")]
@@ -503,12 +470,12 @@ impl StatementTmplArgTarget {
     pub fn as_anchored_key(
         &self,
         builder: &mut CircuitBuilder,
-    ) -> (BoolTarget, Target, LiteralOrWildcardTarget) {
+    ) -> (BoolTarget, Target, ValueTarget) {
         let prefix = builder.constant(F::from(StatementTmplArgPrefix::AnchoredKey));
         let case_ok = builder.is_equal(self.elements[0], prefix);
         let id_wildcard_index = self.elements[1];
-        let value_key_or_wildcard = LiteralOrWildcardTarget::from_slice(&self.elements[5..9]);
-        (case_ok, id_wildcard_index, value_key_or_wildcard)
+        let key = ValueTarget::from_slice(&self.elements[5..9]);
+        (case_ok, id_wildcard_index, key)
     }
 
     pub fn as_wildcard_literal(&self, builder: &mut CircuitBuilder) -> (BoolTarget, Target) {

--- a/src/backends/plonky2/circuits/mainpod/mod.rs
+++ b/src/backends/plonky2/circuits/mainpod/mod.rs
@@ -1462,11 +1462,8 @@ fn make_statement_arg_from_template_circuit(
 ) -> StatementArgTarget {
     let zero = builder.zero();
     let (is_literal, value_literal) = st_tmpl_arg.as_literal(builder);
-    let (is_ak, ak_id_wc_index, ak_key_lit_or_wc) = st_tmpl_arg.as_anchored_key(builder);
+    let (is_ak, ak_id_wc_index, ak_key) = st_tmpl_arg.as_anchored_key(builder);
     let (is_wc_literal, wc_index) = st_tmpl_arg.as_wildcard_literal(builder);
-
-    let ((_is_ak_key_lit, ak_key_lit), (is_ak_key_wc, ak_key_wc_index)) =
-        ak_key_lit_or_wc.cases(builder);
 
     // optimization: ak_id_wc_index and wc_index use the same signals, so we only need to do one
     // random access to resolve both of them
@@ -1479,16 +1476,6 @@ fn make_statement_arg_from_template_circuit(
     let first_index = builder.select(is_first_index_valid, first_index, zero);
     let resolved_ak_id = builder.vec_ref_small(params, args, first_index);
     let resolved_wc = resolved_ak_id;
-
-    // If the index is not used, use a 0 instead to still pass the range constraints from
-    // vec_ref
-    let second_index = ak_key_wc_index;
-    let is_second_index_valid = builder.and(is_ak, is_ak_key_wc);
-    let second_index = builder.select(is_second_index_valid, second_index, zero);
-    let resolved_ak_key = builder.vec_ref_small(params, args, second_index);
-
-    let ak_key = ak_key_lit; // is_ak_key_lit
-    let ak_key = builder.select_flattenable(params, is_ak_key_wc, &resolved_ak_key, &ak_key);
 
     let first = ValueTarget::zero(builder); // is_none
     let first = builder.select_flattenable(params, is_literal, &value_literal, &first);

--- a/src/backends/plonky2/mainpod/mod.rs
+++ b/src/backends/plonky2/mainpod/mod.rs
@@ -1337,6 +1337,58 @@ pub mod tests {
     }
 
     #[test]
+    fn test_record_typed_dot_real_prover() {
+        // Real-prover counterpart to `test_e2e_record_typed_dot_proves_via_mock`
+        // in src/lang/mod.rs. MockProver runs middleware checks only and never
+        // executes the circuit's template verification, so the wildcard-
+        // heuristic issue with integer keys is invisible there. This test
+        // exercises the real circuit and is expected to fail.
+
+        let params = middleware::Params::default();
+        // Record `Inputs` declares two entries: `x` at index 0, `y` at index 1.
+        // The predicate `at_x_is(arr, val)` asserts that `arr.x` (the entry at
+        // index 0 of `arr`) equals `val`. Lowering produces the template
+        // `Equal(AnchoredKey(arr, IndexKey(0)), val)`, which is the shape that
+        // triggers the wildcard-heuristic misfire in the circuit.
+        let module = load_module(
+            r#"
+            record Inputs = (x, y)
+            at_x_is(arr Inputs, val) = AND(
+                Equal(arr.x, val)
+            )
+            "#,
+            "records_dot_real",
+            &params,
+            &[],
+        )
+        .unwrap();
+        let at_x_is = module.batch.predicate_ref_by_name("at_x_is").unwrap();
+
+        // Concrete witness: arr[0] = 7, arr[1] = 13. So `arr.x` is 7.
+        let arr = middleware::containers::Array::new(vec![Value::from(7i64), Value::from(13i64)]);
+
+        let mut vds = DEFAULT_VD_LIST.clone();
+        vds.push(rec_main_pod_circuit_data(&params).1.verifier_only.clone());
+        let vd_set = VDSet::new(&vds);
+
+        let mut builder = MainPodBuilder::new(&params, &vd_set);
+        // Show that arr contains 7 at index 0, then that that value equals 7.
+        let contains_st = builder
+            .priv_op(frontend::Operation::array_contains(arr, 0i64, 7i64))
+            .unwrap();
+        let equal_st = builder
+            .priv_op(frontend::Operation::eq(contains_st, 7i64))
+            .unwrap();
+        // Publicly claim `at_x_is(arr, 7)` via the custom predicate.
+        builder
+            .pub_op(frontend::Operation::custom(at_x_is, [equal_st]))
+            .unwrap();
+        let prover = Prover {};
+        let pod = builder.prove(&prover).unwrap();
+        pod.pod.verify().unwrap();
+    }
+
+    #[test]
     fn test_replace_value_with_entry() {
         let params = middleware::Params::default();
         let vd_set = &*DEFAULT_VD_SET;

--- a/src/middleware/custom.rs
+++ b/src/middleware/custom.rs
@@ -72,10 +72,10 @@ impl From<StatementTmplArgPrefix> for F {
 impl ToFields for StatementTmplArg {
     fn to_fields(&self) -> Vec<F> {
         // Encoding:
-        // None =>                         (0,          0, 0, 0, 0,  0, 0, 0, 0)
-        // Literal(v) =>                   (1,        [v         ],  0, 0, 0, 0)
-        // Key(wc_index, key_or_wc) =>     (2, [wc_index], 0, 0, 0, [key_or_wc])
-        // WildcardLiteral(wc_index) =>    (3, [wc_index], 0, 0, 0,  0, 0, 0, 0)
+        // None =>                          (0,          0, 0, 0, 0,  0, 0, 0, 0)
+        // Literal(v) =>                    (1,        [v         ],  0, 0, 0, 0)
+        // AnchoredKey(wc_index, key) =>    (2, [wc_index], 0, 0, 0, [key      ])
+        // WildcardLiteral(wc_index) =>     (3, [wc_index], 0, 0, 0,  0, 0, 0, 0)
         // SelfPredicateHash(pred_index) => (4, pred_index, 0, 0, 0,  0, 0, 0, 0)
         // In all cases, we pad to 2 * hash_size + 1 = 9 field elements
         match self {
@@ -88,11 +88,11 @@ impl ToFields for StatementTmplArg {
                 .chain(iter::repeat(F::ZERO))
                 .take(Params::statement_tmpl_arg_size())
                 .collect_vec(),
-            StatementTmplArg::AnchoredKey(wc1, kw2) => {
+            StatementTmplArg::AnchoredKey(wc, key) => {
                 iter::once(F::from(StatementTmplArgPrefix::AnchoredKey))
-                    .chain(wc1.to_fields())
+                    .chain(wc.to_fields())
                     .chain(iter::repeat(F::ZERO).take(VALUE_SIZE - 1))
-                    .chain(kw2.to_fields())
+                    .chain(key.to_fields())
                     .collect_vec()
             }
             StatementTmplArg::Wildcard(wc) => {


### PR DESCRIPTION
This PR removes legacy support for wildcard keys, which was interfering with the new integer "index" keys.