### PR TITLE
Make SolvedMultiPod and AbstractDep public

### DIFF
--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -29,7 +29,9 @@ mod pod_request;
 mod serialization;
 pub use custom::*;
 pub use error::*;
-pub use multi_pod::{Error as MultiPodError, MultiPodBuilder, MultiPodResult};
+pub use multi_pod::{
+    AbstractDep, Error as MultiPodError, MultiPodBuilder, MultiPodResult, SolvedMultiPod,
+};
 pub use operation::*;
 pub use pod_request::*;
 


### PR DESCRIPTION
These are necessary for the `pexe inspect` command to be able to inspect more details of what MultiPodBuilder returns.