### PR TITLE
Add tagging to discriminate between container serialized forms

### DIFF
--- a/src/frontend/serialization.rs
+++ b/src/frontend/serialization.rs
@@ -87,7 +87,7 @@ mod tests {
             (Value::from(true), r#"{"Int":"1"}"#),
             (
                 Value::from(Array::new(vec![Value::from("foo"), Value::from(false)])),
-                r#"{"inner":[[{"Int":"0"},"foo"],[{"Int":"1"},{"Int":"0"}]]}"#,
+                r#"{"Array":[[{"Int":"0"},"foo"],[{"Int":"1"},{"Int":"0"}]]}"#,
             ),
             (
                 Value::from(Dictionary::new(HashMap::from([
@@ -104,11 +104,11 @@ mod tests {
                     // Keys can contain emojis
                     (("🥳".into()), "party time!".into()),
                 ]))),
-                r#"{"inner":[["!@£$%^&&*()",""],["🥳","party time!"],["    hi",{"Int":"0"}],["foo",{"Int":"123"}],["\u0000",""],["","baz"]]}"#,
+                r#"{"Dictionary":[["!@£$%^&&*()",""],["🥳","party time!"],["    hi",{"Int":"0"}],["foo",{"Int":"123"}],["\u0000",""],["","baz"]]}"#,
             ),
             (
                 Value::from(Set::new(HashSet::from(["foo".into(), "bar".into()]))),
-                r#"{"inner":[["bar"],["foo"]]}"#,
+                r#"{"Set":[["bar"],["foo"]]}"#,
             ),
         ];
 

--- a/src/middleware/containers.rs
+++ b/src/middleware/containers.rs
@@ -111,6 +111,57 @@ impl<'de> Deserialize<'de> for Container {
     }
 }
 
+// Enforce the same rules about key types and key-value relationships that
+// are enforced by Dictionary/Set/Array constructors.
+
+impl<'de> Deserialize<'de> for Set {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let inner = Container::deserialize(deserializer)?;
+        for kv in inner.iter() {
+            let (key, value) = kv.map_err(D::Error::custom)?;
+            if key != value {
+                return Err(D::Error::custom("not a set: entry key != value"));
+            }
+        }
+        Ok(Set { inner })
+    }
+}
+
+impl<'de> Deserialize<'de> for Dictionary {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let inner = Container::deserialize(deserializer)?;
+        for kv in inner.iter() {
+            let (key, _) = kv.map_err(D::Error::custom)?;
+            if !matches!(&key.typed, TypedValue::String(_)) {
+                return Err(D::Error::custom("not a dictionary: non-string key"));
+            }
+        }
+        Ok(Dictionary { inner })
+    }
+}
+
+impl<'de> Deserialize<'de> for Array {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let inner = Container::deserialize(deserializer)?;
+        for kv in inner.iter() {
+            let (key, _) = kv.map_err(D::Error::custom)?;
+            if !matches!(&key.typed, TypedValue::Int(i) if *i >= 0) {
+                return Err(D::Error::custom("not an array: non-index key"));
+            }
+        }
+        Ok(Array { inner })
+    }
+}
+
 impl PartialEq for Container {
     fn eq(&self, other: &Self) -> bool {
         self.root == other.root
@@ -254,7 +305,8 @@ impl Container {
 /// Dictionary: the user original keys and values are hashed to be used in the leaf.
 ///    leaf.key=hash(original_key)
 ///    leaf.value=hash(original_value)
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, JsonSchema)]
+#[serde(transparent)]
 pub struct Dictionary {
     pub(crate) inner: Container,
 }
@@ -361,7 +413,8 @@ impl Eq for Dictionary {}
 /// Set: the value field of the leaf is unused, and the key contains the hash of the element.
 ///    leaf.key=hash(original_value)
 ///    leaf.value=0
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, JsonSchema)]
+#[serde(transparent)]
 pub struct Set {
     pub(crate) inner: Container,
 }
@@ -440,7 +493,8 @@ impl Eq for Set {}
 ///    leaf.value=original_value
 /// Due to its construction this should be seen as a sparse array, where there can be gaps
 /// (unused indices).
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, JsonSchema)]
+#[serde(transparent)]
 pub struct Array {
     pub(crate) inner: Container,
 }
