### PR TITLE
Add ContainerKind

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ good_lp = { version = "1.8", default-features = false, features = [
 vergen-gitcl = { version = "1.0.0", features = ["build"] }
 
 [features]
-default = ["backend_plonky2", "zk", "mem_cache", "db_rocksdb"]
+default = ["backend_plonky2", "zk", "mem_cache"]
 backend_plonky2 = ["plonky2"]
 zk = []
 metrics = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ good_lp = { version = "1.8", default-features = false, features = [
 vergen-gitcl = { version = "1.0.0", features = ["build"] }
 
 [features]
-default = ["backend_plonky2", "zk", "mem_cache"]
+default = ["backend_plonky2", "zk", "mem_cache", "db_rocksdb"]
 backend_plonky2 = ["plonky2"]
 zk = []
 metrics = []

--- a/src/backends/plonky2/primitives/merkletree/circuit.rs
+++ b/src/backends/plonky2/primitives/merkletree/circuit.rs
@@ -676,7 +676,7 @@ pub mod tests {
     use crate::{
         backends::plonky2::{
             basetypes::C,
-            primitives::merkletree::{keypath, kv_hash, MerkleProof, MerkleTree},
+            primitives::merkletree::{self, keypath, kv_hash, MerkleProof, MerkleTree},
         },
         middleware::{hash_value, RawValue},
     };
@@ -796,9 +796,9 @@ pub mod tests {
         assert_eq!(proof.existence, existence);
 
         if existence {
-            MerkleTree::verify(tree.root(), &proof, &key, &value)?;
+            merkletree::verify(tree.root(), &proof, &key, &value)?;
         } else {
-            MerkleTree::verify_nonexistence(tree.root(), &proof, &key)?;
+            merkletree::verify_nonexistence(tree.root(), &proof, &key)?;
         }
 
         // circuit
@@ -881,7 +881,7 @@ pub mod tests {
         assert_eq!(value, RawValue::from(5));
         assert!(proof.existence);
 
-        MerkleTree::verify(tree.root(), &proof, &key, &value)?;
+        merkletree::verify(tree.root(), &proof, &key, &value)?;
 
         // circuit
         let config = CircuitConfig::standard_recursion_config();
@@ -953,9 +953,9 @@ pub mod tests {
 
         // verify the proof (non circuit)
         if proof.existence {
-            MerkleTree::verify(tree.root(), &proof, &key, &value)?;
+            merkletree::verify(tree.root(), &proof, &key, &value)?;
         } else {
-            MerkleTree::verify_nonexistence(tree.root(), &proof, &key)?;
+            merkletree::verify_nonexistence(tree.root(), &proof, &key)?;
         }
 
         // circuit
@@ -995,9 +995,9 @@ pub mod tests {
         kvs.insert(RawValue::from(100), RawValue::from(100));
         let tree2 = MerkleTree::new(&kvs);
 
-        MerkleTree::verify(tree.root(), &proof, &key, &value)?;
+        merkletree::verify(tree.root(), &proof, &key, &value)?;
         assert_eq!(
-            MerkleTree::verify(tree2.root(), &proof, &key, &value)
+            merkletree::verify(tree2.root(), &proof, &key, &value)
                 .unwrap_err()
                 .inner()
                 .unwrap()
@@ -1031,10 +1031,10 @@ pub mod tests {
     ) -> Result<()> {
         // sanity check, run the out-circuit proof verification
         if expect_pass {
-            MerkleTree::verify_state_transition(state_transition_proof)?;
+            merkletree::verify_state_transition(state_transition_proof)?;
         } else {
             // expect out-circuit verification to fail
-            let _ = MerkleTree::verify_state_transition(state_transition_proof).is_err();
+            let _ = merkletree::verify_state_transition(state_transition_proof).is_err();
         }
 
         let config = CircuitConfig::standard_recursion_config();
@@ -1261,7 +1261,7 @@ pub mod tests {
         )
         .unwrap();
 
-        MerkleTree::verify_state_transition(&mtp0).unwrap();
+        merkletree::verify_state_transition(&mtp0).unwrap();
 
         let mut mt = MerkleTree::new(&HashMap::new());
         let v =

--- a/src/backends/plonky2/primitives/merkletree/db/mod.rs
+++ b/src/backends/plonky2/primitives/merkletree/db/mod.rs
@@ -3,7 +3,7 @@
 use std::{
     collections::HashMap,
     fmt::Debug,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, MutexGuard},
 };
 
 use anyhow::{anyhow, Result};
@@ -46,10 +46,7 @@ impl MemDB {
 
 impl Read for MemDB {
     fn load_node(&self, hash: Hash) -> Result<Option<Node>> {
-        let db = self
-            .inner
-            .lock()
-            .map_err(|e| anyhow!("failed to acquire memdb lock for read: {}", e))?;
+        let db = self.inner.lock().expect("not poisoned");
 
         if hash == EMPTY_HASH {
             return Ok(Some(Node::Intermediate(Intermediate::new(
@@ -62,16 +59,35 @@ impl Read for MemDB {
 
 impl DB for MemDB {
     fn tx<'a>(&'a self) -> Box<dyn TX + 'a> {
-        todo!()
+        Box::new(MemTx {
+            db: self.inner.lock().expect("not poisoned"),
+            tmp: HashMap::new(),
+        })
     }
-    // fn store_node(&mut self, node: Node) -> Result<()> {
-    //     let mut db = self
-    //         .inner
-    //         .lock()
-    //         .map_err(|e| anyhow!("failed to acquire memdb lock for write: {}", e))?;
-    //     db.insert(node.hash(), node);
-    //     Ok(())
-    // }
+}
+
+pub(crate) struct MemTx<'a> {
+    db: MutexGuard<'a, HashMap<Hash, Node>>,
+    tmp: HashMap<Hash, Node>,
+}
+
+impl<'a> Read for MemTx<'a> {
+    fn load_node(&self, hash: Hash) -> Result<Option<Node>> {
+        Ok(self.tmp.get(&hash).or_else(|| self.db.get(&hash)).cloned())
+    }
+}
+
+impl<'a> TX for MemTx<'a> {
+    fn store_node(&mut self, node: Node) -> Result<()> {
+        self.tmp.insert(node.hash(), node);
+        Ok(())
+    }
+    fn commit(mut self: Box<Self>) -> Result<()> {
+        for (k, v) in self.tmp {
+            self.db.insert(k, v);
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/backends/plonky2/primitives/merkletree/db/mod.rs
+++ b/src/backends/plonky2/primitives/merkletree/db/mod.rs
@@ -6,7 +6,7 @@ use std::{
     sync::{Arc, Mutex, MutexGuard},
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use dyn_clone::DynClone;
 
 use crate::{

--- a/src/backends/plonky2/primitives/merkletree/db/mod.rs
+++ b/src/backends/plonky2/primitives/merkletree/db/mod.rs
@@ -17,10 +17,18 @@ use crate::{
 #[cfg(feature = "db_rocksdb")]
 pub mod rocks;
 
-pub trait DB: Debug + DynClone + Sync + Send {
+pub trait Read {
     /// Must always return the empty intermediate node when hash is EMPTY_HASH
     fn load_node(&self, hash: Hash) -> Result<Option<Node>>;
+}
+
+pub trait TX: Read {
     fn store_node(&mut self, node: Node) -> Result<()>;
+    fn commit(self: Box<Self>) -> Result<()>;
+}
+
+pub trait DB: Debug + DynClone + Sync + Send + Read {
+    fn tx<'a>(&'a self) -> Box<dyn TX + 'a>;
 }
 dyn_clone::clone_trait_object!(DB);
 
@@ -36,7 +44,7 @@ impl MemDB {
     }
 }
 
-impl DB for MemDB {
+impl Read for MemDB {
     fn load_node(&self, hash: Hash) -> Result<Option<Node>> {
         let db = self
             .inner
@@ -50,15 +58,20 @@ impl DB for MemDB {
         }
         Ok(db.get(&hash).cloned())
     }
+}
 
-    fn store_node(&mut self, node: Node) -> Result<()> {
-        let mut db = self
-            .inner
-            .lock()
-            .map_err(|e| anyhow!("failed to acquire memdb lock for write: {}", e))?;
-        db.insert(node.hash(), node);
-        Ok(())
+impl DB for MemDB {
+    fn tx<'a>(&'a self) -> Box<dyn TX + 'a> {
+        todo!()
     }
+    // fn store_node(&mut self, node: Node) -> Result<()> {
+    //     let mut db = self
+    //         .inner
+    //         .lock()
+    //         .map_err(|e| anyhow!("failed to acquire memdb lock for write: {}", e))?;
+    //     db.insert(node.hash(), node);
+    //     Ok(())
+    // }
 }
 
 #[cfg(test)]
@@ -83,7 +96,9 @@ pub mod tests {
 
     fn test_db_opt(db: &mut dyn DB) -> Result<()> {
         let node = Leaf::new(1.into(), 1.into());
-        db.store_node(Node::Leaf(node.clone()))?;
+        let mut tx = db.tx();
+        tx.store_node(Node::Leaf(node.clone()))?;
+        tx.commit().unwrap();
 
         let obtained_node = db.load_node(node.hash)?.unwrap();
         let leaf = match obtained_node {

--- a/src/backends/plonky2/primitives/merkletree/db/rocks.rs
+++ b/src/backends/plonky2/primitives/merkletree/db/rocks.rs
@@ -1,7 +1,7 @@
 use std::{fmt, path::Path, sync::Arc};
 
 use anyhow::{anyhow, Result};
-use rocksdb::{Options, TransactionDB, TransactionDBOptions};
+use rocksdb::{Options, Transaction, TransactionDB, TransactionDBOptions};
 
 use crate::{
     backends::plonky2::primitives::merkletree::{self, db},
@@ -9,7 +9,7 @@ use crate::{
 };
 
 #[derive(Clone)]
-pub struct RocksDB(Arc<TransactionDB>);
+pub struct RocksDB(pub(crate) Arc<TransactionDB>);
 
 #[allow(dead_code)]
 impl RocksDB {
@@ -25,37 +25,80 @@ impl RocksDB {
 
 impl fmt::Debug for RocksDB {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "RocksDB")
+        writeln!(f, "RocksDB(path: {:?})", self.0.path())
+    }
+}
+
+pub(crate) fn load_node_db(db: &TransactionDB, hash: Hash) -> Result<Option<merkletree::Node>> {
+    if hash == EMPTY_HASH {
+        return Ok(Some(merkletree::Node::Intermediate(
+            merkletree::Intermediate::new(EMPTY_HASH, EMPTY_HASH),
+        )));
+    }
+
+    match db
+        .get(RawValue::from(hash).to_bytes())
+        .map_err(|e| anyhow!("rocksdb: get failed: {e}"))?
+    {
+        None => Ok(None),
+        Some(bytes) => Ok(Some(merkletree::Node::decode(bytes.as_ref())?)),
     }
 }
 
 impl db::Read for RocksDB {
     fn load_node(&self, hash: Hash) -> Result<Option<merkletree::Node>> {
-        if hash == EMPTY_HASH {
-            return Ok(Some(merkletree::Node::Intermediate(
-                merkletree::Intermediate::new(EMPTY_HASH, EMPTY_HASH),
-            )));
-        }
-
-        match self
-            .0
-            .get(RawValue::from(hash).to_bytes())
-            .map_err(|e| anyhow!("rocksdb: get failed: {e}"))?
-        {
-            None => Ok(None),
-            Some(bytes) => Ok(Some(merkletree::Node::decode(bytes.as_ref())?)),
-        }
+        load_node_db(&self.db, hash)
     }
 }
 
 impl db::DB for RocksDB {
     fn tx<'a>(&'a self) -> Box<dyn db::TX + 'a> {
-        todo!()
+        Box::new(RocksTx(self.0.transaction()))
+    }
+}
+
+pub(crate) struct RocksTx<'a>(pub(crate) Transaction<'a, TransactionDB>);
+
+pub(crate) fn load_node_tx<'a>(
+    tx: &Transaction<'a, TransactionDB>,
+    hash: Hash,
+) -> Result<Option<merkletree::Node>> {
+    if hash == EMPTY_HASH {
+        return Ok(Some(merkletree::Node::Intermediate(
+            merkletree::Intermediate::new(EMPTY_HASH, EMPTY_HASH),
+        )));
     }
 
-    // fn store_node(&mut self, node: merkletree::Node) -> Result<()> {
-    //     self.0
-    //         .put(RawValue::from(node.hash()).to_bytes(), node.encode()?)
-    //         .map_err(|e| anyhow!("rocksdb transaction put failed: {e}"))
-    // }
+    match tx
+        .get(RawValue::from(hash).to_bytes())
+        .map_err(|e| anyhow!("rocksdb: get failed: {e}"))?
+    {
+        None => Ok(None),
+        Some(bytes) => Ok(Some(merkletree::Node::decode(bytes.as_ref())?)),
+    }
+}
+
+impl<'a> db::Read for RocksTx<'a> {
+    fn load_node(&self, hash: Hash) -> Result<Option<merkletree::Node>> {
+        load_node_tx(&self.0, hash)
+    }
+}
+
+pub(crate) fn store_node_tx(
+    tx: &Transaction<'a, TransactionDB>,
+    node: merkletree::Node,
+) -> Result<()> {
+    tx.put(RawValue::from(node.hash()).to_bytes(), node.encode()?)
+        .map_err(|e| anyhow!("rocksdb transaction put failed: {e}"))
+}
+
+impl<'a> db::TX for RocksTx<'a> {
+    fn store_node(&mut self, node: merkletree::Node) -> Result<()> {
+        store_node_tx(&self.tx, node)
+    }
+    fn commit(self: Box<Self>) -> Result<()> {
+        self.0
+            .commit()
+            .map_err(|e| anyhow!("rocksdb commit error: {e}"))
+    }
 }

--- a/src/backends/plonky2/primitives/merkletree/db/rocks.rs
+++ b/src/backends/plonky2/primitives/merkletree/db/rocks.rs
@@ -29,7 +29,7 @@ impl fmt::Debug for RocksDB {
     }
 }
 
-impl db::DB for RocksDB {
+impl db::Read for RocksDB {
     fn load_node(&self, hash: Hash) -> Result<Option<merkletree::Node>> {
         if hash == EMPTY_HASH {
             return Ok(Some(merkletree::Node::Intermediate(
@@ -46,10 +46,16 @@ impl db::DB for RocksDB {
             Some(bytes) => Ok(Some(merkletree::Node::decode(bytes.as_ref())?)),
         }
     }
+}
 
-    fn store_node(&mut self, node: merkletree::Node) -> Result<()> {
-        self.0
-            .put(RawValue::from(node.hash()).to_bytes(), node.encode()?)
-            .map_err(|e| anyhow!("rocksdb transaction put failed: {e}"))
+impl db::DB for RocksDB {
+    fn tx<'a>(&'a self) -> Box<dyn db::TX + 'a> {
+        todo!()
     }
+
+    // fn store_node(&mut self, node: merkletree::Node) -> Result<()> {
+    //     self.0
+    //         .put(RawValue::from(node.hash()).to_bytes(), node.encode()?)
+    //         .map_err(|e| anyhow!("rocksdb transaction put failed: {e}"))
+    // }
 }

--- a/src/backends/plonky2/primitives/merkletree/db/rocks.rs
+++ b/src/backends/plonky2/primitives/merkletree/db/rocks.rs
@@ -1,7 +1,7 @@
 use std::{fmt, path::Path, sync::Arc};
 
 use anyhow::{anyhow, Result};
-use rocksdb::{Options, Transaction, TransactionDB, TransactionDBOptions};
+use rocksdb::{DBAccess, Options, ReadOptions, Transaction, TransactionDB, TransactionDBOptions};
 
 use crate::{
     backends::plonky2::primitives::merkletree::{self, db},
@@ -29,7 +29,7 @@ impl fmt::Debug for RocksDB {
     }
 }
 
-pub(crate) fn load_node_db(db: &TransactionDB, hash: Hash) -> Result<Option<merkletree::Node>> {
+fn load_node_db(db: &impl DBAccess, hash: Hash) -> Result<Option<merkletree::Node>> {
     if hash == EMPTY_HASH {
         return Ok(Some(merkletree::Node::Intermediate(
             merkletree::Intermediate::new(EMPTY_HASH, EMPTY_HASH),
@@ -37,7 +37,7 @@ pub(crate) fn load_node_db(db: &TransactionDB, hash: Hash) -> Result<Option<merk
     }
 
     match db
-        .get(RawValue::from(hash).to_bytes())
+        .get_opt(RawValue::from(hash).to_bytes(), &ReadOptions::default())
         .map_err(|e| anyhow!("rocksdb: get failed: {e}"))?
     {
         None => Ok(None),
@@ -47,7 +47,7 @@ pub(crate) fn load_node_db(db: &TransactionDB, hash: Hash) -> Result<Option<merk
 
 impl db::Read for RocksDB {
     fn load_node(&self, hash: Hash) -> Result<Option<merkletree::Node>> {
-        load_node_db(&self.db, hash)
+        load_node_db(&*self.0, hash)
     }
 }
 
@@ -59,32 +59,13 @@ impl db::DB for RocksDB {
 
 pub(crate) struct RocksTx<'a>(pub(crate) Transaction<'a, TransactionDB>);
 
-pub(crate) fn load_node_tx<'a>(
-    tx: &Transaction<'a, TransactionDB>,
-    hash: Hash,
-) -> Result<Option<merkletree::Node>> {
-    if hash == EMPTY_HASH {
-        return Ok(Some(merkletree::Node::Intermediate(
-            merkletree::Intermediate::new(EMPTY_HASH, EMPTY_HASH),
-        )));
-    }
-
-    match tx
-        .get(RawValue::from(hash).to_bytes())
-        .map_err(|e| anyhow!("rocksdb: get failed: {e}"))?
-    {
-        None => Ok(None),
-        Some(bytes) => Ok(Some(merkletree::Node::decode(bytes.as_ref())?)),
-    }
-}
-
 impl<'a> db::Read for RocksTx<'a> {
     fn load_node(&self, hash: Hash) -> Result<Option<merkletree::Node>> {
-        load_node_tx(&self.0, hash)
+        load_node_db(&self.0, hash)
     }
 }
 
-pub(crate) fn store_node_tx(
+pub(crate) fn store_node_tx<'a>(
     tx: &Transaction<'a, TransactionDB>,
     node: merkletree::Node,
 ) -> Result<()> {
@@ -94,7 +75,7 @@ pub(crate) fn store_node_tx(
 
 impl<'a> db::TX for RocksTx<'a> {
     fn store_node(&mut self, node: merkletree::Node) -> Result<()> {
-        store_node_tx(&self.tx, node)
+        store_node_tx(&self.0, node)
     }
     fn commit(self: Box<Self>) -> Result<()> {
         self.0

--- a/src/backends/plonky2/primitives/merkletree/mod.rs
+++ b/src/backends/plonky2/primitives/merkletree/mod.rs
@@ -17,7 +17,7 @@ use crate::middleware::{Hash, RawValue, EMPTY_HASH, EMPTY_VALUE, F};
 pub mod circuit;
 pub use circuit::*;
 pub mod db;
-pub use db::DB;
+pub use db::{DB, TX};
 pub mod error;
 pub use error::{TreeError, TreeResult};
 use error::{TreeError as Error, TreeResult as Result};
@@ -44,17 +44,463 @@ impl PartialEq for MerkleTree {
 }
 impl Eq for MerkleTree {}
 
-pub(crate) fn load_node(db: &dyn DB, hash: Hash) -> Result<Node> {
+pub(crate) fn load_node(db: &dyn db::Read, hash: Hash) -> Result<Node> {
     match db.load_node(hash) {
         Err(e) => Err(Error::Database(e)),
         Ok(None) => Err(Error::node_not_found(hash)),
         Ok(Some(node)) => Ok(node),
     }
 }
-fn store_node(db: &mut dyn DB, node: Node) -> Result<()> {
-    match db.store_node(node) {
+
+fn store_node(tx: &mut dyn TX, node: Node) -> Result<()> {
+    match tx.store_node(node) {
         Ok(_) => Ok(()),
         Err(e) => Err(Error::Database(e)),
+    }
+}
+
+fn prove(db: &dyn db::Read, root: Hash, key: &RawValue) -> Result<(RawValue, MerkleProof)> {
+    let path = keypath(*key);
+
+    let mut siblings: Vec<Hash> = Vec::new();
+    match down(
+        db,
+        (path, 0),
+        root,
+        *key,
+        Some(&mut siblings),
+        MerkleTreeOp::ReadOnly,
+    )? {
+        Some((k, v)) if &k == key => Ok((
+            v,
+            MerkleProof {
+                existence: true,
+                siblings,
+                other_leaf: None,
+            },
+        )),
+        _ => Err(Error::key_not_found()),
+    }
+}
+
+/// returns a proof of non-existence, which proves that the given
+/// `key` does not exist in the tree. The return value specifies
+/// the key-value pair in the leaf reached as a result of
+/// resolving `key` as well as a `MerkleProof`.
+fn prove_nonexistence(db: &dyn db::Read, root: Hash, key: &RawValue) -> Result<MerkleProof> {
+    let path = keypath(*key);
+
+    let mut siblings: Vec<Hash> = Vec::new();
+
+    // note: non-existence of a key can be in 2 cases:
+    match down(
+        db,
+        (path, 0),
+        root,
+        *key,
+        Some(&mut siblings),
+        MerkleTreeOp::ReadOnly,
+    )? {
+        // case i) the expected leaf does not exist
+        None => Ok(MerkleProof {
+            existence: false,
+            siblings,
+            other_leaf: None,
+        }),
+        // case ii) the expected leaf does exist in the tree, but it has a different `key`
+        Some((k, v)) if &k != key => Ok(MerkleProof {
+            existence: false,
+            siblings,
+            other_leaf: Some((k, v)),
+        }),
+        _ => Err(Error::key_exists()),
+    }
+    // both cases prove that the given key don't exist in the tree.
+}
+
+pub fn insert_tx(
+    tx: &mut dyn TX,
+    root: Hash,
+    key: &RawValue,
+    value: &RawValue,
+) -> Result<MerkleTreeStateTransitionProof> {
+    let proof_non_existence = prove_nonexistence(tx, root, key)?;
+
+    let old_root = root;
+    let root = apply_op(tx, MerkleTreeOp::Insert, root, *key, Some(*value))?;
+
+    let (v, proof) = prove(tx, root, key)?;
+    assert!(proof.existence);
+    assert_eq!(v, *value);
+    assert!(proof.other_leaf.is_none());
+
+    Ok(MerkleTreeStateTransitionProof {
+        op: MerkleTreeOp::Insert, // insertion
+        old_root,
+        op_proof: proof_non_existence,
+        new_root: root,
+        op_key: *key,
+        op_value: *value,
+        value: None,
+        siblings: proof.siblings,
+    })
+}
+
+pub fn update_tx(
+    tx: &mut dyn TX,
+    root: Hash,
+    key: &RawValue,
+    value: &RawValue,
+) -> Result<MerkleTreeStateTransitionProof> {
+    let (old_value, old_proof) = prove(tx, root, key)?;
+
+    let old_root = root;
+    let root = apply_op(tx, MerkleTreeOp::Update, root, *key, Some(*value))?;
+
+    let (v, proof) = prove(tx, root, key)?;
+    assert!(proof.existence);
+    assert_eq!(v, *value);
+    assert!(proof.other_leaf.is_none());
+
+    Ok(MerkleTreeStateTransitionProof {
+        op: MerkleTreeOp::Update,
+        old_root,
+        op_proof: old_proof,
+        new_root: root,
+        op_key: *key,
+        op_value: *value,
+        value: Some(old_value),
+        siblings: proof.siblings,
+    })
+}
+
+pub fn delete_tx(
+    tx: &mut dyn TX,
+    root: Hash,
+    key: &RawValue,
+) -> Result<MerkleTreeStateTransitionProof> {
+    let (value, proof_existence) = prove(tx, root, key)?;
+
+    let old_root = root;
+    let root = apply_op(tx, MerkleTreeOp::Delete, root, *key, None)?;
+
+    let proof = prove_nonexistence(tx, root, key)?;
+    assert!(!proof.existence);
+
+    Ok(MerkleTreeStateTransitionProof {
+        op: MerkleTreeOp::Delete,
+        old_root,
+        op_proof: proof,
+        new_root: root,
+        op_key: *key,
+        op_value: value,
+        value: None,
+        siblings: proof_existence.siblings,
+    })
+}
+
+/// Goes down from the current node until it encounters a terminal node,
+/// viz. a leaf or empty node, or until it reaches the maximum depth. The
+/// `siblings` parameter is used to store the siblings while going down to
+/// the leaf, if the given parameter is set to `None`, then no siblings are
+/// stored. In this way, the same method `down` can be used by MerkleTree
+/// methods `get`, `contains`, `prove` and `prove_nonexistence`.
+///
+/// Be aware that this method will return the found leaf at the given path,
+/// which may contain a different key and value than the expected one. And
+/// while it does not return explicitly a `siblings` variable, the input
+/// `siblings` is modified adding there the siblings found along the path.
+fn down(
+    db: &dyn db::Read,
+    path_and_lvl: (Vec<bool>, usize), // path and lvl
+    curr_node_hash: Hash,             // hash of current level node
+    new_key: RawValue,                // key to be added/found at the leaf
+    mut siblings: Option<&mut Vec<Hash>>,
+    op: MerkleTreeOp,
+) -> Result<Option<(RawValue, RawValue)>> {
+    let (path, lvl) = path_and_lvl;
+
+    if lvl > MAX_DEPTH {
+        return Err(Error::max_depth());
+    }
+
+    if curr_node_hash == EMPTY_HASH {
+        return Ok(None);
+    }
+
+    let node = load_node(db, curr_node_hash)?;
+    match node {
+        Node::Intermediate(n) => {
+            if path[lvl] {
+                if let Some(s) = siblings.as_mut() {
+                    s.push(n.left);
+                }
+                down(db, (path, lvl + 1), n.right, new_key, siblings, op)
+            } else {
+                if let Some(s) = siblings.as_mut() {
+                    s.push(n.right);
+                }
+                down(db, (path, lvl + 1), n.left, new_key, siblings, op)
+            }
+        }
+        Node::Leaf(old_leaf) => {
+            if op == MerkleTreeOp::ReadOnly {
+                return Ok(Some((old_leaf.key, old_leaf.value)));
+            }
+
+            if new_key == old_leaf.key {
+                if op == MerkleTreeOp::Insert {
+                    // in Insert, key should not exist
+                    return Err(Error::key_exists());
+                }
+                // we're at the operation Update/Delete case
+                return Ok(Some((old_leaf.key, old_leaf.value)));
+            }
+
+            down_till_divergence(
+                lvl,
+                curr_node_hash.into(),
+                old_leaf.path,
+                path,
+                siblings.ok_or(Error::custom("expected siblings, got None"))?,
+            )?;
+            Ok(Some((old_leaf.key, old_leaf.value)))
+        }
+    }
+}
+
+/// goes down through a 'virtual' path till finding a divergence. This
+/// method is used for when adding a new leaf another already existing leaf
+/// is found, so that both leaves (new and old) are pushed down the path
+/// till their keys diverge.
+fn down_till_divergence(
+    lvl: usize,
+    old_key: RawValue,
+    old_path: Vec<bool>,
+    new_path: Vec<bool>,
+    siblings: &mut Vec<Hash>,
+) -> Result<()> {
+    if lvl > MAX_DEPTH {
+        return Err(Error::max_depth());
+    }
+    if old_path[lvl] == new_path[lvl] {
+        siblings.push(EMPTY_HASH);
+        return down_till_divergence(lvl + 1, old_key, old_path, new_path, siblings);
+    }
+    // reached the divergence
+    siblings.push(old_key.into());
+    Ok(())
+}
+
+/// go up recursively updating the intermediate nodes
+fn up(
+    tx: &mut dyn TX,
+    path: Vec<bool>,
+    curr_lvl: usize,
+    key: Hash,
+    siblings: Vec<Hash>,
+    op: MerkleTreeOp,
+    // first_zeroes should be set to `true` when calling `up` from outside
+    // the method itself. It is used internally to know when to go up
+    // 'virtually' for the first batch of zeroes.
+    first_zeroes: bool,
+) -> Result<Hash> {
+    // recall, in the delete case, the `key` is the `remaining_key`
+    let key_node = load_node(tx, key)?;
+    if op == MerkleTreeOp::Delete
+        && first_zeroes
+        && matches!(key_node, Node::Leaf(..))
+        && siblings[curr_lvl] == EMPTY_HASH
+    {
+        // - if we're at operation delete, the node that we're holding is a leaf,
+        // and we're at the first consecutive zero siblings
+        // - in operation Delete, go up till the first non-zero sibling and
+        // pair the given key with that sibling.
+        // This is only done for the first batch of zero siblings, that is,
+        // after a non-zero sibling, no matter how many zero siblings it
+        // has, don't do this logic anymore.
+        if curr_lvl == 0 {
+            return Ok(key);
+        }
+        return up(tx, path, curr_lvl - 1, key, siblings, op, true);
+    }
+
+    let node = if path[curr_lvl] {
+        Intermediate::new(siblings[curr_lvl], key)
+    } else {
+        Intermediate::new(key, siblings[curr_lvl])
+    };
+    let node_hash = node.hash; // variable to avoid cloning `node` later
+
+    // store in db
+    store_node(tx, Node::Intermediate(node))?;
+
+    if curr_lvl == 0 {
+        return Ok(node_hash);
+    }
+    up(tx, path, curr_lvl - 1, node_hash, siblings, op, false)
+}
+
+/// verifies an inclusion proof for the given `key` and `value`
+pub fn verify(root: Hash, proof: &MerkleProof, key: &RawValue, value: &RawValue) -> Result<()> {
+    let h = proof.compute_root_from_leaf(key, Some(*value))?;
+
+    if h != root {
+        Err(Error::proof_fail("inclusion".to_string()))
+    } else {
+        Ok(())
+    }
+}
+
+/// verifies a non-inclusion proof for the given `key`, that is, the given
+/// `key` does not exist in the tree
+pub fn verify_nonexistence(root: Hash, proof: &MerkleProof, key: &RawValue) -> Result<()> {
+    match proof.other_leaf {
+        Some((k, _v)) if &k == key => Err(Error::invalid_proof("non-existence".to_string())),
+        _ => {
+            let k = proof.other_leaf.map(|(k, _)| k).unwrap_or(*key);
+            let v: Option<RawValue> = proof.other_leaf.map(|(_, v)| v);
+            let h = proof.compute_root_from_leaf(&k, v)?;
+
+            if h != root {
+                Err(Error::proof_fail("exclusion".to_string()))
+            } else {
+                Ok(())
+            }
+        }
+    }
+}
+
+pub fn verify_state_transition(proof: &MerkleTreeStateTransitionProof) -> Result<()> {
+    let mut old_siblings = proof.op_proof.siblings.clone();
+    let new_siblings = proof.siblings.clone();
+
+    match proof.op {
+        // A deletion is but an insertion subject to a time reversal.
+        MerkleTreeOp::Delete => {
+            let equivalent_insertion_proof = MerkleTreeStateTransitionProof {
+                op: MerkleTreeOp::Insert,
+                new_root: proof.old_root,
+                old_root: proof.new_root,
+                ..proof.clone()
+            };
+            verify_state_transition(&equivalent_insertion_proof)
+        }
+        MerkleTreeOp::Update => {
+            if proof.value.is_none() {
+                return Err(Error::state_transition_fail(
+                    "Invalid proof of update: proof.value should not be None".to_string(),
+                ));
+            }
+            // check that for the old_root, (op_key, value) *does* exist in the tree
+            verify(
+                proof.old_root,
+                &proof.op_proof,
+                &proof.op_key,
+                &proof.value.unwrap(), // unrawp is safe due prev `is_none` check
+            )?;
+            // check that for the new_root, (op_key, op_value) *does* exist in the tree
+            verify(
+                proof.new_root,
+                &MerkleProof {
+                    existence: true,
+                    siblings: proof.siblings.clone(),
+                    other_leaf: None,
+                },
+                &proof.op_key,
+                &proof.op_value,
+            )?;
+
+            // All siblings should agree
+            (proof.siblings == proof.op_proof.siblings)
+                .then_some(())
+                .ok_or(Error::state_transition_fail(format!(
+                    "Invalid proof of update for key {}: Siblings don't match.",
+                    proof.op_key
+                )))
+        }
+        MerkleTreeOp::Insert => {
+            // check that for the old_root, the new_key does not exist in the tree
+            verify_nonexistence(proof.old_root, &proof.op_proof, &proof.op_key)?;
+
+            // check that new_siblings verify with the new_root
+            verify(
+                proof.new_root,
+                &MerkleProof {
+                    existence: true,
+                    siblings: new_siblings.clone(),
+                    other_leaf: None,
+                },
+                &proof.op_key,
+                &proof.op_value,
+            )?;
+
+            // if other_leaf exists, check path divergence
+            if let Some((other_key, _)) = proof.op_proof.other_leaf {
+                let old_path = keypath(other_key);
+                let new_path = keypath(proof.op_key);
+
+                let divergence_lvl: usize =
+                    match zip_eq(old_path, new_path).position(|(x, y)| x != y) {
+                        Some(d) => d,
+                        None => return Err(Error::max_depth()),
+                    };
+
+                if divergence_lvl != new_siblings.len() - 1 {
+                    return Err(Error::state_transition_fail(
+                        "paths divergence does not match".to_string(),
+                    ));
+                }
+            }
+
+            // let d=divergence_level, assert that:
+            // 1) old_siblings[i] == new_siblings[i] ∀ i \ {d}
+            // 2) at i==d, if old_siblings[i] != new_siblings[i]:
+            //     old_siblings[i] == EMPTY_HASH
+            //     new_siblings[i] == old_leaf_hash
+
+            // First rule out the case of insertion into empty tree.
+            if new_siblings.is_empty() {
+                return (old_siblings.is_empty() && proof.old_root == EMPTY_HASH)
+                    .then_some(())
+                    .ok_or(Error::state_transition_fail(
+                        "new tree has no siblings yet old tree is not the empty tree".to_string(),
+                    ));
+            }
+
+            let d = new_siblings.len() - 1;
+            old_siblings.resize(d + 1, EMPTY_HASH);
+            for i in 0..d {
+                if old_siblings[i] != new_siblings[i] {
+                    return Err(Error::state_transition_fail(
+                        "siblings don't match: old[i]!=new[i] ∀ i (except at i==d)".to_string(),
+                    ));
+                }
+            }
+            if old_siblings[d] != new_siblings[d] {
+                if old_siblings[d] != EMPTY_HASH {
+                    return Err(Error::state_transition_fail(
+                        "siblings don't match: old[d]!=empty".to_string(),
+                    ));
+                }
+                let k = proof
+                .op_proof
+                .other_leaf
+                .map(|(k, _)| k)
+                .ok_or(Error::state_transition_fail(
+                        "proof.proof_non_existence.other_leaf can not be empty for the case old_siblings[d]!=new_siblings[d]".to_string()
+                        ))?;
+                let v: Option<RawValue> = proof.op_proof.other_leaf.map(|(_, v)| v);
+                let old_leaf_hash = kv_hash(&k, v);
+                if new_siblings[d] != old_leaf_hash {
+                    return Err(Error::state_transition_fail(
+                        "siblings don't match: new[d]!=old_leaf_hash".to_string(),
+                    ));
+                }
+            }
+            Ok(())
+        }
+        _ => Err(Error::invalid_proof("proof.op".to_string())),
     }
 }
 
@@ -66,15 +512,15 @@ impl MerkleTree {
     }
     pub fn new_with_db(db: Box<dyn DB>, kvs: &HashMap<RawValue, RawValue>) -> Result<Self> {
         // Start with an empty node as root.
-        let (root, db) = {
-            let mut db = db;
-
+        let root = {
+            let mut tx = db.tx();
             // Iterate over key-value pairs (if any) and add them.
             let mut root = EMPTY_HASH;
             for (k, v) in kvs.iter() {
-                root = Self::apply_op(db.as_mut(), MerkleTreeOp::Insert, root, *k, Some(*v))?;
+                root = apply_op(tx.as_mut(), MerkleTreeOp::Insert, root, *k, Some(*v))?;
             }
-            (root, db)
+            tx.commit().map_err(|e| Error::Database(e))?;
+            root
         };
 
         Ok(Self { root, db })
@@ -93,152 +539,10 @@ impl MerkleTree {
         self.root
     }
 
-    /// Goes down from the current node until it encounters a terminal node,
-    /// viz. a leaf or empty node, or until it reaches the maximum depth. The
-    /// `siblings` parameter is used to store the siblings while going down to
-    /// the leaf, if the given parameter is set to `None`, then no siblings are
-    /// stored. In this way, the same method `down` can be used by MerkleTree
-    /// methods `get`, `contains`, `prove` and `prove_nonexistence`.
-    ///
-    /// Be aware that this method will return the found leaf at the given path,
-    /// which may contain a different key and value than the expected one. And
-    /// while it does not return explicitly a `siblings` variable, the input
-    /// `siblings` is modified adding there the siblings found along the path.
-    fn down(
-        db: &dyn DB,
-        path_and_lvl: (Vec<bool>, usize), // path and lvl
-        curr_node_hash: Hash,             // hash of current level node
-        new_key: RawValue,                // key to be added/found at the leaf
-        mut siblings: Option<&mut Vec<Hash>>,
-        op: MerkleTreeOp,
-    ) -> Result<Option<(RawValue, RawValue)>> {
-        let (path, lvl) = path_and_lvl;
-
-        if lvl > MAX_DEPTH {
-            return Err(Error::max_depth());
-        }
-
-        if curr_node_hash == EMPTY_HASH {
-            return Ok(None);
-        }
-
-        let node = load_node(db, curr_node_hash)?;
-        match node {
-            Node::Intermediate(n) => {
-                if path[lvl] {
-                    if let Some(s) = siblings.as_mut() {
-                        s.push(n.left);
-                    }
-                    Self::down(db, (path, lvl + 1), n.right, new_key, siblings, op)
-                } else {
-                    if let Some(s) = siblings.as_mut() {
-                        s.push(n.right);
-                    }
-                    Self::down(db, (path, lvl + 1), n.left, new_key, siblings, op)
-                }
-            }
-            Node::Leaf(old_leaf) => {
-                if op == MerkleTreeOp::ReadOnly {
-                    return Ok(Some((old_leaf.key, old_leaf.value)));
-                }
-
-                if new_key == old_leaf.key {
-                    if op == MerkleTreeOp::Insert {
-                        // in Insert, key should not exist
-                        return Err(Error::key_exists());
-                    }
-                    // we're at the operation Update/Delete case
-                    return Ok(Some((old_leaf.key, old_leaf.value)));
-                }
-
-                Self::down_till_divergence(
-                    lvl,
-                    curr_node_hash.into(),
-                    old_leaf.path,
-                    path,
-                    siblings.ok_or(Error::custom("expected siblings, got None"))?,
-                )?;
-                Ok(Some((old_leaf.key, old_leaf.value)))
-            }
-        }
-    }
-
-    /// goes down through a 'virtual' path till finding a divergence. This
-    /// method is used for when adding a new leaf another already existing leaf
-    /// is found, so that both leaves (new and old) are pushed down the path
-    /// till their keys diverge.
-    fn down_till_divergence(
-        lvl: usize,
-        old_key: RawValue,
-        old_path: Vec<bool>,
-        new_path: Vec<bool>,
-        siblings: &mut Vec<Hash>,
-    ) -> Result<()> {
-        if lvl > MAX_DEPTH {
-            return Err(Error::max_depth());
-        }
-        if old_path[lvl] == new_path[lvl] {
-            siblings.push(EMPTY_HASH);
-            return Self::down_till_divergence(lvl + 1, old_key, old_path, new_path, siblings);
-        }
-        // reached the divergence
-        siblings.push(old_key.into());
-        Ok(())
-    }
-
-    /// go up recursively updating the intermediate nodes
-    fn up(
-        db: &mut dyn DB,
-        path: Vec<bool>,
-        curr_lvl: usize,
-        key: Hash,
-        siblings: Vec<Hash>,
-        op: MerkleTreeOp,
-        // first_zeroes should be set to `true` when calling `up` from outside
-        // the method itself. It is used internally to know when to go up
-        // 'virtually' for the first batch of zeroes.
-        first_zeroes: bool,
-    ) -> Result<Hash> {
-        // recall, in the delete case, the `key` is the `remaining_key`
-        let key_node = load_node(db, key)?;
-        if op == MerkleTreeOp::Delete
-            && first_zeroes
-            && matches!(key_node, Node::Leaf(..))
-            && siblings[curr_lvl] == EMPTY_HASH
-        {
-            // - if we're at operation delete, the node that we're holding is a leaf,
-            // and we're at the first consecutive zero siblings
-            // - in operation Delete, go up till the first non-zero sibling and
-            // pair the given key with that sibling.
-            // This is only done for the first batch of zero siblings, that is,
-            // after a non-zero sibling, no matter how many zero siblings it
-            // has, don't do this logic anymore.
-            if curr_lvl == 0 {
-                return Ok(key);
-            }
-            return Self::up(db, path, curr_lvl - 1, key, siblings, op, true);
-        }
-
-        let node = if path[curr_lvl] {
-            Intermediate::new(siblings[curr_lvl], key)
-        } else {
-            Intermediate::new(key, siblings[curr_lvl])
-        };
-        let node_hash = node.hash; // variable to avoid cloning `node` later
-
-        // store in db
-        store_node(db, Node::Intermediate(node))?;
-
-        if curr_lvl == 0 {
-            return Ok(node_hash);
-        }
-        Self::up(db, path, curr_lvl - 1, node_hash, siblings, op, false)
-    }
-
     /// returns the value at the given key
     pub fn get(&self, key: &RawValue) -> Result<Option<RawValue>> {
         let path = keypath(*key);
-        let key_resolution = Self::down(
+        let key_resolution = down(
             self.db.as_ref(),
             (path, 0),
             self.root,
@@ -255,7 +559,7 @@ impl MerkleTree {
     /// returns a boolean indicating whether the key exists in the tree
     pub fn contains(&self, key: &RawValue) -> Result<bool> {
         let path = keypath(*key);
-        match Self::down(
+        match down(
             self.db.as_ref(),
             (path, 0),
             self.root,
@@ -273,33 +577,11 @@ impl MerkleTree {
         key: &RawValue,
         value: &RawValue,
     ) -> Result<MerkleTreeStateTransitionProof> {
-        let proof_non_existence = self.prove_nonexistence(key)?;
-
-        let old_root: Hash = self.root;
-
-        self.root = Self::apply_op(
-            self.db.as_mut(),
-            MerkleTreeOp::Insert,
-            self.root,
-            *key,
-            Some(*value),
-        )?;
-
-        let (v, proof) = self.prove(key)?;
-        assert!(proof.existence);
-        assert_eq!(v, *value);
-        assert!(proof.other_leaf.is_none());
-
-        Ok(MerkleTreeStateTransitionProof {
-            op: MerkleTreeOp::Insert, // insertion
-            old_root,
-            op_proof: proof_non_existence,
-            new_root: self.root,
-            op_key: *key,
-            op_value: *value,
-            value: None,
-            siblings: proof.siblings,
-        })
+        let mut tx = self.db.tx();
+        let proof = insert_tx(tx.as_mut(), self.root, key, value)?;
+        tx.commit().map_err(|e| Error::Database(e))?;
+        self.root = proof.new_root;
+        Ok(proof)
     }
 
     pub fn update(
@@ -307,86 +589,26 @@ impl MerkleTree {
         key: &RawValue,
         value: &RawValue,
     ) -> Result<MerkleTreeStateTransitionProof> {
-        let (old_value, old_proof) = self.prove(key)?;
-
-        let old_root: Hash = self.root;
-        self.root = Self::apply_op(
-            self.db.as_mut(),
-            MerkleTreeOp::Update,
-            self.root,
-            *key,
-            Some(*value),
-        )?;
-
-        let (v, proof) = self.prove(key)?;
-        assert!(proof.existence);
-        assert_eq!(v, *value);
-        assert!(proof.other_leaf.is_none());
-
-        Ok(MerkleTreeStateTransitionProof {
-            op: MerkleTreeOp::Update,
-            old_root,
-            op_proof: old_proof,
-            new_root: self.root,
-            op_key: *key,
-            op_value: *value,
-            value: Some(old_value),
-            siblings: proof.siblings,
-        })
+        let mut tx = self.db.tx();
+        let proof = update_tx(tx.as_mut(), self.root, key, value)?;
+        tx.commit().map_err(|e| Error::Database(e))?;
+        self.root = proof.new_root;
+        Ok(proof)
     }
 
     pub fn delete(&mut self, key: &RawValue) -> Result<MerkleTreeStateTransitionProof> {
-        let (value, proof_existence) = self.prove(key)?;
-
-        let old_root: Hash = self.root;
-        self.root = Self::apply_op(
-            self.db.as_mut(),
-            MerkleTreeOp::Delete,
-            self.root,
-            *key,
-            None,
-        )?;
-
-        let proof = self.prove_nonexistence(key)?;
-        assert!(!proof.existence);
-
-        Ok(MerkleTreeStateTransitionProof {
-            op: MerkleTreeOp::Delete,
-            old_root,
-            op_proof: proof,
-            new_root: self.root,
-            op_key: *key,
-            op_value: value,
-            value: None,
-            siblings: proof_existence.siblings,
-        })
+        let mut tx = self.db.tx();
+        let proof = delete_tx(tx.as_mut(), self.root, key)?;
+        tx.commit().map_err(|e| Error::Database(e))?;
+        self.root = proof.new_root;
+        Ok(proof)
     }
 
     /// returns a proof of existence, which proves that the given key exists in
     /// the tree. It returns the `value` of the leaf at the given `key`, and the
     /// `MerkleProof`.
     pub fn prove(&self, key: &RawValue) -> Result<(RawValue, MerkleProof)> {
-        let path = keypath(*key);
-
-        let mut siblings: Vec<Hash> = Vec::new();
-        match Self::down(
-            self.db.as_ref(),
-            (path, 0),
-            self.root,
-            *key,
-            Some(&mut siblings),
-            MerkleTreeOp::ReadOnly,
-        )? {
-            Some((k, v)) if &k == key => Ok((
-                v,
-                MerkleProof {
-                    existence: true,
-                    siblings,
-                    other_leaf: None,
-                },
-            )),
-            _ => Err(Error::key_not_found()),
-        }
+        prove(self.db.as_ref(), self.root, key)
     }
 
     /// returns a proof of non-existence, which proves that the given
@@ -394,315 +616,121 @@ impl MerkleTree {
     /// the key-value pair in the leaf reached as a result of
     /// resolving `key` as well as a `MerkleProof`.
     pub fn prove_nonexistence(&self, key: &RawValue) -> Result<MerkleProof> {
-        let path = keypath(*key);
-
-        let mut siblings: Vec<Hash> = Vec::new();
-
-        // note: non-existence of a key can be in 2 cases:
-        match Self::down(
-            self.db.as_ref(),
-            (path, 0),
-            self.root,
-            *key,
-            Some(&mut siblings),
-            MerkleTreeOp::ReadOnly,
-        )? {
-            // case i) the expected leaf does not exist
-            None => Ok(MerkleProof {
-                existence: false,
-                siblings,
-                other_leaf: None,
-            }),
-            // case ii) the expected leaf does exist in the tree, but it has a different `key`
-            Some((k, v)) if &k != key => Ok(MerkleProof {
-                existence: false,
-                siblings,
-                other_leaf: Some((k, v)),
-            }),
-            _ => Err(Error::key_exists()),
-        }
-        // both cases prove that the given key don't exist in the tree.
-    }
-
-    /// verifies an inclusion proof for the given `key` and `value`
-    pub fn verify(root: Hash, proof: &MerkleProof, key: &RawValue, value: &RawValue) -> Result<()> {
-        let h = proof.compute_root_from_leaf(key, Some(*value))?;
-
-        if h != root {
-            Err(Error::proof_fail("inclusion".to_string()))
-        } else {
-            Ok(())
-        }
-    }
-
-    /// verifies a non-inclusion proof for the given `key`, that is, the given
-    /// `key` does not exist in the tree
-    pub fn verify_nonexistence(root: Hash, proof: &MerkleProof, key: &RawValue) -> Result<()> {
-        match proof.other_leaf {
-            Some((k, _v)) if &k == key => Err(Error::invalid_proof("non-existence".to_string())),
-            _ => {
-                let k = proof.other_leaf.map(|(k, _)| k).unwrap_or(*key);
-                let v: Option<RawValue> = proof.other_leaf.map(|(_, v)| v);
-                let h = proof.compute_root_from_leaf(&k, v)?;
-
-                if h != root {
-                    Err(Error::proof_fail("exclusion".to_string()))
-                } else {
-                    Ok(())
-                }
-            }
-        }
-    }
-
-    pub fn verify_state_transition(proof: &MerkleTreeStateTransitionProof) -> Result<()> {
-        let mut old_siblings = proof.op_proof.siblings.clone();
-        let new_siblings = proof.siblings.clone();
-
-        match proof.op {
-            // A deletion is but an insertion subject to a time reversal.
-            MerkleTreeOp::Delete => {
-                let equivalent_insertion_proof = MerkleTreeStateTransitionProof {
-                    op: MerkleTreeOp::Insert,
-                    new_root: proof.old_root,
-                    old_root: proof.new_root,
-                    ..proof.clone()
-                };
-                Self::verify_state_transition(&equivalent_insertion_proof)
-            }
-            MerkleTreeOp::Update => {
-                if proof.value.is_none() {
-                    return Err(Error::state_transition_fail(
-                        "Invalid proof of update: proof.value should not be None".to_string(),
-                    ));
-                }
-                // check that for the old_root, (op_key, value) *does* exist in the tree
-                Self::verify(
-                    proof.old_root,
-                    &proof.op_proof,
-                    &proof.op_key,
-                    &proof.value.unwrap(), // unrawp is safe due prev `is_none` check
-                )?;
-                // check that for the new_root, (op_key, op_value) *does* exist in the tree
-                Self::verify(
-                    proof.new_root,
-                    &MerkleProof {
-                        existence: true,
-                        siblings: proof.siblings.clone(),
-                        other_leaf: None,
-                    },
-                    &proof.op_key,
-                    &proof.op_value,
-                )?;
-
-                // All siblings should agree
-                (proof.siblings == proof.op_proof.siblings)
-                    .then_some(())
-                    .ok_or(Error::state_transition_fail(format!(
-                        "Invalid proof of update for key {}: Siblings don't match.",
-                        proof.op_key
-                    )))
-            }
-            MerkleTreeOp::Insert => {
-                // check that for the old_root, the new_key does not exist in the tree
-                Self::verify_nonexistence(proof.old_root, &proof.op_proof, &proof.op_key)?;
-
-                // check that new_siblings verify with the new_root
-                Self::verify(
-                    proof.new_root,
-                    &MerkleProof {
-                        existence: true,
-                        siblings: new_siblings.clone(),
-                        other_leaf: None,
-                    },
-                    &proof.op_key,
-                    &proof.op_value,
-                )?;
-
-                // if other_leaf exists, check path divergence
-                if let Some((other_key, _)) = proof.op_proof.other_leaf {
-                    let old_path = keypath(other_key);
-                    let new_path = keypath(proof.op_key);
-
-                    let divergence_lvl: usize =
-                        match zip_eq(old_path, new_path).position(|(x, y)| x != y) {
-                            Some(d) => d,
-                            None => return Err(Error::max_depth()),
-                        };
-
-                    if divergence_lvl != new_siblings.len() - 1 {
-                        return Err(Error::state_transition_fail(
-                            "paths divergence does not match".to_string(),
-                        ));
-                    }
-                }
-
-                // let d=divergence_level, assert that:
-                // 1) old_siblings[i] == new_siblings[i] ∀ i \ {d}
-                // 2) at i==d, if old_siblings[i] != new_siblings[i]:
-                //     old_siblings[i] == EMPTY_HASH
-                //     new_siblings[i] == old_leaf_hash
-
-                // First rule out the case of insertion into empty tree.
-                if new_siblings.is_empty() {
-                    return (old_siblings.is_empty() && proof.old_root == EMPTY_HASH)
-                        .then_some(())
-                        .ok_or(Error::state_transition_fail(
-                            "new tree has no siblings yet old tree is not the empty tree"
-                                .to_string(),
-                        ));
-                }
-
-                let d = new_siblings.len() - 1;
-                old_siblings.resize(d + 1, EMPTY_HASH);
-                for i in 0..d {
-                    if old_siblings[i] != new_siblings[i] {
-                        return Err(Error::state_transition_fail(
-                            "siblings don't match: old[i]!=new[i] ∀ i (except at i==d)".to_string(),
-                        ));
-                    }
-                }
-                if old_siblings[d] != new_siblings[d] {
-                    if old_siblings[d] != EMPTY_HASH {
-                        return Err(Error::state_transition_fail(
-                            "siblings don't match: old[d]!=empty".to_string(),
-                        ));
-                    }
-                    let k = proof
-                .op_proof
-                .other_leaf
-                .map(|(k, _)| k)
-                .ok_or(Error::state_transition_fail(
-                        "proof.proof_non_existence.other_leaf can not be empty for the case old_siblings[d]!=new_siblings[d]".to_string()
-                        ))?;
-                    let v: Option<RawValue> = proof.op_proof.other_leaf.map(|(_, v)| v);
-                    let old_leaf_hash = kv_hash(&k, v);
-                    if new_siblings[d] != old_leaf_hash {
-                        return Err(Error::state_transition_fail(
-                            "siblings don't match: new[d]!=old_leaf_hash".to_string(),
-                        ));
-                    }
-                }
-                Ok(())
-            }
-            _ => Err(Error::invalid_proof("proof.op".to_string())),
-        }
+        prove_nonexistence(self.db.as_ref(), self.root, key)
     }
 }
 
 // auxiliary methods
-impl MerkleTree {
-    /// Applies given Merkle tree op.
-    pub(crate) fn apply_op(
-        db: &mut dyn DB,
-        op: MerkleTreeOp,
-        root: Hash,
-        k: RawValue,
-        maybe_value: Option<RawValue>,
-    ) -> Result<Hash> {
-        // Rule out invalid arguments
-        match (op, maybe_value) {
-            (MerkleTreeOp::Insert, None) | (MerkleTreeOp::Update, None) => {
-                Err(Error::invalid_state_transition_proof_arg(format!(
-                    "{:?} op requires a value argument.",
-                    op
-                )))
-            }
-            (MerkleTreeOp::Delete, Some(_)) => {
-                Err(Error::invalid_state_transition_proof_arg(format!(
-                    "{:?} op requires no value argument, yet one was provided.",
-                    op
-                )))
-            }
-            (MerkleTreeOp::ReadOnly, _) => Err(Error::invalid_state_transition_proof_arg(format!(
-                "{:?} 'read only' op should not reach the 'apply_op' method",
+
+/// Applies given Merkle tree op.
+pub(crate) fn apply_op(
+    tx: &mut dyn TX,
+    op: MerkleTreeOp,
+    root: Hash,
+    k: RawValue,
+    maybe_value: Option<RawValue>,
+) -> Result<Hash> {
+    // Rule out invalid arguments
+    match (op, maybe_value) {
+        (MerkleTreeOp::Insert, None) | (MerkleTreeOp::Update, None) => {
+            Err(Error::invalid_state_transition_proof_arg(format!(
+                "{:?} op requires a value argument.",
                 op
-            ))),
-            _ => Ok(()),
-        }?;
+            )))
+        }
+        (MerkleTreeOp::Delete, Some(_)) => Err(Error::invalid_state_transition_proof_arg(format!(
+            "{:?} op requires no value argument, yet one was provided.",
+            op
+        ))),
+        (MerkleTreeOp::ReadOnly, _) => Err(Error::invalid_state_transition_proof_arg(format!(
+            "{:?} 'read only' op should not reach the 'apply_op' method",
+            op
+        ))),
+        _ => Ok(()),
+    }?;
 
-        // go down, update the leaf, go up storing new hashes in the db
-        let path = keypath(k);
-        let mut siblings: Vec<Hash> = Vec::new();
-        let _ = Self::down(
-            db,
-            (path.clone(), 0), // from lvl 0
-            root,
-            k,
-            Some(&mut siblings),
-            op,
-        )?;
+    // go down, update the leaf, go up storing new hashes in the db
+    let path = keypath(k);
+    let mut siblings: Vec<Hash> = Vec::new();
+    let _ = down(
+        tx,
+        (path.clone(), 0), // from lvl 0
+        root,
+        k,
+        Some(&mut siblings),
+        op,
+    )?;
 
-        let node: Node = match (op, maybe_value) {
-            (MerkleTreeOp::Insert, Some(value)) | (MerkleTreeOp::Update, Some(value)) => {
-                Node::Leaf(Leaf::new(k, value))
+    let node: Node = match (op, maybe_value) {
+        (MerkleTreeOp::Insert, Some(value)) | (MerkleTreeOp::Update, Some(value)) => {
+            Node::Leaf(Leaf::new(k, value))
+        }
+        (MerkleTreeOp::Delete, None) => {
+            // return a node whose hash is 'empty', to indicate that there is no leaf
+            Node::Intermediate(Intermediate {
+                hash: EMPTY_HASH,
+                left: EMPTY_HASH,
+                right: EMPTY_HASH,
+            })
+        }
+        _ => {
+            return Err(Error::invalid_state_transition_proof_arg(format!(
+                "{:?} op has invalid value type: {:?}",
+                op, maybe_value
+            )))
+        }
+    };
+    let node_hash = node.hash(); // variable to avoid cloning `leaf` later
+    store_node(tx, node)?;
+    if siblings.is_empty() {
+        // return the leaf's hash as root
+        return Ok(node_hash);
+    }
+
+    let new_root = if op == MerkleTreeOp::Delete {
+        if siblings.len() == 1 {
+            // we're at the root-1 level, there is only a sibling, and we're
+            // removing the current leaf.
+            // If the sibling is a Leaf, the sibling (leaf) is now the new root
+            let sibling_node = load_node(tx, siblings[0])?;
+            if matches!(sibling_node, Node::Leaf(..)) {
+                return Ok(siblings[0]);
             }
-            (MerkleTreeOp::Delete, None) => {
-                // return a node whose hash is 'empty', to indicate that there is no leaf
-                Node::Intermediate(Intermediate {
-                    hash: EMPTY_HASH,
-                    left: EMPTY_HASH,
-                    right: EMPTY_HASH,
-                })
-            }
-            _ => {
-                return Err(Error::invalid_state_transition_proof_arg(format!(
-                    "{:?} op has invalid value type: {:?}",
-                    op, maybe_value
-                )))
-            }
-        };
-        let node_hash = node.hash(); // variable to avoid cloning `leaf` later
-        store_node(db, node)?;
-        if siblings.is_empty() {
-            // return the leaf's hash as root
+            // if the sibling is an Intermediate node, it means that the
+            // branch goes deeper, so don't short the path going up and pair
+            // it with an empty hash.
+            let node = if path[0] {
+                Intermediate::new(siblings[0], EMPTY_HASH)
+            } else {
+                Intermediate::new(EMPTY_HASH, siblings[0])
+            };
+            let node_hash = node.hash; // variable to avoid cloning `node` later
+
+            // store in db
+            store_node(tx, Node::Intermediate(node))?;
             return Ok(node_hash);
         }
+        // use the last sibling as the key that we will push up from
+        let l = siblings.len() - 1;
+        let remaining_key = siblings[l];
+        siblings[l] = EMPTY_HASH;
+        // invert the last sibling level
+        let mut path = path.clone();
+        path[siblings.len() - 1] = !path[siblings.len() - 1];
+        up(
+            tx,
+            path,
+            siblings.len() - 1,
+            remaining_key,
+            siblings,
+            op,
+            true,
+        )?
+    } else {
+        up(tx, path, siblings.len() - 1, node_hash, siblings, op, true)?
+    };
 
-        let new_root = if op == MerkleTreeOp::Delete {
-            if siblings.len() == 1 {
-                // we're at the root-1 level, there is only a sibling, and we're
-                // removing the current leaf.
-                // If the sibling is a Leaf, the sibling (leaf) is now the new root
-                let sibling_node = load_node(db, siblings[0])?;
-                if matches!(sibling_node, Node::Leaf(..)) {
-                    return Ok(siblings[0]);
-                }
-                // if the sibling is an Intermediate node, it means that the
-                // branch goes deeper, so don't short the path going up and pair
-                // it with an empty hash.
-                let node = if path[0] {
-                    Intermediate::new(siblings[0], EMPTY_HASH)
-                } else {
-                    Intermediate::new(EMPTY_HASH, siblings[0])
-                };
-                let node_hash = node.hash; // variable to avoid cloning `node` later
-
-                // store in db
-                store_node(db, Node::Intermediate(node))?;
-                return Ok(node_hash);
-            }
-            // use the last sibling as the key that we will push up from
-            let l = siblings.len() - 1;
-            let remaining_key = siblings[l];
-            siblings[l] = EMPTY_HASH;
-            // invert the last sibling level
-            let mut path = path.clone();
-            path[siblings.len() - 1] = !path[siblings.len() - 1];
-            Self::up(
-                db,
-                path,
-                siblings.len() - 1,
-                remaining_key,
-                siblings,
-                op,
-                true,
-            )?
-        } else {
-            Self::up(db, path, siblings.len() - 1, node_hash, siblings, op, true)?
-        };
-
-        Ok(new_root)
-    }
+    Ok(new_root)
 }
 
 /// Hash function for key-value pairs. Different branch pair hashes to
@@ -1141,7 +1169,7 @@ pub mod tests {
         assert_eq!(v, RawValue::from(1013));
         println!("{}", proof);
 
-        MerkleTree::verify(tree.root(), &proof, &key, &value)?;
+        verify(tree.root(), &proof, &key, &value)?;
 
         // Exclusion checks
         let key = RawValue::from(12);
@@ -1152,14 +1180,14 @@ pub mod tests {
         );
         println!("{}", proof);
 
-        MerkleTree::verify_nonexistence(tree.root(), &proof, &key)?;
+        verify_nonexistence(tree.root(), &proof, &key)?;
 
         let key = RawValue::from(1);
         let proof = tree.prove_nonexistence(&RawValue::from(1))?;
         assert_eq!(proof.other_leaf, None);
         println!("{}", proof);
 
-        MerkleTree::verify_nonexistence(tree.root(), &proof, &key)?;
+        verify_nonexistence(tree.root(), &proof, &key)?;
 
         // Check iterator
         let collected_kvs: Vec<_> = tree.into_iter().collect::<Vec<_>>();
@@ -1196,10 +1224,10 @@ pub mod tests {
     #[test]
     fn test_merkletree_pad() {
         let claim = MerkleClaimAndProof::pad();
-        MerkleTree::verify(claim.root, &claim.proof, &claim.key, &claim.value).unwrap();
+        verify(claim.root, &claim.proof, &claim.key, &claim.value).unwrap();
 
         let proof = MerkleTreeStateTransitionProof::pad();
-        MerkleTree::verify_state_transition(&proof).unwrap();
+        verify_state_transition(&proof).unwrap();
     }
 
     #[test]
@@ -1293,17 +1321,17 @@ pub mod tests {
         let (key, value) = (175.into(), 0.into());
         let (v, proof) = tree.prove(&key)?;
         assert_eq!(v, value);
-        MerkleTree::verify(tree.root(), &proof, &key, &value)?;
+        verify(tree.root(), &proof, &key, &value)?;
 
         let (key, value) = (2.into(), 88.into());
         let (v, proof) = tree.prove(&key)?;
         assert_eq!(v, value);
-        MerkleTree::verify(tree.root(), &proof, &key, &value)?;
+        verify(tree.root(), &proof, &key, &value)?;
 
         let (key, value) = (175.into(), 0.into());
         let (v, proof) = tree.prove(&key)?;
         assert_eq!(v, value);
-        MerkleTree::verify(tree.root(), &proof, &key, &value)?;
+        verify(tree.root(), &proof, &key, &value)?;
 
         Ok(())
     }
@@ -1334,7 +1362,7 @@ pub mod tests {
         .collect();
         let mut tree = MerkleTree::new_with_db(db.clone(), &kvs)?;
         let state_transition_proof = tree.update(&7.into(), &0.into())?;
-        MerkleTree::verify_state_transition(&state_transition_proof)?;
+        verify_state_transition(&state_transition_proof)?;
 
         let kvs = [
             (1.into(), 1.into()),
@@ -1350,11 +1378,11 @@ pub mod tests {
 
         // update the other leaves
         let state_transition_proof = tree.update(&1.into(), &0.into())?;
-        MerkleTree::verify_state_transition(&state_transition_proof)?;
+        verify_state_transition(&state_transition_proof)?;
         let state_transition_proof = tree.update(&9.into(), &0.into())?;
-        MerkleTree::verify_state_transition(&state_transition_proof)?;
+        verify_state_transition(&state_transition_proof)?;
         let state_transition_proof = tree.update(&15.into(), &0.into())?;
-        MerkleTree::verify_state_transition(&state_transition_proof)
+        verify_state_transition(&state_transition_proof)
     }
 
     #[test]
@@ -1383,19 +1411,19 @@ pub mod tests {
             .map(|i| (i.into(), i.into()))
             .try_for_each(|(k, v)| {
                 let mtp = mt.insert(&k, &v).unwrap();
-                MerkleTree::verify_state_transition(&mtp)
+                verify_state_transition(&mtp)
             })?;
         // update
         (11..20)
             .map(|i| (i.into(), (i + 1).into()))
             .try_for_each(|(k, v)| {
                 let mtp = mt.update(&k, &v).unwrap();
-                MerkleTree::verify_state_transition(&mtp)
+                verify_state_transition(&mtp)
             })?;
         // delete
         (11..20).map(|i| i.into()).try_for_each(|k| {
             let mtp = mt.delete(&k).unwrap();
-            MerkleTree::verify_state_transition(&mtp)
+            verify_state_transition(&mtp)
         })?;
 
         Ok(())
@@ -1433,7 +1461,7 @@ pub mod tests {
         .collect();
         let mut tree = MerkleTree::new_with_db(db.clone(), &kvs)?;
         let state_transition_proof = tree.delete(&15.into())?;
-        MerkleTree::verify_state_transition(&state_transition_proof)?;
+        verify_state_transition(&state_transition_proof)?;
 
         let kvs = [
             (1.into(), 1.into()),
@@ -1449,7 +1477,7 @@ pub mod tests {
         // delete the leaf '7', which when deleted will leave an entire branch
         // empty
         let state_transition_proof = tree.delete(&7.into())?;
-        MerkleTree::verify_state_transition(&state_transition_proof)?;
+        verify_state_transition(&state_transition_proof)?;
 
         assert_eq!(tree.root, expected_root);
 
@@ -1523,7 +1551,7 @@ pub mod tests {
         let value = RawValue::from(1037);
         let state_transition_proof = tree.insert(&key, &value)?;
 
-        MerkleTree::verify_state_transition(&state_transition_proof)?;
+        verify_state_transition(&state_transition_proof)?;
         assert_eq!(state_transition_proof.old_root, old_root);
         assert_eq!(state_transition_proof.new_root, tree.root());
         assert_eq!(state_transition_proof.op_key, key);
@@ -1534,7 +1562,7 @@ pub mod tests {
         // should be the same (mutatis mutandis).
         let mut tree_with_deleted_key = tree.clone();
         let state_transition_proof1 = tree_with_deleted_key.delete(&key)?;
-        MerkleTree::verify_state_transition(&state_transition_proof1)?;
+        verify_state_transition(&state_transition_proof1)?;
         assert_eq!(
             state_transition_proof1.old_root,
             state_transition_proof.new_root
@@ -1566,14 +1594,14 @@ pub mod tests {
         let value = RawValue::from(1021);
         let state_transition_proof = tree_with_another_leaf.insert(&key, &value)?;
 
-        MerkleTree::verify_state_transition(&state_transition_proof)?;
+        verify_state_transition(&state_transition_proof)?;
 
         // Alternatively add this key with another value then update.
         let value1 = RawValue::from(99);
         tree.insert(&key, &value1)?;
         let state_transition_proof1 = tree.update(&key, &value)?;
 
-        MerkleTree::verify_state_transition(&state_transition_proof1)?;
+        verify_state_transition(&state_transition_proof1)?;
 
         // `tree` and `tree_with_another_leaf` should coincide.
         assert_eq!(tree.root(), tree_with_another_leaf.root());

--- a/src/backends/plonky2/primitives/merkletree/mod.rs
+++ b/src/backends/plonky2/primitives/merkletree/mod.rs
@@ -519,7 +519,7 @@ impl MerkleTree {
             for (k, v) in kvs.iter() {
                 root = apply_op(tx.as_mut(), MerkleTreeOp::Insert, root, *k, Some(*v))?;
             }
-            tx.commit().map_err(|e| Error::Database(e))?;
+            tx.commit().map_err(Error::Database)?;
             root
         };
 
@@ -579,7 +579,7 @@ impl MerkleTree {
     ) -> Result<MerkleTreeStateTransitionProof> {
         let mut tx = self.db.tx();
         let proof = insert_tx(tx.as_mut(), self.root, key, value)?;
-        tx.commit().map_err(|e| Error::Database(e))?;
+        tx.commit().map_err(Error::Database)?;
         self.root = proof.new_root;
         Ok(proof)
     }
@@ -591,7 +591,7 @@ impl MerkleTree {
     ) -> Result<MerkleTreeStateTransitionProof> {
         let mut tx = self.db.tx();
         let proof = update_tx(tx.as_mut(), self.root, key, value)?;
-        tx.commit().map_err(|e| Error::Database(e))?;
+        tx.commit().map_err(Error::Database)?;
         self.root = proof.new_root;
         Ok(proof)
     }
@@ -599,7 +599,7 @@ impl MerkleTree {
     pub fn delete(&mut self, key: &RawValue) -> Result<MerkleTreeStateTransitionProof> {
         let mut tx = self.db.tx();
         let proof = delete_tx(tx.as_mut(), self.root, key)?;
-        tx.commit().map_err(|e| Error::Database(e))?;
+        tx.commit().map_err(Error::Database)?;
         self.root = proof.new_root;
         Ok(proof)
     }

--- a/src/examples/mod.rs
+++ b/src/examples/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     lang::parse_request,
     middleware::{
         self, containers::Set, hash_values, CustomPredicateRef, Params, Predicate, PublicKey,
-        Signer as _, Statement, StatementArg, TypedValue, VDSet, Value,
+        Signer as _, Statement, StatementArg, VDSet, Value,
     },
 };
 
@@ -383,7 +383,7 @@ pub fn tickets_pod_builder(
     expect_consumed: bool,
     blacklisted_emails: &Set,
 ) -> Result<MainPodBuilder> {
-    let blacklisted_email_set_value = Value::from(TypedValue::Set(blacklisted_emails.clone()));
+    let blacklisted_email_set_value = Value::from(blacklisted_emails.clone());
     // Create a main pod referencing this signed pod with some statements
     let mut builder = MainPodBuilder::new(params, vd_set);
     builder.pub_op(Operation::dict_signed_by(signed_dict))?;

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -397,12 +397,12 @@ impl MainPodBuilder {
                         .unwrap_or(Value::from(EMPTY_VALUE));
                 let proof = match op_type {
                     Native(ContainerInsertFromEntries) => {
-                        as_container_or_err(old_container)?.insert(key.clone(), value)?
+                        as_container_or_err(old_container)?.insert_proof(key.clone(), value)?
                     }
                     Native(ContainerUpdateFromEntries) => {
-                        as_container_or_err(old_container)?.update(key.raw(), value)?
+                        as_container_or_err(old_container)?.update_proof(key.raw(), value)?
                     }
-                    _ => as_container_or_err(old_container)?.delete(key.raw())?,
+                    _ => as_container_or_err(old_container)?.delete_proof(key.raw())?,
                 };
                 Ok(Operation(
                     op_type.clone(),

--- a/src/frontend/serialization.rs
+++ b/src/frontend/serialization.rs
@@ -87,7 +87,7 @@ mod tests {
             (Value::from(true), r#"{"Int":"1"}"#),
             (
                 Value::from(Array::new(vec![Value::from("foo"), Value::from(false)])),
-                r#"{"Array":[[{"Int":"0"},"foo"],[{"Int":"1"},{"Int":"0"}]]}"#,
+                r#"{"Container":{"kind":"--a","kvs":[[{"Int":"0"},"foo"],[{"Int":"1"},{"Int":"0"}]]}}"#,
             ),
             (
                 Value::from(Dictionary::new(HashMap::from([
@@ -104,11 +104,11 @@ mod tests {
                     // Keys can contain emojis
                     (("🥳".into()), "party time!".into()),
                 ]))),
-                r#"{"Dictionary":[["!@£$%^&&*()",""],["🥳","party time!"],["    hi",{"Int":"0"}],["foo",{"Int":"123"}],["\u0000",""],["","baz"]]}"#,
+                r#"{"Container":{"kind":"d--","kvs":[["!@£$%^&&*()",""],["🥳","party time!"],["    hi",{"Int":"0"}],["foo",{"Int":"123"}],["\u0000",""],["","baz"]]}}"#,
             ),
             (
                 Value::from(Set::new(HashSet::from(["foo".into(), "bar".into()]))),
-                r#"{"Set":[["bar"],["foo"]]}"#,
+                r#"{"Container":{"kind":"-s-","kvs":[["bar"],["foo"]]}}"#,
             ),
         ];
 

--- a/src/middleware/containers.rs
+++ b/src/middleware/containers.rs
@@ -17,7 +17,7 @@ use crate::backends::plonky2::primitives::merkletree::{self, MerkleProof, Merkle
 use crate::{
     backends::plonky2::primitives::merkletree::MerkleTreeStateTransitionProof,
     middleware::{
-        db::{mem::MemDB, DB},
+        db::{self, mem::MemDB, DB, TX},
         Error, Hash, RawValue, Result, StrKey, TypedValue, Value, EMPTY_HASH,
     },
 };
@@ -198,31 +198,32 @@ impl PartialEq for Container {
 }
 impl Eq for Container {}
 
-fn store_container_mt(db: &mut dyn DB, container: &Container) -> Result<()> {
-    match db.load_node(container.root) {
+fn store_container_mt(tx: &mut dyn TX, container: &Container) -> Result<()> {
+    match tx.load_node(container.root) {
         Err(e) => return Err(Error::Database(e)),
         // Container already exists in the DB
         Ok(Some(_)) => return Ok(()),
         // Container not existing, we need to save it
         Ok(None) => {}
     };
-    let mut container_copy = Container::empty_with_db(db.clone_box());
+    let mut root = EMPTY_HASH;
     for kv_result in container.iter() {
         let (k, v) = kv_result?;
-        container_copy.insert(k, v)?;
+        let mtp = insert_tx(tx, root, k, v)?;
+        root = mtp.new_root;
     }
     Ok(())
 }
 
-fn store_value(db: &mut dyn DB, v: Value) -> Result<()> {
+fn store_value(tx: &mut dyn TX, v: Value) -> Result<()> {
     match &v.typed {
-        TypedValue::Container(inner) if db.is_persistent() => store_container_mt(db, inner)?,
-        _ => db.store_value(v).map_err(Error::Database)?,
+        TypedValue::Container(inner) if tx.is_persistent() => store_container_mt(tx, inner)?,
+        _ => tx.store_value(v).map_err(Error::Database)?,
     }
     Ok(())
 }
 
-fn load_value(db: &dyn DB, value_raw: RawValue) -> Result<Value> {
+fn load_value(db: &dyn db::Read, value_raw: RawValue) -> Result<Value> {
     match db.load_value(value_raw) {
         Err(e) => Err(Error::Database(e)),
         Ok(Some(v)) => Ok(v),
@@ -230,6 +231,19 @@ fn load_value(db: &dyn DB, value_raw: RawValue) -> Result<Value> {
             "Value from {value_raw} not found in DB"
         ))),
     }
+}
+
+fn insert_tx(
+    tx: &mut dyn TX,
+    root: Hash,
+    key: Value,
+    value: Value,
+) -> Result<MerkleTreeStateTransitionProof> {
+    let (key_raw, value_raw) = (key.raw(), value.raw());
+    store_value(tx, key)?;
+    store_value(tx, value)?;
+    let mtp = merkletree::insert_tx(tx, root, &key_raw, &value_raw)?;
+    Ok(mtp)
 }
 
 impl Container {
@@ -253,7 +267,8 @@ impl Container {
     pub fn from_db(root: Hash, db: Box<dyn DB>) -> Result<Self> {
         // Make sure the root exists in the db
         let _ = merkletree::load_node(db.as_ref(), root)?;
-        Ok(Self { root, db })
+        let kind = db.load_kind(root).map_err(|e| Error::Database(e))?;
+        Ok(Self { kind, root, db })
     }
     pub fn commitment(&self) -> Hash {
         self.root
@@ -273,12 +288,12 @@ impl Container {
         Ok(self.mt().prove_nonexistence(&key_raw)?)
     }
     fn insert(&mut self, key: Value, value: Value) -> Result<MerkleTreeStateTransitionProof> {
-        let (key_raw, value_raw) = (key.raw(), value.raw());
-        store_value(self.db.as_mut(), key)?;
-        store_value(self.db.as_mut(), value)?;
-        let mut mt = self.mt();
-        let mtp = mt.insert(&key_raw, &value_raw)?;
-        self.root = mt.root();
+        let mut tx = DB::tx(self.db.as_ref());
+        let mtp = insert_tx(tx.as_mut(), self.root, key, value)?;
+        tx.update_kind(mtp.new_root, self.kind)
+            .map_err(|e| Error::Database(e))?;
+        TX::commit(tx).map_err(|e| Error::Database(e))?;
+        self.root = mtp.new_root;
         Ok(mtp)
     }
     pub fn insert_proof(&self, key: Value, value: Value) -> Result<MerkleTreeStateTransitionProof> {
@@ -291,10 +306,13 @@ impl Container {
         value: Value,
     ) -> Result<MerkleTreeStateTransitionProof> {
         let value_raw = value.raw();
-        store_value(self.db.as_mut(), value)?;
-        let mut mt = self.mt();
-        let mtp = mt.update(&key_raw, &value_raw)?;
-        self.root = mt.root();
+        let mut tx = DB::tx(self.db.as_ref());
+        store_value(tx.as_mut(), value)?;
+        let mtp = merkletree::update_tx(tx.as_mut(), self.root, &key_raw, &value_raw)?;
+        tx.update_kind(mtp.new_root, self.kind)
+            .map_err(|e| Error::Database(e))?;
+        TX::commit(tx).map_err(|e| Error::Database(e))?;
+        self.root = mtp.new_root;
         Ok(mtp)
     }
     pub fn update_proof(
@@ -306,9 +324,12 @@ impl Container {
         container.update(key_raw, value)
     }
     fn delete(&mut self, key_raw: RawValue) -> Result<MerkleTreeStateTransitionProof> {
-        let mut mt = self.mt();
-        let mtp = mt.delete(&key_raw)?;
-        self.root = mt.root();
+        let mut tx = DB::tx(self.db.as_ref());
+        let mtp = merkletree::delete_tx(tx.as_mut(), self.root, &key_raw)?;
+        tx.update_kind(mtp.new_root, self.kind)
+            .map_err(|e| Error::Database(e))?;
+        TX::commit(tx).map_err(|e| Error::Database(e))?;
+        self.root = mtp.new_root;
         Ok(mtp)
     }
     pub fn delete_proof(&self, key_raw: RawValue) -> Result<MerkleTreeStateTransitionProof> {
@@ -321,13 +342,13 @@ impl Container {
         key_raw: RawValue,
         value_raw: RawValue,
     ) -> Result<()> {
-        Ok(MerkleTree::verify(root, proof, &key_raw, &value_raw)?)
+        Ok(merkletree::verify(root, proof, &key_raw, &value_raw)?)
     }
     pub fn verify_nonexistence(root: Hash, proof: &MerkleProof, key_raw: RawValue) -> Result<()> {
-        Ok(MerkleTree::verify_nonexistence(root, proof, &key_raw)?)
+        Ok(merkletree::verify_nonexistence(root, proof, &key_raw)?)
     }
     pub fn verify_state_transition(proof: &MerkleTreeStateTransitionProof) -> Result<()> {
-        MerkleTree::verify_state_transition(proof).map_err(|e| e.into())
+        merkletree::verify_state_transition(proof).map_err(|e| e.into())
     }
     pub fn iter(&self) -> impl Iterator<Item = Result<(Value, Value)>> {
         let db = self.db.clone();
@@ -795,8 +816,8 @@ mod tests {
         assert_eq!(kvs0, kvs1);
 
         match &kvs1["y"].typed {
-            TypedValue::Dictionary(d) => {
-                let nested_kvs1 = d.dump().unwrap();
+            TypedValue::Container(d) => {
+                let nested_kvs1 = d.as_dictionary().unwrap().dump().unwrap();
                 assert_eq!(nested_kvs0, nested_kvs1);
             }
             _ => unreachable!(),

--- a/src/middleware/containers.rs
+++ b/src/middleware/containers.rs
@@ -289,6 +289,8 @@ impl PartialEq for Container {
 impl Eq for Container {}
 
 fn store_container_mt(tx: &mut dyn TX, container: &Container) -> Result<()> {
+    tx.update_kind(container.commitment(), container.kind)
+        .map_err(Error::Database)?;
     match tx.load_node(container.root) {
         Err(e) => return Err(Error::Database(e)),
         // Container already exists in the DB
@@ -305,9 +307,10 @@ fn store_container_mt(tx: &mut dyn TX, container: &Container) -> Result<()> {
     Ok(())
 }
 
+// Store a value into the database while flattening nested containers
 fn store_value(tx: &mut dyn TX, v: Value) -> Result<()> {
     match &v.typed {
-        TypedValue::Container(inner) if tx.is_persistent() => store_container_mt(tx, inner)?,
+        TypedValue::Container(inner) => store_container_mt(tx, inner)?,
         _ => tx.store_value(v).map_err(Error::Database)?,
     }
     Ok(())
@@ -318,16 +321,15 @@ fn load_value(db: &dyn db::DB, value_raw: RawValue) -> Result<Value> {
         Err(e) => Err(Error::Database(e)),
         Ok(Some(v)) => Ok(v),
         Ok(None) => {
-            // With a persistent DB we skip storing containers as values and instead store them as
+            // We skip storing containers as values and instead store them as
             // merkle trees via the Container type.
-            if db.is_persistent() {
-                if let Ok(c) = Container::from_db(Hash(value_raw.0), db.clone_box()) {
-                    return Ok(Value::from(c));
-                }
+            if let Ok(c) = Container::from_db(Hash(value_raw.0), db.clone_box()) {
+                Ok(Value::from(c))
+            } else {
+                Err(Error::custom(format!(
+                    "Value from {value_raw} not found in DB"
+                )))
             }
-            Err(Error::custom(format!(
-                "Value from {value_raw} not found in DB"
-            )))
         }
     }
 }
@@ -1021,5 +1023,51 @@ mod tests {
     #[test]
     fn test_kind() {
         test_databases(&_test_kind);
+    }
+
+    fn _test_mem_to_db(db: Box<dyn DB>) {
+        let nested_dict = Dictionary::new(
+            [
+                (StrKey::from("a"), Value::from("a")),
+                (StrKey::from("b"), Value::from("b")),
+            ]
+            .into_iter()
+            .collect(),
+        );
+
+        assert!(nested_dict.inner.kind.is_dictionary());
+        assert!(!nested_dict.inner.kind.is_set());
+        assert!(!nested_dict.inner.kind.is_array());
+
+        let nested_set = Set::new([Value::from("a"), Value::from("b")].into_iter().collect());
+
+        // We intentionally made a collision
+        assert_eq!(nested_dict.commitment(), nested_set.commitment());
+
+        let mut dict0 = Dictionary::empty_with_db(db.clone());
+        dict0
+            .insert(&StrKey::from("x"), &Value::from(nested_dict))
+            .unwrap();
+        dict0
+            .insert(&StrKey::from("y"), &Value::from(nested_set.clone()))
+            .unwrap();
+
+        assert!(dict0
+            .get(&StrKey::from("x"))
+            .unwrap()
+            .unwrap()
+            .as_dictionary()
+            .is_some());
+        assert!(dict0
+            .get(&StrKey::from("y"))
+            .unwrap()
+            .unwrap()
+            .as_set()
+            .is_some());
+    }
+
+    #[test]
+    fn test_mem_to_db() {
+        test_databases(&_test_mem_to_db);
     }
 }

--- a/src/middleware/containers.rs
+++ b/src/middleware/containers.rs
@@ -7,10 +7,7 @@ use std::{
 };
 
 use schemars::JsonSchema;
-use serde::{
-    de::{Error as _, SeqAccess, Visitor},
-    ser, Deserialize, Deserializer, Serialize,
-};
+use serde::{de::Error as _, ser, Deserialize, Deserializer, Serialize};
 
 #[cfg(feature = "backend_plonky2")]
 use crate::backends::plonky2::primitives::merkletree::{self, MerkleProof, MerkleTree};
@@ -25,7 +22,7 @@ use crate::{
 pub const EMPTY_MT_ROOT: Hash = EMPTY_HASH;
 
 /// Bitmask of container type.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub struct ContainerKind(pub(crate) u8);
 
 impl ContainerKind {
@@ -50,6 +47,77 @@ impl ContainerKind {
         self.0 |= 1 << 2;
         self
     }
+    pub fn from_str(s: &str) -> Option<Self> {
+        let s = s.as_bytes();
+        if s.len() != 3 {
+            return None;
+        }
+        let mut kind = Self::default();
+        if s[0] == b'd' {
+            kind.set_dictionary();
+        } else if s[0] != b'-' {
+            return None;
+        }
+        if s[1] == b's' {
+            kind.set_set();
+        } else if s[1] != b'-' {
+            return None;
+        }
+        if s[2] == b'a' {
+            kind.set_array();
+        } else if s[2] != b'-' {
+            return None;
+        }
+        Some(kind)
+    }
+}
+
+impl fmt::Display for ContainerKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.is_dictionary() {
+            true => write!(f, "d")?,
+            false => write!(f, "-")?,
+        }
+        match self.is_set() {
+            true => write!(f, "s")?,
+            false => write!(f, "-")?,
+        }
+        match self.is_array() {
+            true => write!(f, "a")?,
+            false => write!(f, "-")?,
+        }
+        Ok(())
+    }
+}
+
+impl JsonSchema for ContainerKind {
+    fn schema_name() -> String {
+        "ContainerKind".to_string()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        String::json_schema(gen)
+    }
+}
+
+impl Serialize for ContainerKind {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&format!("{}", self))
+    }
+}
+
+impl<'de> Deserialize<'de> for ContainerKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        ContainerKind::from_str(&s)
+            .ok_or_else(|| D::Error::custom("invalid encoding of ContainerKind"))
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -59,14 +127,19 @@ pub struct Container {
     db: Box<dyn DB>,
 }
 
+#[derive(Serialize, Deserialize, JsonSchema)]
+struct SerializedContainer {
+    kind: ContainerKind,
+    kvs: Vec<Vec<Value>>,
+}
+
 impl JsonSchema for Container {
     fn schema_name() -> String {
         "Container".to_string()
     }
 
     fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        // Just use the schema of Vec<Vec<Value>> since that's what we're actually serializing
-        Vec::<Vec<Value>>::json_schema(gen)
+        SerializedContainer::json_schema(gen)
     }
 }
 
@@ -77,38 +150,26 @@ impl Serialize for Container {
     {
         let mut pairs = self
             .iter()
-            .collect::<Result<Vec<(Value, Value)>>>()
+            .map(|result_pair| result_pair.map(|(k, v)| if k == v { vec![v] } else { vec![k, v] }))
+            .collect::<Result<Vec<Vec<Value>>>>()
             .map_err(ser::Error::custom)?;
-        pairs.sort_by(|(k1, _), (k2, _)| k1.raw().cmp(&k2.raw()));
-        // Serialize as an array
-        use serde::ser::SerializeSeq;
-        let mut seq = serializer.serialize_seq(Some(pairs.len()))?;
-        for (k, v) in pairs {
-            if k == v {
-                seq.serialize_element(&[&v])?;
-            } else {
-                seq.serialize_element(&[&k, &v])?;
-            }
+        pairs.sort_by(|pair_l, pair_r| pair_l[0].raw().cmp(&pair_r[0].raw()));
+        SerializedContainer {
+            kind: self.kind,
+            kvs: pairs,
         }
-        seq.end()
+        .serialize(serializer)
     }
 }
 
-struct ContainerVisitor;
-
-impl<'de> Visitor<'de> for ContainerVisitor {
-    type Value = HashMap<Value, Value>;
-
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("a sequence of `[Value]` or `[Value, Value]`")
-    }
-
-    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+impl<'de> Deserialize<'de> for Container {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        A: SeqAccess<'de>,
+        D: serde::Deserializer<'de>,
     {
+        let c = SerializedContainer::deserialize(deserializer)?;
         let mut kvs = HashMap::<Value, Value>::new();
-        while let Some(mut elem) = seq.next_element::<Vec<Value>>()? {
+        for mut elem in c.kvs {
             match elem.len() {
                 1 => {
                     let v = elem.pop().unwrap();
@@ -119,24 +180,13 @@ impl<'de> Visitor<'de> for ContainerVisitor {
                     kvs.insert(k, v);
                 }
                 n => {
-                    return Err(A::Error::custom(format!(
+                    return Err(D::Error::custom(format!(
                         "invalid vec length of {n} in container entry"
                     )))
                 }
             }
         }
-
-        Ok(kvs)
-    }
-}
-
-impl<'de> Deserialize<'de> for Container {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let kvs = deserializer.deserialize_seq(ContainerVisitor)?;
-        Ok(Container::new(kvs))
+        Ok(Container::new(c.kind, kvs))
     }
 }
 
@@ -223,13 +273,23 @@ fn store_value(tx: &mut dyn TX, v: Value) -> Result<()> {
     Ok(())
 }
 
-fn load_value(db: &dyn db::Read, value_raw: RawValue) -> Result<Value> {
+fn load_value(db: &dyn db::DB, value_raw: RawValue) -> Result<Value> {
     match db.load_value(value_raw) {
         Err(e) => Err(Error::Database(e)),
         Ok(Some(v)) => Ok(v),
-        Ok(None) => Err(Error::custom(format!(
-            "Value from {value_raw} not found in DB"
-        ))),
+        Ok(None) => {
+            // With a persistent DB we skip storing containers as values and instead store them as
+            // merkle trees via the Container type.
+            if db.is_persistent() {
+                match Container::from_db(Hash(value_raw.0), db.clone_box()) {
+                    Ok(c) => return Ok(Value::from(c)),
+                    _ => {}
+                }
+            }
+            Err(Error::custom(format!(
+                "Value from {value_raw} not found in DB"
+            )))
+        }
     }
 }
 
@@ -253,12 +313,13 @@ impl Container {
     pub fn mt(&self) -> MerkleTree {
         MerkleTree::from_db(self.root, self.db.clone())
     }
-    fn new(kvs: HashMap<Value, Value>) -> Self {
+    fn new(kind: ContainerKind, kvs: HashMap<Value, Value>) -> Self {
         let db = Box::new(MemDB::new());
         let mut container = Self::empty_with_db(db);
         for (k, v) in kvs {
             container.insert(k, v).expect("no duplicates, no db errors");
         }
+        container.kind = kind;
         container
     }
     fn empty_with_db(db: Box<dyn DB>) -> Self {
@@ -424,6 +485,7 @@ impl Dictionary {
     pub fn new(kvs: HashMap<StrKey, Value>) -> Self {
         Self {
             inner: Container::new(
+                *ContainerKind::default().set_dictionary(),
                 kvs.into_iter()
                     .map(|(k, v)| (Value::from(k.into_name()), v))
                     .collect(),
@@ -514,7 +576,10 @@ pub struct Set {
 impl Set {
     pub fn new(set: HashSet<Value>) -> Self {
         Self {
-            inner: Container::new(set.into_iter().map(|v| (v.clone(), v)).collect()),
+            inner: Container::new(
+                *ContainerKind::default().set_set(),
+                set.into_iter().map(|v| (v.clone(), v)).collect(),
+            ),
         }
     }
     pub fn empty_with_db(db: Box<dyn DB>) -> Self {
@@ -595,6 +660,7 @@ impl Array {
     pub fn new(array: Vec<Value>) -> Self {
         Self {
             inner: Container::new(
+                *ContainerKind::default().set_array(),
                 array
                     .into_iter()
                     .enumerate()
@@ -610,7 +676,7 @@ impl Array {
     }
     pub fn from_db(root: Hash, db: Box<dyn DB>) -> Result<Self> {
         Container::from_db(root, db)?
-            .as_set()
+            .as_array()
             .ok_or_else(|| Error::custom("not an array"))
     }
     pub fn commitment(&self) -> Hash {
@@ -710,19 +776,6 @@ mod tests {
                 "kind mismatch: {value} came back as {back}"
             );
         }
-    }
-
-    /// A tagged container claiming a kind its contents violate must be
-    /// rejected rather than constructed.
-    #[test]
-    fn mistagged_container_is_rejected() {
-        // Dictionary content under a Set tag: entries have key != value.
-        let dict = Value::from(Dictionary::new(
-            [(StrKey::from("score"), Value::from(42))].into(),
-        ));
-        let json = serde_json::to_string(&dict).unwrap();
-        let mistagged = json.replacen("Dictionary", "Set", 1);
-        assert!(serde_json::from_str::<Value>(&mistagged).is_err());
     }
 
     fn test_databases(test_fn: &dyn Fn(Box<dyn DB>)) {

--- a/src/middleware/containers.rs
+++ b/src/middleware/containers.rs
@@ -22,7 +22,7 @@ use crate::{
 
 pub const EMPTY_MT_ROOT: Hash = EMPTY_HASH;
 
-/// Bitmask of container type.  We have three contianer types: Dictionary, Set and Array, and all
+/// Bitmask of container type.  We have three container types: Dictionary, Set and Array, and all
 /// of them are backed up by a MerkleTree.  The three container types internally map to a key-value
 /// where key is Value and value is Value, but they use different rules:
 /// - The Dictionary uses String (as a Value) for the key

--- a/src/middleware/containers.rs
+++ b/src/middleware/containers.rs
@@ -267,7 +267,10 @@ impl Container {
     pub fn from_db(root: Hash, db: Box<dyn DB>) -> Result<Self> {
         // Make sure the root exists in the db
         let _ = merkletree::load_node(db.as_ref(), root)?;
-        let kind = db.load_kind(root).map_err(|e| Error::Database(e))?;
+        let kind = db
+            .load_kind(root)
+            .map_err(|e| Error::Database(e))?
+            .ok_or_else(|| Error::custom("container kind not found"))?;
         Ok(Self { kind, root, db })
     }
     pub fn commitment(&self) -> Hash {
@@ -364,27 +367,27 @@ impl Container {
     }
     pub fn as_dictionary(&self) -> Option<Dictionary> {
         if self.kind.is_dictionary() {
-            Some(Dictionary {
-                inner: self.clone(),
-            })
+            let mut inner = self.clone();
+            inner.kind = *ContainerKind::default().set_dictionary();
+            Some(Dictionary { inner })
         } else {
             None
         }
     }
     pub fn as_set(&self) -> Option<Set> {
         if self.kind.is_set() {
-            Some(Set {
-                inner: self.clone(),
-            })
+            let mut inner = self.clone();
+            inner.kind = *ContainerKind::default().set_set();
+            Some(Set { inner })
         } else {
             None
         }
     }
     pub fn as_array(&self) -> Option<Array> {
         if self.kind.is_array() {
-            Some(Array {
-                inner: self.clone(),
-            })
+            let mut inner = self.clone();
+            inner.kind = *ContainerKind::default().set_array();
+            Some(Array { inner })
         } else {
             None
         }
@@ -433,9 +436,9 @@ impl Dictionary {
         }
     }
     pub fn from_db(root: Hash, db: Box<dyn DB>) -> Result<Self> {
-        Ok(Self {
-            inner: Container::from_db(root, db)?,
-        })
+        Container::from_db(root, db)?
+            .as_dictionary()
+            .ok_or_else(|| Error::custom("not a dictionary"))
     }
     pub fn commitment(&self) -> Hash {
         self.inner.commitment()
@@ -520,9 +523,9 @@ impl Set {
         }
     }
     pub fn from_db(root: Hash, db: Box<dyn DB>) -> Result<Self> {
-        Ok(Self {
-            inner: Container::from_db(root, db)?,
-        })
+        Container::from_db(root, db)?
+            .as_set()
+            .ok_or_else(|| Error::custom("not a set"))
     }
     pub fn commitment(&self) -> Hash {
         self.inner.commitment()
@@ -606,9 +609,9 @@ impl Array {
         }
     }
     pub fn from_db(root: Hash, db: Box<dyn DB>) -> Result<Self> {
-        Ok(Self {
-            inner: Container::from_db(root, db)?,
-        })
+        Container::from_db(root, db)?
+            .as_set()
+            .ok_or_else(|| Error::custom("not an array"))
     }
     pub fn commitment(&self) -> Hash {
         self.inner.commitment()

--- a/src/middleware/containers.rs
+++ b/src/middleware/containers.rs
@@ -21,7 +21,30 @@ use crate::{
 
 pub const EMPTY_MT_ROOT: Hash = EMPTY_HASH;
 
-/// Bitmask of container type.
+/// Bitmask of container type.  We have three contianer types: Dictionary, Set and Array, and all
+/// of them are backed up by a MerkleTree.  The three container types internally map to a key-value
+/// where key is Value and value is Value, but they use different rules:
+/// - The Dictionary uses String (as a Value) for the key
+/// - The Array uses non-negative Int (as a Value) for the key
+/// - The Set uses key = value
+/// Because of this we can have containers that can be different types at the same time, for
+/// example:
+/// - Dict{"a": "a"} == Set{"a"}
+/// - Dict{"a": "a", "b": "b"} = Set{"a", "b"}
+/// - Array[0] == Set{0}
+/// - Array[0, 1] = Set{0, 1}
+/// - Dict{} == Array[] == Set{}
+///
+/// For this reason we use a bitmask for the generic Container to flag what kind of container type
+/// it can be used as.  Usually only one bit will be set, but in the case of an edge case like the
+/// ones above, multiple bits will be set.
+///
+/// When using a persistent database we store this container indexed by the root of the container,
+/// and we update it to store all the container types seen for each root by ORing the mask so that
+/// no information is lost.
+///
+/// The string encoding of this bitmask contains three characters which are `d,s,a` or `-`
+/// depending on whether the bit flag is set or not for each of Dictionary, Set and Array.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub struct ContainerKind(pub(crate) u8);
 
@@ -168,8 +191,26 @@ impl<'de> Deserialize<'de> for Container {
         D: serde::Deserializer<'de>,
     {
         let c = SerializedContainer::deserialize(deserializer)?;
+        let is_dictionary = c.kind.is_dictionary();
+        let is_set = c.kind.is_set();
+        let is_array = c.kind.is_array();
         let mut kvs = HashMap::<Value, Value>::new();
         for mut elem in c.kvs {
+            let Some(key) = elem.first() else {
+                return Err(D::Error::custom(format!(
+                    "invalid container: elem.length() = 0"
+                )));
+            };
+            // Type validation
+            if is_set && elem.len() != 1 {
+                return Err(D::Error::custom("not a set: elem.len != 1"));
+            }
+            if is_array && !matches!(&key.typed, TypedValue::Int(i) if *i >= 0) {
+                return Err(D::Error::custom("not an array: non-index key"));
+            }
+            if is_dictionary && !matches!(&key.typed, TypedValue::String(_)) {
+                return Err(D::Error::custom("not a dictionary: non-string key"));
+            }
             match elem.len() {
                 1 => {
                     let v = elem.pop().unwrap();
@@ -190,21 +231,18 @@ impl<'de> Deserialize<'de> for Container {
     }
 }
 
-// Enforce the same rules about key types and key-value relationships that
-// are enforced by Dictionary/Set/Array constructors.
+// Validate inner container type during deserialization.
 
 impl<'de> Deserialize<'de> for Set {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        let inner = Container::deserialize(deserializer)?;
-        for kv in inner.iter() {
-            let (key, value) = kv.map_err(D::Error::custom)?;
-            if key != value {
-                return Err(D::Error::custom("not a set: entry key != value"));
-            }
+        let mut inner = Container::deserialize(deserializer)?;
+        if !inner.kind.is_set() {
+            return Err(D::Error::custom("container not a set"));
         }
+        inner.kind = *ContainerKind::default().set_set();
         Ok(Set { inner })
     }
 }
@@ -214,13 +252,11 @@ impl<'de> Deserialize<'de> for Dictionary {
     where
         D: Deserializer<'de>,
     {
-        let inner = Container::deserialize(deserializer)?;
-        for kv in inner.iter() {
-            let (key, _) = kv.map_err(D::Error::custom)?;
-            if !matches!(&key.typed, TypedValue::String(_)) {
-                return Err(D::Error::custom("not a dictionary: non-string key"));
-            }
+        let mut inner = Container::deserialize(deserializer)?;
+        if !inner.kind.is_dictionary() {
+            return Err(D::Error::custom("container not a dictionary"));
         }
+        inner.kind = *ContainerKind::default().set_dictionary();
         Ok(Dictionary { inner })
     }
 }
@@ -230,13 +266,11 @@ impl<'de> Deserialize<'de> for Array {
     where
         D: Deserializer<'de>,
     {
-        let inner = Container::deserialize(deserializer)?;
-        for kv in inner.iter() {
-            let (key, _) = kv.map_err(D::Error::custom)?;
-            if !matches!(&key.typed, TypedValue::Int(i) if *i >= 0) {
-                return Err(D::Error::custom("not an array: non-index key"));
-            }
+        let mut inner = Container::deserialize(deserializer)?;
+        if !inner.kind.is_array() {
+            return Err(D::Error::custom("container not an array"));
         }
+        inner.kind = *ContainerKind::default().set_array();
         Ok(Array { inner })
     }
 }
@@ -426,6 +460,8 @@ impl Container {
     pub fn dump(&self) -> Result<HashMap<Value, Value>> {
         self.iter().collect()
     }
+    /// Casting methods narrow the kind in the container so that future write operations only
+    /// record future container roots as that particular kind.
     pub fn as_dictionary(&self) -> Option<Dictionary> {
         if self.kind.is_dictionary() {
             let mut inner = self.clone();
@@ -493,9 +529,9 @@ impl Dictionary {
         }
     }
     pub fn empty_with_db(db: Box<dyn DB>) -> Self {
-        Self {
-            inner: Container::empty_with_db(db),
-        }
+        Container::empty_with_db(db)
+            .as_dictionary()
+            .expect("empty container can be anything")
     }
     pub fn from_db(root: Hash, db: Box<dyn DB>) -> Result<Self> {
         Container::from_db(root, db)?
@@ -583,9 +619,9 @@ impl Set {
         }
     }
     pub fn empty_with_db(db: Box<dyn DB>) -> Self {
-        Self {
-            inner: Container::empty_with_db(db),
-        }
+        Container::empty_with_db(db)
+            .as_set()
+            .expect("empty container can be anything")
     }
     pub fn from_db(root: Hash, db: Box<dyn DB>) -> Result<Self> {
         Container::from_db(root, db)?
@@ -670,9 +706,9 @@ impl Array {
         }
     }
     pub fn empty_with_db(db: Box<dyn DB>) -> Self {
-        Self {
-            inner: Container::empty_with_db(db),
-        }
+        Container::empty_with_db(db)
+            .as_array()
+            .expect("empty container can be anything")
     }
     pub fn from_db(root: Hash, db: Box<dyn DB>) -> Result<Self> {
         Container::from_db(root, db)?
@@ -919,6 +955,66 @@ mod tests {
         println!("a: {}", serde_json::to_string(&a).unwrap());
         println!("b: {}", serde_json::to_string(&b).unwrap());
         let top = Array::new(vec![a, b]);
-        println!("top: {}", serde_json::to_string(&top).unwrap());
+        let top_json = serde_json::to_string(&top).unwrap();
+        println!("top: {}", top_json);
+        assert_eq!(
+            top_json,
+            r#"{"kind":"--a","kvs":[[{"Int":"0"},{"Container":{"kind":"ds-","kvs":[["a"]]}}],[{"Int":"1"},{"Container":{"kind":"ds-","kvs":[["a"]]}}]]}"#
+        );
+    }
+
+    fn _test_kind(db: Box<dyn DB>) {
+        let mut nested_dict = Dictionary::empty_with_db(db.clone());
+        nested_dict
+            .insert(&StrKey::from("a"), &Value::from("a"))
+            .unwrap();
+        nested_dict
+            .insert(&StrKey::from("b"), &Value::from("b"))
+            .unwrap();
+
+        assert!(nested_dict.inner.kind.is_dictionary());
+        assert!(!nested_dict.inner.kind.is_set());
+        assert!(!nested_dict.inner.kind.is_array());
+
+        // Only observed the container as a Dictionary, not a Set
+        assert!(Dictionary::from_db(nested_dict.commitment(), db.clone()).is_ok());
+        assert!(Set::from_db(nested_dict.commitment(), db.clone()).is_err());
+
+        let mut nested_set = Set::empty_with_db(db.clone());
+        nested_set.insert(&Value::from("a")).unwrap();
+        nested_set.insert(&Value::from("b")).unwrap();
+
+        // We intentionally made a collision
+        assert_eq!(nested_dict.commitment(), nested_set.commitment());
+
+        // Observed the container both as a Dictionary and a Set
+        assert!(Dictionary::from_db(nested_dict.commitment(), db.clone()).is_ok());
+        assert!(Set::from_db(nested_dict.commitment(), db.clone()).is_ok());
+
+        let mut dict0 = Dictionary::empty_with_db(db.clone());
+        dict0
+            .insert(&StrKey::from("x"), &Value::from(nested_dict))
+            .unwrap();
+        dict0
+            .insert(&StrKey::from("y"), &Value::from(nested_set.clone()))
+            .unwrap();
+
+        assert!(dict0
+            .get(&StrKey::from("x"))
+            .unwrap()
+            .unwrap()
+            .as_dictionary()
+            .is_some());
+        assert!(dict0
+            .get(&StrKey::from("y"))
+            .unwrap()
+            .unwrap()
+            .as_set()
+            .is_some());
+    }
+
+    #[test]
+    fn test_kind() {
+        test_databases(&_test_kind);
     }
 }

--- a/src/middleware/containers.rs
+++ b/src/middleware/containers.rs
@@ -4,6 +4,7 @@
 use std::{
     collections::{HashMap, HashSet},
     fmt::{self, Debug},
+    str::FromStr,
 };
 
 use schemars::JsonSchema;
@@ -27,6 +28,7 @@ pub const EMPTY_MT_ROOT: Hash = EMPTY_HASH;
 /// - The Dictionary uses String (as a Value) for the key
 /// - The Array uses non-negative Int (as a Value) for the key
 /// - The Set uses key = value
+///
 /// Because of this we can have containers that can be different types at the same time, for
 /// example:
 /// - Dict{"a": "a"} == Set{"a"}
@@ -70,28 +72,32 @@ impl ContainerKind {
         self.0 |= 1 << 2;
         self
     }
-    pub fn from_str(s: &str) -> Option<Self> {
+}
+
+impl FromStr for ContainerKind {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self> {
         let s = s.as_bytes();
         if s.len() != 3 {
-            return None;
+            return Err(Error::custom("invalid length"));
         }
         let mut kind = Self::default();
         if s[0] == b'd' {
             kind.set_dictionary();
         } else if s[0] != b'-' {
-            return None;
+            return Err(Error::custom("invalid char at pos 0"));
         }
         if s[1] == b's' {
             kind.set_set();
         } else if s[1] != b'-' {
-            return None;
+            return Err(Error::custom("invalid char at pos 1"));
         }
         if s[2] == b'a' {
             kind.set_array();
         } else if s[2] != b'-' {
-            return None;
+            return Err(Error::custom("invalid char at pos 2"));
         }
-        Some(kind)
+        Ok(kind)
     }
 }
 
@@ -139,7 +145,7 @@ impl<'de> Deserialize<'de> for ContainerKind {
     {
         let s = String::deserialize(deserializer)?;
         ContainerKind::from_str(&s)
-            .ok_or_else(|| D::Error::custom("invalid encoding of ContainerKind"))
+            .map_err(|e| D::Error::custom(format!("invalid encoding of ContainerKind {e}")))
     }
 }
 
@@ -197,9 +203,9 @@ impl<'de> Deserialize<'de> for Container {
         let mut kvs = HashMap::<Value, Value>::new();
         for mut elem in c.kvs {
             let Some(key) = elem.first() else {
-                return Err(D::Error::custom(format!(
-                    "invalid container: elem.length() = 0"
-                )));
+                return Err(D::Error::custom(
+                    "invalid container: elem.length() = 0".to_string(),
+                ));
             };
             // Type validation
             if is_set && elem.len() != 1 {
@@ -315,9 +321,8 @@ fn load_value(db: &dyn db::DB, value_raw: RawValue) -> Result<Value> {
             // With a persistent DB we skip storing containers as values and instead store them as
             // merkle trees via the Container type.
             if db.is_persistent() {
-                match Container::from_db(Hash(value_raw.0), db.clone_box()) {
-                    Ok(c) => return Ok(Value::from(c)),
-                    _ => {}
+                if let Ok(c) = Container::from_db(Hash(value_raw.0), db.clone_box()) {
+                    return Ok(Value::from(c));
                 }
             }
             Err(Error::custom(format!(
@@ -364,7 +369,7 @@ impl Container {
         let _ = merkletree::load_node(db.as_ref(), root)?;
         let kind = db
             .load_kind(root)
-            .map_err(|e| Error::Database(e))?
+            .map_err(Error::Database)?
             .ok_or_else(|| Error::custom("container kind not found"))?;
         Ok(Self { kind, root, db })
     }
@@ -389,8 +394,8 @@ impl Container {
         let mut tx = DB::tx(self.db.as_ref());
         let mtp = insert_tx(tx.as_mut(), self.root, key, value)?;
         tx.update_kind(mtp.new_root, self.kind)
-            .map_err(|e| Error::Database(e))?;
-        TX::commit(tx).map_err(|e| Error::Database(e))?;
+            .map_err(Error::Database)?;
+        TX::commit(tx).map_err(Error::Database)?;
         self.root = mtp.new_root;
         Ok(mtp)
     }
@@ -408,8 +413,8 @@ impl Container {
         store_value(tx.as_mut(), value)?;
         let mtp = merkletree::update_tx(tx.as_mut(), self.root, &key_raw, &value_raw)?;
         tx.update_kind(mtp.new_root, self.kind)
-            .map_err(|e| Error::Database(e))?;
-        TX::commit(tx).map_err(|e| Error::Database(e))?;
+            .map_err(Error::Database)?;
+        TX::commit(tx).map_err(Error::Database)?;
         self.root = mtp.new_root;
         Ok(mtp)
     }
@@ -425,8 +430,8 @@ impl Container {
         let mut tx = DB::tx(self.db.as_ref());
         let mtp = merkletree::delete_tx(tx.as_mut(), self.root, &key_raw)?;
         tx.update_kind(mtp.new_root, self.kind)
-            .map_err(|e| Error::Database(e))?;
-        TX::commit(tx).map_err(|e| Error::Database(e))?;
+            .map_err(Error::Database)?;
+        TX::commit(tx).map_err(Error::Database)?;
         self.root = mtp.new_root;
         Ok(mtp)
     }

--- a/src/middleware/containers.rs
+++ b/src/middleware/containers.rs
@@ -24,8 +24,37 @@ use crate::{
 
 pub const EMPTY_MT_ROOT: Hash = EMPTY_HASH;
 
+/// Bitmask of container type.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
+pub struct ContainerKind(pub(crate) u8);
+
+impl ContainerKind {
+    pub fn is_dictionary(&self) -> bool {
+        self.0 & (1 << 0) != 0
+    }
+    pub fn is_set(&self) -> bool {
+        self.0 & (1 << 1) != 0
+    }
+    pub fn is_array(&self) -> bool {
+        self.0 & (1 << 2) != 0
+    }
+    pub(crate) fn set_dictionary(&mut self) -> &mut Self {
+        self.0 |= 1 << 0;
+        self
+    }
+    pub(crate) fn set_set(&mut self) -> &mut Self {
+        self.0 |= 1 << 1;
+        self
+    }
+    pub(crate) fn set_array(&mut self) -> &mut Self {
+        self.0 |= 1 << 2;
+        self
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Container {
+    pub(crate) kind: ContainerKind,
     root: Hash,
     db: Box<dyn DB>,
 }
@@ -187,14 +216,7 @@ fn store_container_mt(db: &mut dyn DB, container: &Container) -> Result<()> {
 
 fn store_value(db: &mut dyn DB, v: Value) -> Result<()> {
     match &v.typed {
-        TypedValue::Set(Set { inner })
-        | TypedValue::Dictionary(Dictionary { inner })
-        | TypedValue::Array(Array { inner }) => {
-            if db.is_persistent() {
-                store_container_mt(db, inner)?;
-            }
-            db.store_value(v).map_err(Error::Database)?
-        }
+        TypedValue::Container(inner) if db.is_persistent() => store_container_mt(db, inner)?,
         _ => db.store_value(v).map_err(Error::Database)?,
     }
     Ok(())
@@ -211,10 +233,13 @@ fn load_value(db: &dyn DB, value_raw: RawValue) -> Result<Value> {
 }
 
 impl Container {
-    fn mt(&self) -> MerkleTree {
+    pub fn kind(&self) -> ContainerKind {
+        self.kind
+    }
+    pub fn mt(&self) -> MerkleTree {
         MerkleTree::from_db(self.root, self.db.clone())
     }
-    pub fn new(kvs: HashMap<Value, Value>) -> Self {
+    fn new(kvs: HashMap<Value, Value>) -> Self {
         let db = Box::new(MemDB::new());
         let mut container = Self::empty_with_db(db);
         for (k, v) in kvs {
@@ -222,7 +247,7 @@ impl Container {
         }
         container
     }
-    pub fn empty_with_db(db: Box<dyn DB>) -> Self {
+    fn empty_with_db(db: Box<dyn DB>) -> Self {
         Self::from_db(EMPTY_HASH, db).expect("EMPTY_HASH exists implicitly")
     }
     pub fn from_db(root: Hash, db: Box<dyn DB>) -> Result<Self> {
@@ -247,7 +272,7 @@ impl Container {
     pub fn prove_nonexistence(&self, key_raw: RawValue) -> Result<MerkleProof> {
         Ok(self.mt().prove_nonexistence(&key_raw)?)
     }
-    pub fn insert(&mut self, key: Value, value: Value) -> Result<MerkleTreeStateTransitionProof> {
+    fn insert(&mut self, key: Value, value: Value) -> Result<MerkleTreeStateTransitionProof> {
         let (key_raw, value_raw) = (key.raw(), value.raw());
         store_value(self.db.as_mut(), key)?;
         store_value(self.db.as_mut(), value)?;
@@ -256,7 +281,11 @@ impl Container {
         self.root = mt.root();
         Ok(mtp)
     }
-    pub fn update(
+    pub fn insert_proof(&self, key: Value, value: Value) -> Result<MerkleTreeStateTransitionProof> {
+        let mut container = self.clone();
+        container.insert(key, value)
+    }
+    fn update(
         &mut self,
         key_raw: RawValue,
         value: Value,
@@ -268,11 +297,23 @@ impl Container {
         self.root = mt.root();
         Ok(mtp)
     }
-    pub fn delete(&mut self, key_raw: RawValue) -> Result<MerkleTreeStateTransitionProof> {
+    pub fn update_proof(
+        &self,
+        key_raw: RawValue,
+        value: Value,
+    ) -> Result<MerkleTreeStateTransitionProof> {
+        let mut container = self.clone();
+        container.update(key_raw, value)
+    }
+    fn delete(&mut self, key_raw: RawValue) -> Result<MerkleTreeStateTransitionProof> {
         let mut mt = self.mt();
         let mtp = mt.delete(&key_raw)?;
         self.root = mt.root();
         Ok(mtp)
+    }
+    pub fn delete_proof(&self, key_raw: RawValue) -> Result<MerkleTreeStateTransitionProof> {
+        let mut container = self.clone();
+        container.delete(key_raw)
     }
     pub fn verify(
         root: Hash,
@@ -299,6 +340,33 @@ impl Container {
     /// This is an expensive operation
     pub fn dump(&self) -> Result<HashMap<Value, Value>> {
         self.iter().collect()
+    }
+    pub fn as_dictionary(&self) -> Option<Dictionary> {
+        if self.kind.is_dictionary() {
+            Some(Dictionary {
+                inner: self.clone(),
+            })
+        } else {
+            None
+        }
+    }
+    pub fn as_set(&self) -> Option<Set> {
+        if self.kind.is_set() {
+            Some(Set {
+                inner: self.clone(),
+            })
+        } else {
+            None
+        }
+    }
+    pub fn as_array(&self) -> Option<Array> {
+        if self.kind.is_array() {
+            Some(Array {
+                inner: self.clone(),
+            })
+        } else {
+            None
+        }
     }
 }
 
@@ -760,5 +828,20 @@ mod tests {
         assert_eq!(EMPTY_MT_ROOT, Array::new(Vec::new()).commitment());
         assert_eq!(EMPTY_MT_ROOT, Set::new(HashSet::new()).commitment());
         assert_eq!(EMPTY_MT_ROOT, Dictionary::new(HashMap::new()).commitment());
+    }
+
+    #[test]
+    fn same_roots() {
+        let mut a = Dictionary::new(HashMap::new());
+        a.insert(&StrKey::new("a".to_string()), &Value::from("a".to_string()))
+            .unwrap();
+        let a = Value::from(a);
+        let mut b = Set::new(HashSet::new());
+        b.insert(&Value::from("a".to_string())).unwrap();
+        let b = Value::from(b);
+        println!("a: {}", serde_json::to_string(&a).unwrap());
+        println!("b: {}", serde_json::to_string(&b).unwrap());
+        let top = Array::new(vec![a, b]);
+        println!("top: {}", serde_json::to_string(&top).unwrap());
     }
 }

--- a/src/middleware/db/mem.rs
+++ b/src/middleware/db/mem.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::middleware::TypedValue;
 
 /// MemDB implements the DB trait in a in-memory HashMap.
 #[derive(Clone, Debug, Default)]
@@ -14,7 +13,7 @@ impl MemDB {
     }
 }
 
-impl merkletree::db::DB for MemDB {
+impl merkletree::db::Read for MemDB {
     fn load_node(&self, hash: Hash) -> anyhow::Result<Option<merkletree::Node>> {
         let nodes = self.nodes.read().expect("lock not poisoned");
 
@@ -26,38 +25,53 @@ impl merkletree::db::DB for MemDB {
 
         Ok(nodes.get(&hash).cloned())
     }
-
-    fn store_node(&mut self, node: merkletree::Node) -> anyhow::Result<()> {
-        let mut nodes = self.nodes.write().expect("lock not poisoned");
-        nodes.insert(node.hash(), node);
-        Ok(())
-    }
 }
 
-impl DB for MemDB {
+impl merkletree::db::DB for MemDB {
+    fn tx<'a>(&'a self) -> Box<dyn merkletree::db::TX + 'a> {
+        todo!()
+    }
+
+    // fn store_node(&mut self, node: merkletree::Node) -> anyhow::Result<()> {
+    //     let mut nodes = self.nodes.write().expect("lock not poisoned");
+    //     nodes.insert(node.hash(), node);
+    //     Ok(())
+    // }
+}
+
+impl Read for MemDB {
     fn load_value(&self, raw: RawValue) -> anyhow::Result<Option<Value>> {
         let values = self.values.read().expect("lock not poisoned");
 
         Ok(values.get(&raw).cloned())
     }
-    fn store_value(&mut self, mut value: Value) -> anyhow::Result<()> {
-        let mut values = self.values.write().expect("lock not poisoned");
-        let value_raw = value.raw();
-        if let Some(old_value) = values.get(&value_raw) {
-            // Never overwrite an old value with a RawValue.
-            if value.is_raw() {
-                return Ok(());
-            }
-            // If a container was previously stored, update the kind bitmask
-            if let (TypedValue::Container(old_c), TypedValue::Container(ref mut c)) =
-                (&old_value.typed, &mut value.typed)
-            {
-                c.kind.0 |= old_c.kind.0;
-            }
-        };
-        values.insert(value_raw, value);
-        Ok(())
+    fn load_kind(&self, root: Hash) -> anyhow::Result<ContainerKind> {
+        todo!()
     }
+}
+
+impl DB for MemDB {
+    fn tx<'a>(&'a self) -> Box<dyn TX + 'a> {
+        todo!()
+    }
+    // fn store_value(&mut self, mut value: Value) -> anyhow::Result<()> {
+    //     let mut values = self.values.write().expect("lock not poisoned");
+    //     let value_raw = value.raw();
+    //     if let Some(old_value) = values.get(&value_raw) {
+    //         // Never overwrite an old value with a RawValue.
+    //         if value.is_raw() {
+    //             return Ok(());
+    //         }
+    //         // If a container was previously stored, update the kind bitmask
+    //         if let (TypedValue::Container(old_c), TypedValue::Container(ref mut c)) =
+    //             (&old_value.typed, &mut value.typed)
+    //         {
+    //             c.kind.0 |= old_c.kind.0;
+    //         }
+    //     };
+    //     values.insert(value_raw, value);
+    //     Ok(())
+    // }
     fn is_persistent(&self) -> bool {
         false
     }

--- a/src/middleware/db/mem.rs
+++ b/src/middleware/db/mem.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::middleware::TypedValue;
 
 /// MemDB implements the DB trait in a in-memory HashMap.
 #[derive(Clone, Debug, Default)]
@@ -39,17 +40,21 @@ impl DB for MemDB {
 
         Ok(values.get(&raw).cloned())
     }
-    fn store_value(&mut self, value: Value) -> anyhow::Result<()> {
+    fn store_value(&mut self, mut value: Value) -> anyhow::Result<()> {
         let mut values = self.values.write().expect("lock not poisoned");
         let value_raw = value.raw();
         if let Some(old_value) = values.get(&value_raw) {
-            let old_is_raw = old_value.is_raw();
-            // If we had a non-RawValue stored don't overwrite it (specially not with a
-            // RawValue).   Also skip redundant RawValue overwrite.
-            if !old_is_raw || value.is_raw() {
+            // Never overwrite an old value with a RawValue.
+            if value.is_raw() {
                 return Ok(());
             }
-        }
+            // If a container was previously stored, update the kind bitmask
+            if let (TypedValue::Container(old_c), TypedValue::Container(ref mut c)) =
+                (&old_value.typed, &mut value.typed)
+            {
+                c.kind.0 |= old_c.kind.0;
+            }
+        };
         values.insert(value_raw, value);
         Ok(())
     }

--- a/src/middleware/db/mem.rs
+++ b/src/middleware/db/mem.rs
@@ -1,7 +1,7 @@
 use std::sync::RwLockWriteGuard;
 
 use super::*;
-use crate::middleware::TypedValue;
+use crate::middleware::{TypedValue, EMPTY_HASH};
 
 #[derive(Default, Debug)]
 struct Store {
@@ -41,6 +41,14 @@ impl Read for MemDB {
         Ok(store.values.get(&raw).cloned())
     }
     fn load_kind(&self, root: Hash) -> anyhow::Result<Option<ContainerKind>> {
+        if root == EMPTY_HASH {
+            return Ok(Some(
+                *ContainerKind::default()
+                    .set_dictionary()
+                    .set_set()
+                    .set_array(),
+            ));
+        }
         let store = self.db.read().expect("lock not poisoned");
         Ok(store.kinds.get(&root).cloned())
     }
@@ -93,6 +101,14 @@ impl<'a> Read for MemTx<'a> {
             .cloned())
     }
     fn load_kind(&self, root: Hash) -> anyhow::Result<Option<ContainerKind>> {
+        if root == EMPTY_HASH {
+            return Ok(Some(
+                *ContainerKind::default()
+                    .set_dictionary()
+                    .set_set()
+                    .set_array(),
+            ));
+        }
         Ok(self
             .tmp
             .kinds

--- a/src/middleware/db/mem.rs
+++ b/src/middleware/db/mem.rs
@@ -1,10 +1,19 @@
+use std::sync::RwLockWriteGuard;
+
 use super::*;
+use crate::middleware::TypedValue;
+
+#[derive(Default, Debug)]
+struct Store {
+    values: HashMap<RawValue, Value>,
+    kinds: HashMap<Hash, ContainerKind>,
+}
 
 /// MemDB implements the DB trait in a in-memory HashMap.
 #[derive(Clone, Debug, Default)]
 pub struct MemDB {
-    nodes: Arc<RwLock<HashMap<Hash, merkletree::Node>>>,
-    values: Arc<RwLock<HashMap<RawValue, Value>>>,
+    mt_db: merkletree::db::MemDB,
+    db: Arc<RwLock<Store>>,
 }
 
 impl MemDB {
@@ -15,67 +24,121 @@ impl MemDB {
 
 impl merkletree::db::Read for MemDB {
     fn load_node(&self, hash: Hash) -> anyhow::Result<Option<merkletree::Node>> {
-        let nodes = self.nodes.read().expect("lock not poisoned");
-
-        if hash == EMPTY_HASH {
-            return Ok(Some(merkletree::Node::Intermediate(
-                merkletree::Intermediate::new(EMPTY_HASH, EMPTY_HASH),
-            )));
-        }
-
-        Ok(nodes.get(&hash).cloned())
+        self.mt_db.load_node(hash)
     }
 }
 
 impl merkletree::db::DB for MemDB {
     fn tx<'a>(&'a self) -> Box<dyn merkletree::db::TX + 'a> {
-        todo!()
+        DB::tx(self)
     }
-
-    // fn store_node(&mut self, node: merkletree::Node) -> anyhow::Result<()> {
-    //     let mut nodes = self.nodes.write().expect("lock not poisoned");
-    //     nodes.insert(node.hash(), node);
-    //     Ok(())
-    // }
 }
 
 impl Read for MemDB {
     fn load_value(&self, raw: RawValue) -> anyhow::Result<Option<Value>> {
-        let values = self.values.read().expect("lock not poisoned");
+        let store = self.db.read().expect("lock not poisoned");
 
-        Ok(values.get(&raw).cloned())
+        Ok(store.values.get(&raw).cloned())
     }
-    fn load_kind(&self, root: Hash) -> anyhow::Result<ContainerKind> {
-        todo!()
+    fn load_kind(&self, root: Hash) -> anyhow::Result<Option<ContainerKind>> {
+        let store = self.db.read().expect("lock not poisoned");
+        Ok(store.kinds.get(&root).cloned())
     }
 }
 
 impl DB for MemDB {
     fn tx<'a>(&'a self) -> Box<dyn TX + 'a> {
-        todo!()
+        Box::new(MemTx {
+            mt_tx: merkletree::db::DB::tx(&self.mt_db),
+            db: self.db.write().expect("not poisoned"),
+            tmp: Store::default(),
+        })
     }
-    // fn store_value(&mut self, mut value: Value) -> anyhow::Result<()> {
-    //     let mut values = self.values.write().expect("lock not poisoned");
-    //     let value_raw = value.raw();
-    //     if let Some(old_value) = values.get(&value_raw) {
-    //         // Never overwrite an old value with a RawValue.
-    //         if value.is_raw() {
-    //             return Ok(());
-    //         }
-    //         // If a container was previously stored, update the kind bitmask
-    //         if let (TypedValue::Container(old_c), TypedValue::Container(ref mut c)) =
-    //             (&old_value.typed, &mut value.typed)
-    //         {
-    //             c.kind.0 |= old_c.kind.0;
-    //         }
-    //     };
-    //     values.insert(value_raw, value);
-    //     Ok(())
-    // }
     fn is_persistent(&self) -> bool {
         false
     }
     fn clone_box(&self) -> Box<dyn DB> {
         Box::new(self.clone())
+    }
+}
+
+pub(crate) struct MemTx<'a> {
+    mt_tx: Box<dyn merkletree::db::TX + 'a>,
+    db: RwLockWriteGuard<'a, Store>,
+    tmp: Store,
+}
+
+impl<'a> merkletree::db::Read for MemTx<'a> {
+    fn load_node(&self, hash: Hash) -> anyhow::Result<Option<merkletree::Node>> {
+        self.mt_tx.load_node(hash)
+    }
+}
+
+impl<'a> merkletree::db::TX for MemTx<'a> {
+    fn store_node(&mut self, node: merkletree::Node) -> anyhow::Result<()> {
+        self.mt_tx.store_node(node)
+    }
+    fn commit(self: Box<Self>) -> anyhow::Result<()> {
+        panic!("use middleware::db::TX::commit")
+    }
+}
+
+impl<'a> Read for MemTx<'a> {
+    fn load_value(&self, raw: RawValue) -> anyhow::Result<Option<Value>> {
+        Ok(self
+            .tmp
+            .values
+            .get(&raw)
+            .or_else(|| self.db.values.get(&raw))
+            .cloned())
+    }
+    fn load_kind(&self, root: Hash) -> anyhow::Result<Option<ContainerKind>> {
+        Ok(self
+            .tmp
+            .kinds
+            .get(&root)
+            .or_else(|| self.db.kinds.get(&root))
+            .cloned())
+    }
+}
+
+impl<'a> TX for MemTx<'a> {
+    fn store_value(&mut self, mut value: Value) -> anyhow::Result<()> {
+        let value_raw = value.raw();
+        if let Some(old_value) = self.load_value(value_raw)? {
+            // Never overwrite an old value with a RawValue.
+            if value.is_raw() {
+                return Ok(());
+            }
+            // If a container was previously stored, update the kind bitmask
+            if let (TypedValue::Container(old_c), TypedValue::Container(ref mut c)) =
+                (&old_value.typed, &mut value.typed)
+            {
+                c.kind.0 |= old_c.kind.0;
+            }
+        };
+        self.tmp.values.insert(value_raw, value);
+        Ok(())
+    }
+    fn update_kind(&mut self, root: Hash, kind: ContainerKind) -> anyhow::Result<()> {
+        let kind = match self.load_kind(root).expect("ok") {
+            Some(old_kind) => ContainerKind(old_kind.0 | kind.0),
+            None => kind,
+        };
+        self.tmp.kinds.insert(root, kind);
+        Ok(())
+    }
+    fn is_persistent(&self) -> bool {
+        false
+    }
+    fn commit(mut self: Box<Self>) -> anyhow::Result<()> {
+        self.mt_tx.commit()?;
+        for (k, v) in self.tmp.values {
+            self.db.values.insert(k, v);
+        }
+        for (k, v) in self.tmp.kinds {
+            self.db.kinds.insert(k, v);
+        }
+        Ok(())
     }
 }

--- a/src/middleware/db/mem.rs
+++ b/src/middleware/db/mem.rs
@@ -1,7 +1,7 @@
 use std::sync::RwLockWriteGuard;
 
 use super::*;
-use crate::middleware::{TypedValue, EMPTY_HASH};
+use crate::middleware::EMPTY_HASH;
 
 #[derive(Default, Debug)]
 struct Store {
@@ -62,9 +62,6 @@ impl DB for MemDB {
             tmp: Store::default(),
         })
     }
-    fn is_persistent(&self) -> bool {
-        false
-    }
     fn clone_box(&self) -> Box<dyn DB> {
         Box::new(self.clone())
     }
@@ -119,18 +116,13 @@ impl<'a> Read for MemTx<'a> {
 }
 
 impl<'a> TX for MemTx<'a> {
-    fn store_value(&mut self, mut value: Value) -> anyhow::Result<()> {
+    fn store_value(&mut self, value: Value) -> anyhow::Result<()> {
         let value_raw = value.raw();
         if let Some(old_value) = self.load_value(value_raw)? {
-            // Never overwrite an old value with a RawValue.
-            if value.is_raw() {
+            // Never overwrite an old value with a RawValue.  Skip overwrite if old value is
+            // already non-RawValue.
+            if value.is_raw() || !old_value.is_raw() {
                 return Ok(());
-            }
-            // If a container was previously stored, update the kind bitmask
-            if let (TypedValue::Container(old_c), TypedValue::Container(ref mut c)) =
-                (&old_value.typed, &mut value.typed)
-            {
-                c.kind.0 |= old_c.kind.0;
             }
         };
         self.tmp.values.insert(value_raw, value);
@@ -143,9 +135,6 @@ impl<'a> TX for MemTx<'a> {
         };
         self.tmp.kinds.insert(root, kind);
         Ok(())
-    }
-    fn is_persistent(&self) -> bool {
-        false
     }
     fn commit(mut self: Box<Self>) -> anyhow::Result<()> {
         self.mt_tx.commit()?;

--- a/src/middleware/db/mod.rs
+++ b/src/middleware/db/mod.rs
@@ -8,25 +8,35 @@ use dyn_clone::DynClone;
 
 #[cfg(feature = "backend_plonky2")]
 use crate::backends::plonky2::primitives::merkletree::{self};
-use crate::middleware::{Hash, RawValue, Value, EMPTY_HASH};
+use crate::middleware::{ContainerKind, Hash, RawValue, Value, EMPTY_HASH};
 
 pub mod mem;
 #[cfg(feature = "db_rocksdb")]
 pub mod rocks;
 
-pub trait TX: merkletree::db::DB {}
+pub trait Read {
+    fn load_value(&self, raw: RawValue) -> anyhow::Result<Option<Value>>;
+    fn load_kind(&self, root: Hash) -> anyhow::Result<ContainerKind>;
+}
+
+pub trait TX: Read + merkletree::db::TX {
+    fn store_value(&mut self, value: Value) -> anyhow::Result<()>;
+    fn update_kind(&mut self, root: Hash, kind: ContainerKind) -> anyhow::Result<()>;
+    fn is_persistent(&self) -> bool;
+    fn commit(self: Box<Self>) -> anyhow::Result<()>;
+}
+
+// pub trait TX: merkletree::db::DB {}
 
 // Trait for database that stores values.  Must be cheap to clone.
-pub trait DB: Debug + DynClone + Sync + Send + merkletree::db::DB {
-    fn load_value(&self, raw: RawValue) -> anyhow::Result<Option<Value>>;
+pub trait DB: Debug + DynClone + Sync + Send + Read + merkletree::db::DB {
     // If the DB is persistent, for containers only the root needs to be stored because the
     // Container type makes sure the underlying merkle tree is stored in the DB independently, so
     // that it can be recovered back just with the root and the DB.
     // If the value is RawValue and a previous non-RawValue exists, no store will overwrite it.
     // If the value is non-RawValue and a previous RawValue exists, store should overwrite it.
-    fn store_value(&mut self, value: Value) -> anyhow::Result<()>;
     fn is_persistent(&self) -> bool;
     fn clone_box(&self) -> Box<dyn DB>;
-    // fn tx(&mut self, f: impl FnMut(&dyn TX)) -> anyhow::Result<()>;
+    fn tx<'a>(&'a self) -> Box<dyn TX + 'a>;
 }
 dyn_clone::clone_trait_object!(DB);

--- a/src/middleware/db/mod.rs
+++ b/src/middleware/db/mod.rs
@@ -20,12 +20,10 @@ pub trait Read {
 }
 
 pub trait TX: Read + merkletree::db::TX {
-    // If the value is RawValue and a previous non-RawValue exists, no store will overwrite it.
-    // If the value is non-RawValue and a previous RawValue exists, store should overwrite it,
-    // merging the kind field in case of a Container (unless the DB is persistent).
+    // If the `value` is RawValue and a previous non-RawValue exists, no store should overwrite it.
+    // If the value is non-RawValue and a previous RawValue exists, store should overwrite it.
     fn store_value(&mut self, value: Value) -> anyhow::Result<()>;
     fn update_kind(&mut self, root: Hash, kind: ContainerKind) -> anyhow::Result<()>;
-    fn is_persistent(&self) -> bool;
     fn commit(self: Box<Self>) -> anyhow::Result<()>;
 }
 
@@ -36,7 +34,6 @@ pub trait DB: Debug + DynClone + Sync + Send + Read + merkletree::db::DB {
     // If the DB is persistent, for containers only the root needs to be stored because the
     // Container type makes sure the underlying merkle tree is stored in the DB independently, so
     // that it can be recovered back just with the root and the DB.
-    fn is_persistent(&self) -> bool;
     fn clone_box(&self) -> Box<dyn DB>;
     fn tx<'a>(&'a self) -> Box<dyn TX + 'a>;
 }

--- a/src/middleware/db/mod.rs
+++ b/src/middleware/db/mod.rs
@@ -14,17 +14,19 @@ pub mod mem;
 #[cfg(feature = "db_rocksdb")]
 pub mod rocks;
 
+pub trait TX: merkletree::db::DB {}
+
 // Trait for database that stores values.  Must be cheap to clone.
 pub trait DB: Debug + DynClone + Sync + Send + merkletree::db::DB {
     fn load_value(&self, raw: RawValue) -> anyhow::Result<Option<Value>>;
     // If the DB is persistent, for containers only the root needs to be stored because the
     // Container type makes sure the underlying merkle tree is stored in the DB independently, so
     // that it can be recovered back just with the root and the DB.
-    // If the value is RawValue and a previous non-RawValue exists, no store overwrite it.
-    // should be done. If the value is non-RawValue and a previous RawValue exists, store
-    // should overwrite it.
+    // If the value is RawValue and a previous non-RawValue exists, no store will overwrite it.
+    // If the value is non-RawValue and a previous RawValue exists, store should overwrite it.
     fn store_value(&mut self, value: Value) -> anyhow::Result<()>;
     fn is_persistent(&self) -> bool;
     fn clone_box(&self) -> Box<dyn DB>;
+    // fn tx(&mut self, f: impl FnMut(&dyn TX)) -> anyhow::Result<()>;
 }
 dyn_clone::clone_trait_object!(DB);

--- a/src/middleware/db/mod.rs
+++ b/src/middleware/db/mod.rs
@@ -16,10 +16,13 @@ pub mod rocks;
 
 pub trait Read {
     fn load_value(&self, raw: RawValue) -> anyhow::Result<Option<Value>>;
-    fn load_kind(&self, root: Hash) -> anyhow::Result<ContainerKind>;
+    fn load_kind(&self, root: Hash) -> anyhow::Result<Option<ContainerKind>>;
 }
 
 pub trait TX: Read + merkletree::db::TX {
+    // If the value is RawValue and a previous non-RawValue exists, no store will overwrite it.
+    // If the value is non-RawValue and a previous RawValue exists, store should overwrite it,
+    // merging the kind field in case of a Container (unless the DB is persistent).
     fn store_value(&mut self, value: Value) -> anyhow::Result<()>;
     fn update_kind(&mut self, root: Hash, kind: ContainerKind) -> anyhow::Result<()>;
     fn is_persistent(&self) -> bool;
@@ -33,8 +36,6 @@ pub trait DB: Debug + DynClone + Sync + Send + Read + merkletree::db::DB {
     // If the DB is persistent, for containers only the root needs to be stored because the
     // Container type makes sure the underlying merkle tree is stored in the DB independently, so
     // that it can be recovered back just with the root and the DB.
-    // If the value is RawValue and a previous non-RawValue exists, no store will overwrite it.
-    // If the value is non-RawValue and a previous RawValue exists, store should overwrite it.
     fn is_persistent(&self) -> bool;
     fn clone_box(&self) -> Box<dyn DB>;
     fn tx<'a>(&'a self) -> Box<dyn TX + 'a>;

--- a/src/middleware/db/mod.rs
+++ b/src/middleware/db/mod.rs
@@ -8,7 +8,7 @@ use dyn_clone::DynClone;
 
 #[cfg(feature = "backend_plonky2")]
 use crate::backends::plonky2::primitives::merkletree::{self};
-use crate::middleware::{ContainerKind, Hash, RawValue, Value, EMPTY_HASH};
+use crate::middleware::{ContainerKind, Hash, RawValue, Value};
 
 pub mod mem;
 #[cfg(feature = "db_rocksdb")]

--- a/src/middleware/db/rocks.rs
+++ b/src/middleware/db/rocks.rs
@@ -159,7 +159,7 @@ impl<'a> TX for RocksTx<'a> {
             None => kind,
         };
         let kind_key = kind_key(root);
-        Ok(self.tx.put(&kind_key, &[kind.0])?)
+        Ok(self.tx.put(&kind_key, [kind.0])?)
     }
     fn is_persistent(&self) -> bool {
         true

--- a/src/middleware/db/rocks.rs
+++ b/src/middleware/db/rocks.rs
@@ -124,6 +124,9 @@ impl<'a> Read for RocksTx<'a> {
                     .set_array(),
             ));
         }
+        // We use `get_for_update` because this method is part of a transaction, and it will be
+        // used by `update_kind`, so we want and exclusive lock after the value is read to
+        // guarantee no data-races in the merge update.
         self.tx
             .get_for_update(kind_key(root), true)
             .map(|opt| {
@@ -139,13 +142,12 @@ impl<'a> Read for RocksTx<'a> {
 impl<'a> TX for RocksTx<'a> {
     fn store_value(&mut self, value: Value) -> anyhow::Result<()> {
         let value_key = value_key(value.raw());
-        if let Some(_old_value_bytes) = self.tx.get(&value_key)? {
-            // Never overwrite an old value with a RawValue.
-            if value.is_raw() {
+        if let Some(old_value_bytes) = self.tx.get(&value_key)? {
+            // Never overwrite an old value with a RawValue.  Skip overwrite if old value is
+            // already non-RawValue.
+            if value.is_raw() || !old_value_bytes.is_empty() {
                 return Ok(());
             }
-            // No need to update container kind bitmask because in persistent store we don't store
-            // containers as Value, their content is stored as merkle nodes via the MerkleTree
         };
         let value_bytes = if value.is_raw() {
             // For RawValue we store an empty vector because it's a duplicate of the key.
@@ -163,9 +165,6 @@ impl<'a> TX for RocksTx<'a> {
         };
         let kind_key = kind_key(root);
         Ok(self.tx.put(&kind_key, [kind.0])?)
-    }
-    fn is_persistent(&self) -> bool {
-        true
     }
     fn commit(self: Box<Self>) -> anyhow::Result<()> {
         Ok(self.tx.commit()?)
@@ -209,9 +208,6 @@ impl DB for RocksDB {
             tx: self.0.transaction(),
             db: self.clone(),
         })
-    }
-    fn is_persistent(&self) -> bool {
-        true
     }
     fn clone_box(&self) -> Box<dyn DB> {
         Box::new(self.clone())

--- a/src/middleware/db/rocks.rs
+++ b/src/middleware/db/rocks.rs
@@ -64,6 +64,10 @@ impl merkletree::db::DB for RocksDB {
     }
 }
 
+pub struct RocksTx<'a> {
+    tx: rocksdb::Transaction<'a, rocksdb::TransactionDB>,
+}
+
 impl DB for RocksDB {
     fn load_value(&self, raw: RawValue) -> anyhow::Result<Option<Value>> {
         match self.db.get(value_key(raw))? {
@@ -77,15 +81,19 @@ impl DB for RocksDB {
             })),
         }
     }
-    fn store_value(&mut self, value: Value) -> anyhow::Result<()> {
+    fn store_value(&mut self, mut value: Value) -> anyhow::Result<()> {
         let value_key = value_key(value.raw());
         let tx = self.db.transaction();
         if let Some(old_value_bytes) = tx.get_for_update(&value_key, true)? {
-            let is_raw = old_value_bytes.is_empty();
-            // If we had a non-RawValue stored don't overwrite it (specially not with a
-            // RawValue).   Also skip redundant RawValue overwrite.
-            if !is_raw || (is_raw && value.is_raw()) {
+            // Never overwrite an old value with a RawValue.
+            if value.is_raw() {
                 return Ok(());
+            }
+            // If a container was previously stored, update the kind bitmask
+            if let (TypedValue::Container(old_c), TypedValue::Container(ref mut c)) =
+                (&old_value.typed, &mut value.typed)
+            {
+                c.kind.0 |= old_c.kind.0;
             }
         }
         let value_bytes = if value.is_raw() {

--- a/src/middleware/db/rocks.rs
+++ b/src/middleware/db/rocks.rs
@@ -1,9 +1,10 @@
 use std::{fmt, path::Path, sync::Arc};
 
 use anyhow::{anyhow, Result};
-use rocksdb::{Options, TransactionDB, TransactionDBOptions};
+use rocksdb::{DBAccess, Options, ReadOptions, Transaction, TransactionDB, TransactionDBOptions};
 
 use super::*;
+use crate::middleware::EMPTY_HASH;
 
 fn node_key(hash: Hash) -> Vec<u8> {
     let mut k = Vec::with_capacity(2 + 4);
@@ -22,7 +23,7 @@ fn value_key(raw: RawValue) -> Vec<u8> {
 fn kind_key(root: Hash) -> Vec<u8> {
     let mut k = Vec::with_capacity(2 + 4);
     k.extend_from_slice(b"k/");
-    k.extend_from_slice(&root.to_bytes());
+    k.extend_from_slice(&RawValue(root.0).to_bytes());
     k
 }
 
@@ -46,9 +47,32 @@ impl RocksDB {
     }
 }
 
+fn load_node_db(db: &impl DBAccess, hash: Hash) -> Result<Option<merkletree::Node>> {
+    if hash == EMPTY_HASH {
+        return Ok(Some(merkletree::Node::Intermediate(
+            merkletree::Intermediate::new(EMPTY_HASH, EMPTY_HASH),
+        )));
+    }
+
+    let node_key = node_key(hash);
+    match db
+        .get_opt(&node_key, &ReadOptions::default())
+        .map_err(|e| anyhow!("rocksdb: get failed: {e}"))?
+    {
+        None => Ok(None),
+        Some(bytes) => Ok(Some(merkletree::Node::decode(bytes.as_ref())?)),
+    }
+}
+
+fn store_node_tx<'a>(tx: &Transaction<'a, TransactionDB>, node: merkletree::Node) -> Result<()> {
+    let node_key = node_key(node.hash());
+    tx.put(&node_key, node.encode()?)
+        .map_err(|e| anyhow!("rocksdb transaction put failed: {e}"))
+}
+
 impl merkletree::db::Read for RocksDB {
     fn load_node(&self, hash: Hash) -> Result<Option<merkletree::Node>> {
-        merkletree::db::rocks::load_node_db(&self.0, hash)
+        load_node_db(&*self.0, hash)
     }
 }
 
@@ -56,12 +80,6 @@ impl merkletree::db::DB for RocksDB {
     fn tx<'a>(&'a self) -> Box<dyn merkletree::db::TX + 'a> {
         DB::tx(self)
     }
-
-    // fn store_node(&mut self, node: merkletree::Node) -> Result<()> {
-    //     self.db
-    //         .put(node_key(node.hash()), node.encode()?)
-    //         .map_err(|e| anyhow!("rocksdb transaction put failed: {e}"))
-    // }
 }
 
 pub(crate) struct RocksTx<'a> {
@@ -71,13 +89,13 @@ pub(crate) struct RocksTx<'a> {
 
 impl<'a> merkletree::db::Read for RocksTx<'a> {
     fn load_node(&self, hash: Hash) -> anyhow::Result<Option<merkletree::Node>> {
-        merkletree::db::rocks::load_node_tx(&self.tx, hash)
+        load_node_db(&self.tx, hash)
     }
 }
 
 impl<'a> merkletree::db::TX for RocksTx<'a> {
     fn store_node(&mut self, node: merkletree::Node) -> anyhow::Result<()> {
-        merkletree::db::rocks::store_node_tx(&self.tx, node)
+        store_node_tx(&self.tx, node)
     }
     fn commit(self: Box<Self>) -> anyhow::Result<()> {
         panic!("use middleware::db::TX::commit")
@@ -98,7 +116,15 @@ impl<'a> Read for RocksTx<'a> {
         }
     }
     fn load_kind(&self, root: Hash) -> anyhow::Result<Option<ContainerKind>> {
-        Ok(self.tx.get(kind_key(root)).map(|opt| {
+        if root == EMPTY_HASH {
+            return Ok(Some(
+                *ContainerKind::default()
+                    .set_dictionary()
+                    .set_set()
+                    .set_array(),
+            ));
+        }
+        Ok(self.tx.get_for_update(kind_key(root), true).map(|opt| {
             opt.map(|bytes| {
                 assert_eq!(1, bytes.len());
                 ContainerKind(bytes[0])
@@ -108,63 +134,44 @@ impl<'a> Read for RocksTx<'a> {
 }
 
 impl<'a> TX for RocksTx<'a> {
-    fn store_value(&mut self, mut value: Value) -> anyhow::Result<()> {
-        let value_raw = value.raw();
-        if let Some(old_value) = self.load_value(value_raw)? {
+    fn store_value(&mut self, value: Value) -> anyhow::Result<()> {
+        let value_key = value_key(value.raw());
+        if let Some(_old_value_bytes) = self.tx.get(&value_key)? {
             // Never overwrite an old value with a RawValue.
             if value.is_raw() {
                 return Ok(());
             }
-            // If a container was previously stored, update the kind bitmask
-            if let (TypedValue::Container(old_c), TypedValue::Container(ref mut c)) =
-                (&old_value.typed, &mut value.typed)
-            {
-                c.kind.0 |= old_c.kind.0;
-            }
+            // No need to update container kind bitmask because in persistent store we don't store
+            // containers as Value, their content is stored as merkle nodes via the MerkleTree
         };
-        self.tmp.values.insert(value_raw, value);
-        Ok(())
+        let value_bytes = if value.is_raw() {
+            // For RawValue we store an empty vector because it's a duplicate of the key.
+            // This way we can easily check for RawValue without decoding.
+            vec![]
+        } else {
+            Value::to_bytes(&value)
+        };
+        Ok(self.tx.put(value_key, value_bytes)?)
     }
     fn update_kind(&mut self, root: Hash, kind: ContainerKind) -> anyhow::Result<()> {
         let kind = match self.load_kind(root).expect("ok") {
             Some(old_kind) => ContainerKind(old_kind.0 | kind.0),
             None => kind,
         };
-        self.tmp.kinds.insert(root, kind);
-        Ok(())
+        let kind_key = kind_key(root);
+        Ok(self.tx.put(&kind_key, &[kind.0])?)
     }
     fn is_persistent(&self) -> bool {
         true
     }
-    fn commit(mut self: Box<Self>) -> anyhow::Result<()> {
-        self.tx.commit()
+    fn commit(self: Box<Self>) -> anyhow::Result<()> {
+        Ok(self.tx.commit()?)
     }
 }
 
-// impl<'a> merkletree::db::DB for RocksTx<'a> {
-//     fn load_node(&self, hash: Hash) -> Result<Option<merkletree::Node>> {
-//         if hash == EMPTY_HASH {
-//             return Ok(Some(merkletree::Node::Intermediate(
-//                 merkletree::Intermediate::new(EMPTY_HASH, EMPTY_HASH),
-//             )));
-//         }
-//
-//         match self.tx.get(node_key(hash))? {
-//             None => Ok(None),
-//             Some(bytes) => Ok(Some(merkletree::Node::decode(bytes.as_ref())?)),
-//         }
-//     }
-//
-//     fn store_node(&mut self, node: merkletree::Node) -> Result<()> {
-//         self.tx
-//             .put(node_key(node.hash()), node.encode()?)
-//             .map_err(|e| anyhow!("rocksdb transaction put failed: {e}"))
-//     }
-// }
-
 impl Read for RocksDB {
     fn load_value(&self, raw: RawValue) -> anyhow::Result<Option<Value>> {
-        match self.db.get(value_key(raw))? {
+        match self.0.get(value_key(raw))? {
             None => Ok(None),
             Some(bytes) => Ok(Some({
                 if bytes.is_empty() {
@@ -176,45 +183,34 @@ impl Read for RocksDB {
         }
     }
     fn load_kind(&self, root: Hash) -> anyhow::Result<Option<ContainerKind>> {
-        todo!()
+        if root == EMPTY_HASH {
+            return Ok(Some(
+                *ContainerKind::default()
+                    .set_dictionary()
+                    .set_set()
+                    .set_array(),
+            ));
+        }
+        Ok(self.0.get(kind_key(root)).map(|opt| {
+            opt.map(|bytes| {
+                assert_eq!(1, bytes.len());
+                ContainerKind(bytes[0])
+            })
+        })?)
     }
 }
 
 impl DB for RocksDB {
     fn tx<'a>(&'a self) -> Box<dyn TX + 'a> {
         Box::new(RocksTx {
-            tx: self.tx.transaction(),
-            db: self.db.clone(),
+            tx: self.0.transaction(),
+            db: self.clone(),
         })
     }
-    // fn store_value(&mut self, value: Value) -> anyhow::Result<()> {
-    //     let value_key = value_key(value.raw());
-    //     let tx = self.db.transaction();
-    //     if let Some(_old_value_bytes) = tx.get_for_update(&value_key, true)? {
-    //         // Never overwrite an old value with a RawValue.
-    //         if value.is_raw() {
-    //             return Ok(());
-    //         }
-    //         // No need to update container kind bitmask because in persistent store we don't store
-    //         // containers as Value, their content is stored as merkle nodes via the MerkleTree
-    //     }
-    //     let value_bytes = if value.is_raw() {
-    //         // For RawValue we store an empty vector because it's a duplicate of the key.
-    //         // This way we can easily check for RawValue without decoding.
-    //         vec![]
-    //     } else {
-    //         Value::to_bytes(&value)
-    //     };
-    //     tx.put(value_key, value_bytes)?;
-    //     Ok(tx.commit()?)
-    // }
     fn is_persistent(&self) -> bool {
         true
     }
     fn clone_box(&self) -> Box<dyn DB> {
         Box::new(self.clone())
     }
-    // fn tx<'a>(&'a self) -> Box<dyn TX + 'a> {
-    //     Box::new(self.db.transaction())
-    // }
 }

--- a/src/middleware/db/rocks.rs
+++ b/src/middleware/db/rocks.rs
@@ -19,14 +19,19 @@ fn value_key(raw: RawValue) -> Vec<u8> {
     k
 }
 
-#[derive(Clone)]
-pub struct RocksDB {
-    db: Arc<TransactionDB>,
+fn kind_key(root: Hash) -> Vec<u8> {
+    let mut k = Vec::with_capacity(2 + 4);
+    k.extend_from_slice(b"k/");
+    k.extend_from_slice(&root.to_bytes());
+    k
 }
+
+#[derive(Clone)]
+pub struct RocksDB(Arc<TransactionDB>);
 
 impl fmt::Debug for RocksDB {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "RocksDB(path: {:?})", self.db.path())
+        writeln!(f, "RocksDB(path: {:?})", self.0.path())
     }
 }
 
@@ -37,30 +42,19 @@ impl RocksDB {
         let txn_options = TransactionDBOptions::default();
         let inner =
             TransactionDB::open(&options, &txn_options, path).map_err(|e| anyhow!("{e}"))?;
-        Ok(Self {
-            db: Arc::new(inner),
-        })
+        Ok(Self(Arc::new(inner)))
     }
 }
 
 impl merkletree::db::Read for RocksDB {
     fn load_node(&self, hash: Hash) -> Result<Option<merkletree::Node>> {
-        if hash == EMPTY_HASH {
-            return Ok(Some(merkletree::Node::Intermediate(
-                merkletree::Intermediate::new(EMPTY_HASH, EMPTY_HASH),
-            )));
-        }
-
-        match self.db.get(node_key(hash))? {
-            None => Ok(None),
-            Some(bytes) => Ok(Some(merkletree::Node::decode(bytes.as_ref())?)),
-        }
+        merkletree::db::rocks::load_node_db(&self.0, hash)
     }
 }
 
 impl merkletree::db::DB for RocksDB {
     fn tx<'a>(&'a self) -> Box<dyn merkletree::db::TX + 'a> {
-        todo!()
+        DB::tx(self)
     }
 
     // fn store_node(&mut self, node: merkletree::Node) -> Result<()> {
@@ -70,13 +64,80 @@ impl merkletree::db::DB for RocksDB {
     // }
 }
 
-pub struct RocksTx<'a> {
+pub(crate) struct RocksTx<'a> {
     tx: rocksdb::Transaction<'a, rocksdb::TransactionDB>,
+    db: RocksDB,
 }
 
-impl<'a> fmt::Debug for RocksTx<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "RocksTx")
+impl<'a> merkletree::db::Read for RocksTx<'a> {
+    fn load_node(&self, hash: Hash) -> anyhow::Result<Option<merkletree::Node>> {
+        merkletree::db::rocks::load_node_tx(&self.tx, hash)
+    }
+}
+
+impl<'a> merkletree::db::TX for RocksTx<'a> {
+    fn store_node(&mut self, node: merkletree::Node) -> anyhow::Result<()> {
+        merkletree::db::rocks::store_node_tx(&self.tx, node)
+    }
+    fn commit(self: Box<Self>) -> anyhow::Result<()> {
+        panic!("use middleware::db::TX::commit")
+    }
+}
+
+impl<'a> Read for RocksTx<'a> {
+    fn load_value(&self, raw: RawValue) -> anyhow::Result<Option<Value>> {
+        match self.tx.get(value_key(raw))? {
+            None => Ok(None),
+            Some(bytes) => Ok(Some({
+                if bytes.is_empty() {
+                    Value::from(raw)
+                } else {
+                    Value::from_bytes(bytes.as_ref(), self.db.clone_box())?
+                }
+            })),
+        }
+    }
+    fn load_kind(&self, root: Hash) -> anyhow::Result<Option<ContainerKind>> {
+        Ok(self.tx.get(kind_key(root)).map(|opt| {
+            opt.map(|bytes| {
+                assert_eq!(1, bytes.len());
+                ContainerKind(bytes[0])
+            })
+        })?)
+    }
+}
+
+impl<'a> TX for RocksTx<'a> {
+    fn store_value(&mut self, mut value: Value) -> anyhow::Result<()> {
+        let value_raw = value.raw();
+        if let Some(old_value) = self.load_value(value_raw)? {
+            // Never overwrite an old value with a RawValue.
+            if value.is_raw() {
+                return Ok(());
+            }
+            // If a container was previously stored, update the kind bitmask
+            if let (TypedValue::Container(old_c), TypedValue::Container(ref mut c)) =
+                (&old_value.typed, &mut value.typed)
+            {
+                c.kind.0 |= old_c.kind.0;
+            }
+        };
+        self.tmp.values.insert(value_raw, value);
+        Ok(())
+    }
+    fn update_kind(&mut self, root: Hash, kind: ContainerKind) -> anyhow::Result<()> {
+        let kind = match self.load_kind(root).expect("ok") {
+            Some(old_kind) => ContainerKind(old_kind.0 | kind.0),
+            None => kind,
+        };
+        self.tmp.kinds.insert(root, kind);
+        Ok(())
+    }
+    fn is_persistent(&self) -> bool {
+        true
+    }
+    fn commit(mut self: Box<Self>) -> anyhow::Result<()> {
+        self.tx.commit()
     }
 }
 
@@ -114,14 +175,17 @@ impl Read for RocksDB {
             })),
         }
     }
-    fn load_kind(&self, root: Hash) -> anyhow::Result<ContainerKind> {
+    fn load_kind(&self, root: Hash) -> anyhow::Result<Option<ContainerKind>> {
         todo!()
     }
 }
 
 impl DB for RocksDB {
     fn tx<'a>(&'a self) -> Box<dyn TX + 'a> {
-        todo!()
+        Box::new(RocksTx {
+            tx: self.tx.transaction(),
+            db: self.db.clone(),
+        })
     }
     // fn store_value(&mut self, value: Value) -> anyhow::Result<()> {
     //     let value_key = value_key(value.raw());

--- a/src/middleware/db/rocks.rs
+++ b/src/middleware/db/rocks.rs
@@ -43,7 +43,7 @@ impl RocksDB {
     }
 }
 
-impl merkletree::db::DB for RocksDB {
+impl merkletree::db::Read for RocksDB {
     fn load_node(&self, hash: Hash) -> Result<Option<merkletree::Node>> {
         if hash == EMPTY_HASH {
             return Ok(Some(merkletree::Node::Intermediate(
@@ -56,19 +56,52 @@ impl merkletree::db::DB for RocksDB {
             Some(bytes) => Ok(Some(merkletree::Node::decode(bytes.as_ref())?)),
         }
     }
+}
 
-    fn store_node(&mut self, node: merkletree::Node) -> Result<()> {
-        self.db
-            .put(node_key(node.hash()), node.encode()?)
-            .map_err(|e| anyhow!("rocksdb transaction put failed: {e}"))
+impl merkletree::db::DB for RocksDB {
+    fn tx<'a>(&'a self) -> Box<dyn merkletree::db::TX + 'a> {
+        todo!()
     }
+
+    // fn store_node(&mut self, node: merkletree::Node) -> Result<()> {
+    //     self.db
+    //         .put(node_key(node.hash()), node.encode()?)
+    //         .map_err(|e| anyhow!("rocksdb transaction put failed: {e}"))
+    // }
 }
 
 pub struct RocksTx<'a> {
     tx: rocksdb::Transaction<'a, rocksdb::TransactionDB>,
 }
 
-impl DB for RocksDB {
+impl<'a> fmt::Debug for RocksTx<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "RocksTx")
+    }
+}
+
+// impl<'a> merkletree::db::DB for RocksTx<'a> {
+//     fn load_node(&self, hash: Hash) -> Result<Option<merkletree::Node>> {
+//         if hash == EMPTY_HASH {
+//             return Ok(Some(merkletree::Node::Intermediate(
+//                 merkletree::Intermediate::new(EMPTY_HASH, EMPTY_HASH),
+//             )));
+//         }
+//
+//         match self.tx.get(node_key(hash))? {
+//             None => Ok(None),
+//             Some(bytes) => Ok(Some(merkletree::Node::decode(bytes.as_ref())?)),
+//         }
+//     }
+//
+//     fn store_node(&mut self, node: merkletree::Node) -> Result<()> {
+//         self.tx
+//             .put(node_key(node.hash()), node.encode()?)
+//             .map_err(|e| anyhow!("rocksdb transaction put failed: {e}"))
+//     }
+// }
+
+impl Read for RocksDB {
     fn load_value(&self, raw: RawValue) -> anyhow::Result<Option<Value>> {
         match self.db.get(value_key(raw))? {
             None => Ok(None),
@@ -81,35 +114,43 @@ impl DB for RocksDB {
             })),
         }
     }
-    fn store_value(&mut self, mut value: Value) -> anyhow::Result<()> {
-        let value_key = value_key(value.raw());
-        let tx = self.db.transaction();
-        if let Some(old_value_bytes) = tx.get_for_update(&value_key, true)? {
-            // Never overwrite an old value with a RawValue.
-            if value.is_raw() {
-                return Ok(());
-            }
-            // If a container was previously stored, update the kind bitmask
-            if let (TypedValue::Container(old_c), TypedValue::Container(ref mut c)) =
-                (&old_value.typed, &mut value.typed)
-            {
-                c.kind.0 |= old_c.kind.0;
-            }
-        }
-        let value_bytes = if value.is_raw() {
-            // For RawValue we store an empty vector because it's a duplicate of the key.
-            // This way we can easily check for RawValue without decoding.
-            vec![]
-        } else {
-            Value::to_bytes(&value)
-        };
-        tx.put(value_key, value_bytes)?;
-        Ok(tx.commit()?)
+    fn load_kind(&self, root: Hash) -> anyhow::Result<ContainerKind> {
+        todo!()
     }
+}
+
+impl DB for RocksDB {
+    fn tx<'a>(&'a self) -> Box<dyn TX + 'a> {
+        todo!()
+    }
+    // fn store_value(&mut self, value: Value) -> anyhow::Result<()> {
+    //     let value_key = value_key(value.raw());
+    //     let tx = self.db.transaction();
+    //     if let Some(_old_value_bytes) = tx.get_for_update(&value_key, true)? {
+    //         // Never overwrite an old value with a RawValue.
+    //         if value.is_raw() {
+    //             return Ok(());
+    //         }
+    //         // No need to update container kind bitmask because in persistent store we don't store
+    //         // containers as Value, their content is stored as merkle nodes via the MerkleTree
+    //     }
+    //     let value_bytes = if value.is_raw() {
+    //         // For RawValue we store an empty vector because it's a duplicate of the key.
+    //         // This way we can easily check for RawValue without decoding.
+    //         vec![]
+    //     } else {
+    //         Value::to_bytes(&value)
+    //     };
+    //     tx.put(value_key, value_bytes)?;
+    //     Ok(tx.commit()?)
+    // }
     fn is_persistent(&self) -> bool {
         true
     }
     fn clone_box(&self) -> Box<dyn DB> {
         Box::new(self.clone())
     }
+    // fn tx<'a>(&'a self) -> Box<dyn TX + 'a> {
+    //     Box::new(self.db.transaction())
+    // }
 }

--- a/src/middleware/db/rocks.rs
+++ b/src/middleware/db/rocks.rs
@@ -124,12 +124,15 @@ impl<'a> Read for RocksTx<'a> {
                     .set_array(),
             ));
         }
-        Ok(self.tx.get_for_update(kind_key(root), true).map(|opt| {
-            opt.map(|bytes| {
-                assert_eq!(1, bytes.len());
-                ContainerKind(bytes[0])
-            })
-        })?)
+        self.tx
+            .get_for_update(kind_key(root), true)
+            .map(|opt| {
+                opt.map(|bytes| match bytes.len() {
+                    1 => Ok(ContainerKind(bytes[0])),
+                    l => Err(anyhow!("db: invalid kind len: {}", l)),
+                })
+            })?
+            .transpose()
     }
 }
 

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -339,20 +339,17 @@ impl JsonSchema for TypedValue {
             ..Default::default()
         };
 
-        let tagged = |tag: &str, inner: Schema| {
-            Schema::Object(SchemaObject {
-                instance_type: Some(SingleOrVec::Single(Box::new(InstanceType::Object))),
-                object: Some(Box::new(schemars::schema::ObjectValidation {
-                    properties: [(tag.to_string(), inner)].into_iter().collect(),
-                    required: [tag.to_string()].into_iter().collect(),
-                    ..Default::default()
-                })),
+        let container_schema = schemars::schema::SchemaObject {
+            instance_type: Some(SingleOrVec::Single(Box::new(InstanceType::Object))),
+            object: Some(Box::new(schemars::schema::ObjectValidation {
+                properties: [("Container".to_string(), gen.subschema_for::<Container>())]
+                    .into_iter()
+                    .collect(),
+                required: ["Container".to_string()].into_iter().collect(),
                 ..Default::default()
-            })
+            })),
+            ..Default::default()
         };
-        let set_schema = tagged("Set", gen.subschema_for::<Set>());
-        let dictionary_schema = tagged("Dictionary", gen.subschema_for::<Dictionary>());
-        let array_schema = tagged("Array", gen.subschema_for::<Array>());
 
         let untagged_string_schema = gen.subschema_for::<String>();
 
@@ -364,9 +361,7 @@ impl JsonSchema for TypedValue {
                     Schema::Object(raw_schema),
                     Schema::Object(public_key_schema),
                     Schema::Object(secret_key_schema),
-                    set_schema,
-                    dictionary_schema,
-                    array_schema,
+                    Schema::Object(container_schema),
                     untagged_string_schema,
                 ]),
                 ..Default::default()

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -29,6 +29,8 @@ pub use pod_deserialization::*;
 use serialization::*;
 pub use statement::*;
 
+use crate::middleware::containers::ContainerKind;
+
 // TODO: Move all value-related types to to `value.rs`
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 // TODO #[schemars(transform = serialization::transform_value_schema)]
@@ -57,12 +59,7 @@ pub(crate) enum TypedValue {
     SecretKey(SecretKey),
     // Predicate as a value
     Predicate(Predicate),
-    // Containers are tagged ({"Set": [...]}, {"Dictionary": [...]},
-    // {"Array": [...]}): all three serialize identically, so a tag is need to
-    // discriminate.
-    Set(Set),
-    Dictionary(Dictionary),
-    Array(Array),
+    Container(Container),
     // UNTAGGED TYPES:
     #[serde(untagged)]
     String(String),
@@ -120,21 +117,27 @@ impl From<Predicate> for TypedValue {
     }
 }
 
+impl From<Container> for TypedValue {
+    fn from(c: Container) -> Self {
+        TypedValue::Container(c)
+    }
+}
+
 impl From<Set> for TypedValue {
     fn from(s: Set) -> Self {
-        TypedValue::Set(s)
+        TypedValue::Container(s.inner)
     }
 }
 
 impl From<Dictionary> for TypedValue {
     fn from(d: Dictionary) -> Self {
-        TypedValue::Dictionary(d)
+        TypedValue::Container(d.inner)
     }
 }
 
 impl From<Array> for TypedValue {
     fn from(a: Array) -> Self {
-        TypedValue::Array(a)
+        TypedValue::Container(a.inner)
     }
 }
 
@@ -155,56 +158,75 @@ impl fmt::Display for TypedValue {
                     Err(_) => write!(f, "\"{}\"", s),
                 }
             }
-            TypedValue::Array(a) => {
-                write!(f, "[")?;
-                for (i, r) in a.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ", ")?;
+            TypedValue::Container(c) => {
+                if c.kind() == *ContainerKind::default().set_dictionary() {
+                    let d = c.clone().as_dictionary().expect("dictionary");
+                    write!(f, "{{ ")?;
+                    for (i, r) in d.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ", ")?;
+                        }
+                        if i == 8 {
+                            write!(f, "…")?;
+                            break;
+                        }
+                        match r {
+                            Ok((key, value)) => write!(f, "{}: {}", key, value)?,
+                            Err(e) => write!(f, "{e}")?,
+                        }
                     }
-                    if i == 8 {
-                        write!(f, "…")?;
-                        break;
+                    write!(f, " }}")
+                } else if c.kind() == *ContainerKind::default().set_set() {
+                    let s = c.clone().as_set().expect("set");
+                    write!(f, "#[")?;
+                    for (i, r) in s.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ", ")?;
+                        }
+                        if i == 8 {
+                            write!(f, "…")?;
+                            break;
+                        }
+                        match r {
+                            Ok(value) => write!(f, "{}", value)?,
+                            Err(e) => write!(f, "{e}")?,
+                        }
                     }
-                    match r {
-                        Ok((index, value)) => write!(f, "{}: {}", index, value)?,
-                        Err(e) => write!(f, "{e}")?,
+                    write!(f, "]")
+                } else if c.kind() == *ContainerKind::default().set_array() {
+                    let a = c.clone().as_array().expect("array");
+                    write!(f, "[")?;
+                    for (i, r) in a.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ", ")?;
+                        }
+                        if i == 8 {
+                            write!(f, "…")?;
+                            break;
+                        }
+                        match r {
+                            Ok((index, value)) => write!(f, "{}: {}", index, value)?,
+                            Err(e) => write!(f, "{e}")?,
+                        }
                     }
+                    write!(f, "]")
+                } else {
+                    write!(f, "{{ ")?;
+                    for (i, r) in c.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ", ")?;
+                        }
+                        if i == 8 {
+                            write!(f, "…")?;
+                            break;
+                        }
+                        match r {
+                            Ok((key, value)) => write!(f, "{}: {}", key, value)?,
+                            Err(e) => write!(f, "{e}")?,
+                        }
+                    }
+                    write!(f, " }}")
                 }
-                write!(f, "]")
-            }
-            TypedValue::Dictionary(d) => {
-                write!(f, "{{ ")?;
-                for (i, r) in d.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ", ")?;
-                    }
-                    if i == 8 {
-                        write!(f, "…")?;
-                        break;
-                    }
-                    match r {
-                        Ok((key, value)) => write!(f, "{}: {}", key, value)?,
-                        Err(e) => write!(f, "{e}")?,
-                    }
-                }
-                write!(f, " }}")
-            }
-            TypedValue::Set(s) => {
-                write!(f, "#[")?;
-                for (i, r) in s.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ", ")?;
-                    }
-                    if i == 8 {
-                        write!(f, "…")?;
-                        break;
-                    }
-                    match r {
-                        Ok(value) => write!(f, "{}", value)?,
-                        Err(e) => write!(f, "{e}")?,
-                    }
-                }
-                write!(f, "]")
             }
             TypedValue::PublicKey(p) => write!(f, "PublicKey({})", p),
             TypedValue::SecretKey(p) => write!(f, "SecretKey({})", p),
@@ -221,9 +243,7 @@ impl From<&TypedValue> for RawValue {
         match v {
             TypedValue::String(s) => RawValue::from(hash_str(s)),
             TypedValue::Int(v) => RawValue::from(*v),
-            TypedValue::Dictionary(d) => RawValue::from(d.commitment()),
-            TypedValue::Set(s) => RawValue::from(s.commitment()),
-            TypedValue::Array(a) => RawValue::from(a.commitment()),
+            TypedValue::Container(d) => RawValue::from(d.commitment()),
             TypedValue::Raw(v) => *v,
             TypedValue::PublicKey(p) => RawValue::from(hash_fields(&p.as_fields())),
             TypedValue::SecretKey(sk) => RawValue::from(hash_fields(&sk.to_limbs())),
@@ -407,9 +427,7 @@ enum TypedValueNoRec {
     PublicKey(PublicKey),
     SecretKey(SecretKey),
     Predicate(Predicate),
-    Set(Hash),
-    Dictionary(Hash),
-    Array(Hash),
+    Container(Hash),
     String(String),
 }
 
@@ -423,9 +441,7 @@ impl Value {
             TypedValue::PublicKey(v) => TypedValueNoRec::PublicKey(*v),
             TypedValue::SecretKey(v) => TypedValueNoRec::SecretKey(v.clone()),
             TypedValue::Predicate(v) => TypedValueNoRec::Predicate(v.clone()),
-            TypedValue::Set(v) => TypedValueNoRec::Set(v.commitment()),
-            TypedValue::Dictionary(v) => TypedValueNoRec::Dictionary(v.commitment()),
-            TypedValue::Array(v) => TypedValueNoRec::Array(v.commitment()),
+            TypedValue::Container(v) => TypedValueNoRec::Container(v.commitment()),
             TypedValue::String(v) => TypedValueNoRec::String(v.clone()),
         };
         serde_json::to_vec(&v).expect("json serialization succeeds")
@@ -438,9 +454,7 @@ impl Value {
             TypedValueNoRec::PublicKey(v) => Value::from(v),
             TypedValueNoRec::SecretKey(v) => Value::from(v),
             TypedValueNoRec::Predicate(v) => Value::from(v),
-            TypedValueNoRec::Set(v) => Value::from(Set::from_db(v, db)?),
-            TypedValueNoRec::Dictionary(v) => Value::from(Dictionary::from_db(v, db)?),
-            TypedValueNoRec::Array(v) => Value::from(Array::from_db(v, db)?),
+            TypedValueNoRec::Container(v) => Value::from(Container::from_db(v, db)?),
             TypedValueNoRec::String(v) => Value::from(v),
         })
     }
@@ -512,45 +526,25 @@ impl Value {
     }
     pub fn as_set(&self) -> Option<Set> {
         match &self.typed {
-            TypedValue::Set(s) => Some(s.clone()),
-            TypedValue::Dictionary(d) => Some(Set {
-                inner: d.inner.clone(),
-            }),
-            TypedValue::Array(a) => Some(Set {
-                inner: a.inner.clone(),
-            }),
+            TypedValue::Container(c) => c.as_set(),
             _ => None,
         }
     }
     pub fn as_container(&self) -> Option<Container> {
         match &self.typed {
-            TypedValue::Set(s) => Some(s.inner.clone()),
-            TypedValue::Dictionary(d) => Some(d.inner.clone()),
-            TypedValue::Array(a) => Some(a.inner.clone()),
+            TypedValue::Container(c) => Some(c.clone()),
             _ => None,
         }
     }
     pub fn as_dictionary(&self) -> Option<Dictionary> {
         match &self.typed {
-            TypedValue::Set(s) => Some(Dictionary {
-                inner: s.inner.clone(),
-            }),
-            TypedValue::Dictionary(d) => Some(d.clone()),
-            TypedValue::Array(a) => Some(Dictionary {
-                inner: a.inner.clone(),
-            }),
+            TypedValue::Container(c) => c.as_dictionary(),
             _ => None,
         }
     }
     pub fn as_array(&self) -> Option<Array> {
         match &self.typed {
-            TypedValue::Set(s) => Some(Array {
-                inner: s.inner.clone(),
-            }),
-            TypedValue::Dictionary(d) => Some(Array {
-                inner: d.inner.clone(),
-            }),
-            TypedValue::Array(a) => Some(a.clone()),
+            TypedValue::Container(c) => c.as_array(),
             _ => None,
         }
     }

--- a/src/middleware/operation.rs
+++ b/src/middleware/operation.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     backends::plonky2::primitives::{
         ec::{curve::GROUP_ORDER, schnorr::Signature},
-        merkletree::{MerkleProof, MerkleTree, MerkleTreeOp, MerkleTreeStateTransitionProof},
+        merkletree::{self, MerkleProof, MerkleTreeOp, MerkleTreeStateTransitionProof},
     },
     middleware::{
         hash_values, normalize_statement, AnchoredKey, CustomPredicate, CustomPredicateRef, Error,
@@ -536,13 +536,13 @@ impl Operation {
                 let root = val(root_v, root_s)?;
                 let key = val(key_v, key_s)?;
                 let value = val(val_v, val_s)?;
-                MerkleTree::verify(root.raw().into(), pf, &key.raw(), &value.raw())?;
+                merkletree::verify(root.raw().into(), pf, &key.raw(), &value.raw())?;
                 true
             }
             (Self::NotContainsFromEntries(root_s, key_s, pf), NotContains(root_v, key_v)) => {
                 let root = val(root_v, root_s)?;
                 let key = val(key_v, key_s)?;
-                MerkleTree::verify_nonexistence(root.raw().into(), pf, &key.raw())?;
+                merkletree::verify_nonexistence(root.raw().into(), pf, &key.raw())?;
                 true
             }
             (
@@ -585,7 +585,7 @@ impl Operation {
                 .ok_or(Error::custom(
                     "The provided Merkle tree state transition proof does not match the claim.",
                 ))?;
-                MerkleTree::verify_state_transition(pf)?;
+                merkletree::verify_state_transition(pf)?;
                 true
             }
             (
@@ -605,7 +605,7 @@ impl Operation {
                 .ok_or(Error::custom(
                     "The provided Merkle tree state transition proof does not match the claim.",
                 ))?;
-                MerkleTree::verify_state_transition(pf)?;
+                merkletree::verify_state_transition(pf)?;
                 true
             }
             (
@@ -623,7 +623,7 @@ impl Operation {
                 .ok_or(Error::custom(
                     "The provided Merkle tree state transition proof does not match the claim.",
                 ))?;
-                MerkleTree::verify_state_transition(pf)?;
+                merkletree::verify_state_transition(pf)?;
                 true
             }
             (Self::Custom(CustomPredicateRef { batch, index }, args), Custom(cpr, s_args))
@@ -649,7 +649,7 @@ impl Operation {
                     return Err(deduction_err());
                 }
                 let raw_st_hash = data.raw_statement.hash();
-                MerkleTree::verify(
+                merkletree::verify(
                     data.sts_root,
                     &data.proof,
                     &Value::from(data.st_index as i64).raw(),


### PR DESCRIPTION
Now containers store a bitmask in the `kind` field which contains a flag for valid container types that have been observed in the backing database so far.
With this information we can do proper type checking when casting a Value or a generic Container to a particular kind (Dictionary, Set or Array).

To store this information in the database we need a new key-value entry to associate the kind with the merkle root.  Because we can only store this association after we know the new merkle root, I had to refactor the database traits to work via transactions so that storing the root + bitmask happens atomically.  This corresponds to he biggest change in this PR:
- many merkle tree functions have been refactored to work on database transactions
- the merkle tree and container database-associated traits have been refactored to include transactions
- the memory and disk database-associated trait implementations have been refactored accordingly

In serialization, any of Dictionary, Set, Array and Container use the same encoding, which is a generic container encoding plus the kind which is encoded as a simple 3 character string, inspired by rwx permissions commonly displayed in Unix.

Before this PR it was responsibility of the user to remember the container kind before using it, and the user would be able to cast to the wrong type and perform insert operations leading to a Frankenstein container.  Now this is not possible because the casting operation will return an error if that container had never been seen as the casted type before.  Moreover the user now gets a very good hint as to what kind of container they have by inspecting the bitmask.