### PR TITLE
Allow anchored keys in intro statements

### DIFF
--- a/src/backends/plonky2/mainpod/statement.rs
+++ b/src/backends/plonky2/mainpod/statement.rs
@@ -5,8 +5,8 @@ use serde::{Deserialize, Serialize};
 use crate::{
     backends::plonky2::error::{Error, Result},
     middleware::{
-        self, hash_fields, Hash, NativePredicate, Predicate, StatementArg, ToFields, Value,
-        ValueRef, BASE_PARAMS,
+        self, hash_fields, Hash, NativePredicate, Predicate, StatementArg, ToFields, ValueRef,
+        BASE_PARAMS,
     },
 };
 
@@ -116,15 +116,15 @@ impl TryFrom<Statement> for middleware::Statement {
                 S::Custom(cpr, args)
             }
             Predicate::Intro(ir) => {
-                let vs: Vec<Value> = proper_args
+                let args: Vec<ValueRef> = proper_args
                     .into_iter()
                     .filter_map(|arg| match arg {
+                        SA::Literal(v) => Some(ValueRef::Literal(v)),
+                        SA::Key(k) => Some(ValueRef::Key(k)),
                         SA::None => None,
-                        SA::Literal(v) => Some(v),
-                        _ => unreachable!(),
                     })
                     .collect();
-                S::Intro(ir, vs)
+                S::Intro(ir, args)
             }
             Predicate::BatchSelf(_) => {
                 unreachable!()

--- a/src/middleware/error.rs
+++ b/src/middleware/error.rs
@@ -25,8 +25,6 @@ fn display_wc_map(wc_map: &[Option<Value>]) -> String {
 
 #[derive(Debug, thiserror::Error)]
 pub enum MiddlewareInnerError {
-    #[error("incorrect statement args")]
-    IncorrectStatementArgs,
     #[error("invalid deduction: {0:?} ⇏ {1:#}")]
     InvalidDeduction(Operation, Statement),
     #[error("statement argument {0:?} should be a {1}")]
@@ -94,9 +92,6 @@ macro_rules! new {
 }
 use MiddlewareInnerError::*;
 impl Error {
-    pub(crate) fn incorrect_statements_args() -> Self {
-        new!(IncorrectStatementArgs)
-    }
     pub(crate) fn invalid_deduction(op: Operation, st: Statement) -> Self {
         new!(InvalidDeduction(op, st))
     }

--- a/src/middleware/statement.rs
+++ b/src/middleware/statement.rs
@@ -312,7 +312,7 @@ pub enum Statement {
         /*   key    */ ValueRef,
     ),
     Custom(CustomPredicateRef, Vec<ValueRef>),
-    Intro(IntroPredicateRef, Vec<Value>),
+    Intro(IntroPredicateRef, Vec<ValueRef>),
 }
 
 macro_rules! statement_constructor {
@@ -385,7 +385,6 @@ impl Statement {
         }
     }
     pub fn args(&self) -> Vec<StatementArg> {
-        use StatementArg::*;
         match self.clone() {
             Self::None => vec![],
             Self::Equal(ak1, ak2) => vec![ak1.into(), ak2.into()],
@@ -408,7 +407,7 @@ impl Statement {
             }
             Self::ContainerDelete(ak1, ak2, ak3) => vec![ak1.into(), ak2.into(), ak3.into()],
             Self::Custom(_, args) => Vec::from_iter(args.into_iter().map(StatementArg::from)),
-            Self::Intro(_, args) => Vec::from_iter(args.into_iter().map(Literal)),
+            Self::Intro(_, args) => Vec::from_iter(args.into_iter().map(StatementArg::from)),
         }
     }
 
@@ -485,14 +484,11 @@ impl Statement {
                 Self::Custom(cpr, v_args)
             }
             (Intro(ir), _) => {
-                let v_args: Result<Vec<Value>> = args
+                let v_args = args
                     .iter()
-                    .map(|x| match x {
-                        StatementArg::Literal(v) => Ok(v.clone()),
-                        _ => Err(Error::incorrect_statements_args()),
-                    })
-                    .collect();
-                Self::Intro(ir, v_args?)
+                    .map(|x| x.try_into())
+                    .collect::<Result<Vec<ValueRef>>>()?;
+                Self::Intro(ir, v_args)
             }
         };
         Ok(st)


### PR DESCRIPTION
Although anchored keys cannot be used as arguments to intro operations, they can appear in intro *statements* via `ReplaceValueWithEntry`. This PR allows intro statement arguments to be `ValueRef`s, as is the case for custom statements. This makes the `IncorrectStatementArgs` error obsolete, as any statement can have any kind of `StatementArg` at any position.