### PR TITLE
fix ak with key=0 and literal collision

### DIFF
--- a/book/src/backendtypes.md
+++ b/book/src/backendtypes.md
@@ -11,8 +11,10 @@ The backend encoding stores integers in such a way that arithmetic operations (a
 In the case of the Plonky2 backend, an integer $x$ is decomposed as
 $$x = x_0 + x_1 \cdot 2^{32}$$
 with $0 \leq x_0, x_1 < 2^{32}$ and represented as
-$$\texttt{map}\ \iota\ [x_0, x_1, 0, 0],$$
+$$\texttt{map}\ \iota\ [x_0, x_1, 0, -1],$$
 where $\iota:\mathbb{N}\cup\{0\}\rightarrow\texttt{GoldilocksField}$ is the canonical projection.
+
+We use `-1` as a tag in the last limb in order to distinguish the encoding of 0 from an empty value with zeroes.  `-1` in the GoldilocksField has the canonical projection of `18446744069414584320 = 0xffffffff00000000`.
 
 On the backend, a boolean is stored as an integer, either 0 or 1; so logical operations on booleans are also inexpensive.
 

--- a/src/backends/plonky2/circuits/common.rs
+++ b/src/backends/plonky2/circuits/common.rs
@@ -38,7 +38,7 @@ use crate::{
         OperationType, Params, Predicate, PredicateOrWildcard, PredicateOrWildcardPrefix,
         PredicatePrefix, RawValue, StatementArg, StatementTmpl, StatementTmplArg,
         StatementTmplArgPrefix, ToFields, Value, BASE_PARAMS, EMPTY_VALUE, F, HASH_SIZE,
-        STATEMENT_ARG_F_LEN, VALUE_SIZE,
+        STATEMENT_ARG_F_LEN, VALUE_INT_TAG, VALUE_SIZE,
     },
 };
 