@@ -520,6 +574,64 @@ impl Eq for Array {}
 mod tests {
     use super::*;
     use crate::middleware::db::mem::MemDB;
+
+    #[test]
+    fn value_serde_round_trip_preserves_container_kind() {
+        let dict = Value::from(Dictionary::new(
+            [(StrKey::from("score"), Value::from(42))].into(),
+        ));
+        let array = Value::from(Array::new(vec![Value::from(10), Value::from("x")]));
+        let set = Value::from(Set::new(HashSet::from([Value::from(7)])));
+        let nested = Value::from(Dictionary::new(
+            [(
+                StrKey::from("items"),
+                Value::from(Array::new(vec![Value::from(1)])),
+            )]
+            .into(),
+        ));
+        let empty_dict = Value::from(Dictionary::new([].into()));
+        let empty_array = Value::from(Array::new(vec![]));
+        // Sets always have identical keys and values, so this example is
+        // used to check that a dict which happens to have key=value is not
+        // mistakenly interpreted as a set.
+        let self_keyed_dict = Value::from(Dictionary::new(
+            [(StrKey::from("a"), Value::from("a"))].into(),
+        ));
+        let identity_array = Value::from(Array::new(vec![Value::from(0), Value::from(1)]));
+
+        for value in [
+            dict,
+            array,
+            set,
+            nested,
+            empty_dict,
+            empty_array,
+            self_keyed_dict,
+            identity_array,
+        ] {
+            let json = serde_json::to_string(&value).unwrap();
+            let back: Value = serde_json::from_str(&json).unwrap();
+            assert_eq!(back.raw(), value.raw(), "raw mismatch for {value}");
+            assert_eq!(
+                std::mem::discriminant(&back.typed),
+                std::mem::discriminant(&value.typed),
+                "kind mismatch: {value} came back as {back}"
+            );
+        }
+    }
+
+    /// A tagged container claiming a kind its contents violate must be
+    /// rejected rather than constructed.
+    #[test]
+    fn mistagged_container_is_rejected() {
+        // Dictionary content under a Set tag: entries have key != value.
+        let dict = Value::from(Dictionary::new(
+            [(StrKey::from("score"), Value::from(42))].into(),
+        ));
+        let json = serde_json::to_string(&dict).unwrap();
+        let mistagged = json.replacen("Dictionary", "Set", 1);
+        assert!(serde_json::from_str::<Value>(&mistagged).is_err());
+    }
 
     fn test_databases(test_fn: &dyn Fn(Box<dyn DB>)) {
         let db = MemDB::new();

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -38,9 +38,8 @@ pub(crate) enum TypedValue {
     // Variants without "untagged" will be serialized as "tagged" values by
     // default, meaning that a Set appears in JSON as {"Set":[...]}
     // and not as [...]
-    // Arrays, Strings and Booleans are untagged, as there is a natural JSON
-    // representation for them that is unambiguous to deserialize and is fully
-    // compatible with the semantics of the POD types.
+    // Strings are untagged, as there is a natural JSON representation that
+    // is unambiguous to deserialize.
     // As JSON integers do not specify precision, and JavaScript is limited to
     // 53-bit precision for integers, integers are represented as tagged
     // strings, with a custom serializer and deserializer.
@@ -58,13 +57,13 @@ pub(crate) enum TypedValue {
     SecretKey(SecretKey),
     // Predicate as a value
     Predicate(Predicate),
-    // UNTAGGED TYPES:
-    #[serde(untagged)]
+    // Containers are tagged ({"Set": [...]}, {"Dictionary": [...]},
+    // {"Array": [...]}): all three serialize identically, so a tag is need to
+    // discriminate.
     Set(Set),
-    #[serde(untagged)]
     Dictionary(Dictionary),
-    #[serde(untagged)]
     Array(Array),
+    // UNTAGGED TYPES:
     #[serde(untagged)]
     String(String),
 }
@@ -320,12 +319,22 @@ impl JsonSchema for TypedValue {
             ..Default::default()
         };
 
-        // This is the part that Schemars can't generate automatically:
-        let untagged_array_schema = gen.subschema_for::<Array>();
-        let untagged_set_schema = gen.subschema_for::<Set>();
-        let untagged_dictionary_schema = gen.subschema_for::<Dictionary>();
+        let tagged = |tag: &str, inner: Schema| {
+            Schema::Object(SchemaObject {
+                instance_type: Some(SingleOrVec::Single(Box::new(InstanceType::Object))),
+                object: Some(Box::new(schemars::schema::ObjectValidation {
+                    properties: [(tag.to_string(), inner)].into_iter().collect(),
+                    required: [tag.to_string()].into_iter().collect(),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            })
+        };
+        let set_schema = tagged("Set", gen.subschema_for::<Set>());
+        let dictionary_schema = tagged("Dictionary", gen.subschema_for::<Dictionary>());
+        let array_schema = tagged("Array", gen.subschema_for::<Array>());
+
         let untagged_string_schema = gen.subschema_for::<String>();
-        let untagged_bool_schema = gen.subschema_for::<bool>();
 
         Schema::Object(SchemaObject {
             subschemas: Some(Box::new(schemars::schema::SubschemaValidation {
@@ -335,16 +344,15 @@ impl JsonSchema for TypedValue {
                     Schema::Object(raw_schema),
                     Schema::Object(public_key_schema),
                     Schema::Object(secret_key_schema),
-                    untagged_array_schema,
-                    untagged_dictionary_schema,
+                    set_schema,
+                    dictionary_schema,
+                    array_schema,
                     untagged_string_schema,
-                    untagged_set_schema,
-                    untagged_bool_schema,
                 ]),
                 ..Default::default()
             })),
             metadata: Some(Box::new(schemars::schema::Metadata {
-                description: Some("Represents various POD value types. Array, String, and Bool variants are represented untagged in JSON.".to_string()),
+                description: Some("Represents various POD value types. Containers (Set, Dictionary, Array) are externally tagged; String is untagged.".to_string()),
                 ..Default::default()
             })),
             ..Default::default()


### PR DESCRIPTION
Prior to #493, container types were specified as untagged variants of `TypedValue`. This worked because they could be disambiguated by their internal structure, with separate struct fields (`kvs`, `set` and `array`) in dictionary, set and array respectively.

In #493 the internal structure changed so that each has an `inner` field of type `Container`. This means that serde cannot disambiguate the type using the shape of the serialized object. As a result, containers may be deserialized incorrectly (e.g. a set as a dictionary). This is not picked up by tests because operations on the containers don't care about the Rust-level wrapper type.

This PR restores tagged variants, and adds a custom deserialize function for each container, ensuring that the same invariants applied during construction are applied during deserialization (e.g. dictionary keys must be strings, set entries must have identical keys and values).