@@ -67,10 +67,16 @@ impl From<HashOutTarget> for ValueTarget {
 }
 
 impl ValueTarget {
-    pub fn zero(builder: &mut CircuitBuilder) -> Self {
+    pub fn empty(builder: &mut CircuitBuilder) -> Self {
+        let zero = builder.zero();
         Self {
-            elements: [builder.zero(); VALUE_SIZE],
+            elements: [zero; VALUE_SIZE],
         }
+    }
+
+    pub fn zero(builder: &mut CircuitBuilder) -> Self {
+        let zero = builder.zero();
+        Self::from_int_lo(builder, zero)
     }
 
     pub fn one(builder: &mut CircuitBuilder) -> Self {
@@ -87,8 +93,9 @@ impl ValueTarget {
 
     pub fn from_int_lo(builder: &mut CircuitBuilder, x: Target) -> Self {
         let zero = builder.zero();
+        let int_tag = builder.constant(VALUE_INT_TAG);
         Self {
-            elements: [x, zero, zero, zero],
+            elements: [x, zero, zero, int_tag],
         }
     }
 
@@ -693,10 +700,7 @@ impl CustomPredicateInBatchTarget {
             MerkleClaimAndProofTarget::new_virtual(Params::max_depth_custom_batch_mt(), builder);
         let _true = builder._true();
         builder.connect(_true.target, mtp.existence.target);
-        let zero = builder.constant(F(0));
-        let key = ValueTarget {
-            elements: [index, zero, zero, zero],
-        };
+        let key = ValueTarget::from_int_lo(builder, index);
         builder.connect_values(key, mtp.key);
         let id = mtp.root;
 
@@ -1571,11 +1575,10 @@ impl CircuitBuilderPod<F, D> for CircuitBuilder {
     }
 
     fn assert_i64(&mut self, x: ValueTarget) {
-        // `x` should only have two limbs.
-        x.elements
-            .into_iter()
-            .skip(2)
-            .for_each(|l| self.assert_zero(l));
+        let zero = self.zero();
+        let int_tag = self.constant(VALUE_INT_TAG);
+        self.connect(x.elements[2], zero);
+        self.connect(x.elements[3], int_tag);
 
         // 32-bit range check.
         self.range_check(x.elements[0], NUM_BITS);
@@ -1622,6 +1625,7 @@ impl CircuitBuilderPod<F, D> for CircuitBuilder {
 
     fn i64_wrapping_add(&mut self, x: ValueTarget, y: ValueTarget) -> ValueTarget {
         let zero = self.zero();
+        let int_tag = self.constant(VALUE_INT_TAG);
 
         // Add components and carry where appropriate.
         let (_, sum) = std::iter::zip(&x.elements[..2], &y.elements[..2]).fold(
@@ -1636,7 +1640,7 @@ impl CircuitBuilderPod<F, D> for CircuitBuilder {
             },
         );
 
-        ValueTarget::from_slice(&[sum[0], sum[1], zero, zero])
+        ValueTarget::from_slice(&[sum[0], sum[1], zero, int_tag])
     }
 
     fn i64_add(&mut self, x: ValueTarget, y: ValueTarget) -> ValueTarget {
@@ -1666,6 +1670,7 @@ impl CircuitBuilderPod<F, D> for CircuitBuilder {
 
     fn i64_mul(&mut self, x: ValueTarget, y: ValueTarget) -> ValueTarget {
         let zero = self.zero();
+        let int_tag = self.constant(VALUE_INT_TAG);
         let i64_min = ValueTarget::from_slice(&self.constants(&RawValue::from(i64::MIN).0));
         let (abs_x, x_is_negative) = self.i64_abs(x);
         let (abs_y, y_is_negative) = self.i64_abs(y);
@@ -1695,7 +1700,7 @@ impl CircuitBuilderPod<F, D> for CircuitBuilder {
             self.split_low_high(sum2, NUM_BITS, F::BITS)
         };
 
-        let abs_prod = ValueTarget::from_slice(&[prod_lower, prod_upper, zero, zero]);
+        let abs_prod = ValueTarget::from_slice(&[prod_lower, prod_upper, zero, int_tag]);
 
         // Overflow check: The latter two products in `prods` should
         // have zero higher-order coefficients.

--- a/src/backends/plonky2/circuits/mainpod/mod.rs
+++ b/src/backends/plonky2/circuits/mainpod/mod.rs
@@ -1535,12 +1535,12 @@ fn make_statement_arg_from_template_circuit(
     let resolved_ak_id = builder.vec_ref_small(params, args, first_index);
     let resolved_wc = resolved_ak_id;
 
-    let first = ValueTarget::zero(builder); // is_none
+    let first = ValueTarget::empty(builder); // is_none
     let first = builder.select_flattenable(params, is_literal, &value_literal, &first);
     let first = builder.select_flattenable(params, is_ak, &resolved_ak_id, &first);
     let first = builder.select_flattenable(params, is_wc_literal, &resolved_wc, &first);
 
-    let second = ValueTarget::zero(builder); // is_none or is_literal or is_wc_literal
+    let second = ValueTarget::empty(builder); // is_none or is_literal or is_wc_literal
     let second = builder.select_flattenable(params, is_ak, &ak_key, &second);
 
     StatementArgTarget::new(first, second)
@@ -1610,7 +1610,7 @@ fn make_custom_statement_circuit(
 
     // Build the statement
     let st_predicate = PredicateTarget::new_custom(builder, batch_id, index);
-    let arg_none = ValueTarget::zero(builder);
+    let arg_none = ValueTarget::empty(builder);
     let lt_mask = builder.lt_mask(
         Params::max_statement_args(),
         custom_predicate.predicate.args_len,

--- a/src/backends/plonky2/circuits/mainpod/tests.rs
+++ b/src/backends/plonky2/circuits/mainpod/tests.rs
@@ -1360,10 +1360,7 @@ fn test_custom_operation_verify_gadget_positive() -> frontend::Result<()> {
         Statement::equal(AnchoredKey::new(dict, Key::from("key")), Value::from(1234)),
     ];
     let args = vec![Value::from(dict), Value::from(1234)];
-    let expected_st = Statement::Custom(
-        custom_predicate.clone(),
-        vec![value_ref(args[0].clone()), value_ref(0)],
-    );
+    let expected_st = Statement::Custom(custom_predicate.clone(), vec![value_ref(args[0].clone())]);
 
     helper_custom_operation_verify_gadget(
         &params,
@@ -1381,10 +1378,7 @@ fn test_custom_operation_verify_gadget_positive() -> frontend::Result<()> {
         Statement::None,
     ];
     let args = vec![Value::from(dict), Value::from(0)];
-    let expected_st = Statement::Custom(
-        custom_predicate.clone(),
-        vec![value_ref(args[0].clone()), value_ref(0)],
-    );
+    let expected_st = Statement::Custom(custom_predicate.clone(), vec![value_ref(args[0].clone())]);
 
     helper_custom_operation_verify_gadget(
         &params,
@@ -1402,10 +1396,7 @@ fn test_custom_operation_verify_gadget_positive() -> frontend::Result<()> {
         Statement::equal(AnchoredKey::new(dict, Key::from("key")), Value::from(1234)),
     ];
     let args = vec![Value::from(dict), Value::from(1234)];
-    let expected_st = Statement::Custom(
-        custom_predicate.clone(),
-        vec![value_ref(args[0].clone()), value_ref(0)],
-    );
+    let expected_st = Statement::Custom(custom_predicate.clone(), vec![value_ref(args[0].clone())]);
 
     helper_custom_operation_verify_gadget(
         &params,
@@ -1454,10 +1445,7 @@ fn test_custom_operation_verify_gadget_negative() -> frontend::Result<()> {
         ),
     ];
     let args = vec![Value::from(dict), Value::from(secret_dict)];
-    let expected_st = Statement::Custom(
-        custom_predicate.clone(),
-        vec![value_ref(args[0].clone()), value_ref(0)],
-    );
+    let expected_st = Statement::Custom(custom_predicate.clone(), vec![value_ref(args[0].clone())]);
 
     helper_custom_operation_verify_gadget(
         &params,

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -216,7 +216,7 @@ mod tests {
     fn test_e2e_simple_request() -> Result<(), LangError> {
         let input = r#"
             REQUEST(
-                Equal(ConstPod["my_val"], Raw(0x0000000000000000000000000000000000000000000000000000000000000001))
+                Equal(ConstPod["my_val"], Raw(0xffffffff00000000000000000000000000000000000000000000000000000001))
                 Lt(GovPod["dob"], ConstPod["my_val"])
             )
         "#;

--- a/src/middleware/basetypes.rs
+++ b/src/middleware/basetypes.rs
@@ -105,11 +105,13 @@ impl PartialOrd for RawValue {
     }
 }
 
+pub const VALUE_INT_TAG: F = F::NEG_ONE;
+
 impl From<i64> for RawValue {
     fn from(v: i64) -> Self {
         let lo = F::from_canonical_u64((v as u64) & 0xffffffff);
         let hi = F::from_canonical_u64((v as u64) >> 32);
-        RawValue([lo, hi, F::ZERO, F::ZERO])
+        RawValue([lo, hi, F::ZERO, VALUE_INT_TAG])
     }
 }
 

--- a/src/middleware/statement.rs
+++ b/src/middleware/statement.rs
@@ -642,3 +642,22 @@ where
         Self::Literal(value.into())
     }
 }
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    #[test]
+    fn test_statement_arg_no_collision() {
+        let none = StatementArg::None;
+        let zero = StatementArg::Literal(0.into());
+        // [0, 0, 0, 0, 0, 0, 0, 0] != [0, 0, 0, VALUE_INT_TAG, 0, 0, 0, 0]
+        assert_ne!(none.to_fields(), zero.to_fields());
+
+        let root = Hash([F(1), F(2), F(3), F(4)]);
+        let one = StatementArg::Literal(root.into());
+        let ak = StatementArg::Key((root, 0i64).into());
+        // [1, 2, 3, 4, 0, 0, 0, 0] != [1, 2, 3, 4, 0, 0, 0, VALUE_INT_TAG]
+        assert_ne!(one.to_fields(), ak.to_fields());
+    }
+}


### PR DESCRIPTION
Change the encoding of integers as Value to include a non-zero tag value a the highest limb (previously 0) so that it doesn't collide with the empty value.  This fixes the collision between `StatementArg::Literal(x)` and `StatementArg::Key((x, 0))`

Resolve #513 