### PR TITLE
Simplify MuxTableTarget, cheaper query hashes

### DIFF
--- a/src/backends/plonky2/circuits/common.rs
+++ b/src/backends/plonky2/circuits/common.rs
@@ -224,6 +224,10 @@ impl StatementTarget {
         Self::new_with_pred(builder, params, pred, args)
     }
 
+    pub fn hash(&self, builder: &mut CircuitBuilder) -> HashOutTarget {
+        builder.hash_n_to_hash_no_pad::<PoseidonHash>(self.flatten())
+    }
+
     pub fn set_targets(&self, pw: &mut PartialWitness<F>, st: &Statement) -> Result<()> {
         if let Some(pred) = &self.pred {
             pred.set_targets(pw, &st.predicate())?;
@@ -318,10 +322,6 @@ impl OperationTypeTarget {
 
     pub fn set_targets(&self, pw: &mut PartialWitness<F>, op_type: &OperationType) -> Result<()> {
         Ok(pw.set_target_arr(&self.elements, &op_type.to_fields())?)
-    }
-
-    fn size(_params: &Params) -> usize {
-        Params::operation_type_size()
     }
 }
 
@@ -921,58 +921,6 @@ impl CustomPredicateVerifyEntryTarget {
     }
 }
 
-/// Query for the custom predicate verification table
-#[derive(Clone, Serialize, Deserialize)]
-pub struct CustomPredicateVerifyQueryTarget {
-    pub statement: StatementTarget,
-    pub op_type: OperationTypeTarget,
-    pub op_args: Vec<StatementTarget>,
-}
-
-impl CustomPredicateVerifyQueryTarget {
-    pub fn hash(&self, builder: &mut CircuitBuilder) -> HashOutTarget {
-        builder.hash_n_to_hash_no_pad::<PoseidonHash>(self.flatten())
-    }
-}
-
-impl Flattenable for CustomPredicateVerifyQueryTarget {
-    fn flatten(&self) -> Vec<Target> {
-        self.statement
-            .flatten()
-            .iter()
-            .chain(self.op_type.elements.iter())
-            .cloned()
-            .chain(self.op_args.iter().flat_map(|op_arg| op_arg.flatten()))
-            .collect()
-    }
-    fn from_flattened(params: &Params, vs: &[Target]) -> Self {
-        assert_eq!(vs.len(), Self::size(params));
-        let (pos, size) = (0, StatementTarget::size(params));
-        let statement = StatementTarget::from_flattened(params, &vs[pos..pos + size]);
-        let (pos, size) = (pos + size, OperationTypeTarget::size(params));
-        let op_type = OperationTypeTarget {
-            elements: vs[pos..pos + size]
-                .try_into()
-                .expect("len = operation_type_size"),
-        };
-        let (pos, size) = (pos + size, StatementTarget::size(params));
-        let op_args = (0..BASE_PARAMS.max_operation_args)
-            .map(|i| {
-                StatementTarget::from_flattened(params, &vs[pos + i * size..pos + (1 + i) * size])
-            })
-            .collect();
-        Self {
-            statement,
-            op_type,
-            op_args,
-        }
-    }
-    fn size(params: &Params) -> usize {
-        StatementTarget::size(params) * (1 + BASE_PARAMS.max_operation_args)
-            + OperationTypeTarget::size(params)
-    }
-}
-
 /// Trait for target structs that may be converted to and from vectors
 /// of targets.
 pub trait Flattenable {
@@ -1376,14 +1324,16 @@ pub trait CircuitBuilderPod<F: RichField + Extendable<D>, const D: usize> {
     /// materializes the selected row via a witness generator and constrains its hash. Cheaper than
     /// `vec_ref` when each entry has many fields, since random access runs only over the 4-field
     /// hashes. The caller is responsible for precomputing `ts_flattened` and `ts_hashes` once and
-    /// reusing the same slices across multiple lookups.
+    /// reusing the same slices across multiple lookups. Returns the materialized row alongside
+    /// the selected hash (already constrained equal to the row's hash) so callers that need to
+    /// re-use the hash downstream can avoid re-computing it.
     fn vec_ref_projected<T: Flattenable>(
         &mut self,
         params: &Params,
         ts_flattened: &[Vec<Target>],
         ts_hashes: &[HashOutTarget],
         i: &IndexTarget,
-    ) -> T;
+    ) -> (T, HashOutTarget);
     fn select_flattenable<T: Flattenable>(
         &mut self,
         params: &Params,
@@ -1828,7 +1778,7 @@ impl CircuitBuilderPod<F, D> for CircuitBuilder {
         ts_flattened: &[Vec<Target>],
         ts_hashes: &[HashOutTarget],
         i: &IndexTarget,
-    ) -> T {
+    ) -> (T, HashOutTarget) {
         assert_eq!(ts_flattened.len(), ts_hashes.len());
         let selected_hash = self.vec_ref(params, ts_hashes, i);
         let selected_flattened = self.add_virtual_targets(T::size(params));
@@ -1841,7 +1791,7 @@ impl CircuitBuilderPod<F, D> for CircuitBuilder {
             ts_flattened.to_vec(),
             selected_flattened,
         ));
-        result
+        (result, selected_hash)
     }
 
     fn vec_ref_small<T: Flattenable>(&mut self, params: &Params, ts: &[T], i: Target) -> T {

--- a/src/backends/plonky2/circuits/mainpod/mod.rs
+++ b/src/backends/plonky2/circuits/mainpod/mod.rs
@@ -212,9 +212,9 @@ enum OperationAuxQueryKind {
     MerkleTransition = 3,
     MerkleDelete = 4,
     OpenInputStatement = 5,
-    PublicKeyOf = 6,
-    SignedBy = 7,
-    CustomPredVerify = 8,
+    CustomPredVerify = 6,
+    PublicKeyOf = 7,
+    SignedBy = 8,
 }
 
 fn operation_aux_query_hash(
@@ -294,7 +294,10 @@ fn hash_merkle_delete_query(
     )
 }
 
-fn hash_statement_query(builder: &mut CircuitBuilder, st_hash: &HashOutTarget) -> HashOutTarget {
+fn hash_open_input_statement_query(
+    builder: &mut CircuitBuilder,
+    st_hash: &HashOutTarget,
+) -> HashOutTarget {
     operation_aux_query_hash(
         builder,
         OperationAuxQueryKind::OpenInputStatement,
@@ -517,7 +520,7 @@ fn append_open_input_statements_aux_table_circuit(
             &pod.vd_hash,
         );
         let st_hash = st.hash(builder);
-        let query_hash = hash_statement_query(builder, &st_hash);
+        let query_hash = hash_open_input_statement_query(builder, &st_hash);
         table.push(query_hash);
         measure_gates_end!(builder, measure);
     }
@@ -1049,7 +1052,7 @@ fn verify_open_input_statement_circuit(
 ) -> BoolTarget {
     let measure = measure_gates_begin!(builder, "OpOpenInputSt");
     let op_code_ok = op_type.has_native(builder, NativeOperation::OpenInputStatement);
-    let expected_query_hash = hash_statement_query(builder, st_hash);
+    let expected_query_hash = hash_open_input_statement_query(builder, st_hash);
     let query_ok = builder.is_equal_flattenable(&resolved_query_hash, &expected_query_hash);
 
     let ok = builder.all([op_code_ok, query_ok]);

--- a/src/backends/plonky2/circuits/mainpod/mod.rs
+++ b/src/backends/plonky2/circuits/mainpod/mod.rs
@@ -22,14 +22,13 @@ use crate::{
         circuits::{
             common::{
                 CircuitBuilderPod, CustomPredicateEntryTarget, CustomPredicateInBatchTarget,
-                CustomPredicateTarget, CustomPredicateVerifyEntryTarget,
-                CustomPredicateVerifyQueryTarget, Flattenable, InputPodEntryTarget,
-                MerkleClaimTarget, MerkleTreeStateTransitionClaimTarget, OperationTarget,
-                OperationTypeTarget, PredicateHashOrWildcardTarget, PredicateTarget,
-                StatementArgTarget, StatementTarget, StatementTmplArgTarget, StatementTmplTarget,
-                ValueTarget,
+                CustomPredicateTarget, CustomPredicateVerifyEntryTarget, Flattenable,
+                InputPodEntryTarget, MerkleClaimTarget, MerkleTreeStateTransitionClaimTarget,
+                OperationTarget, OperationTypeTarget, PredicateHashOrWildcardTarget,
+                PredicateTarget, StatementArgTarget, StatementTarget, StatementTmplArgTarget,
+                StatementTmplTarget, ValueTarget,
             },
-            mux_table::{MuxTableTarget, TableEntryTarget},
+            mux_table::MuxTableTarget,
         },
         error::Result,
         mainpod::{self, MerkleProofs, MerkleTransitionProofs, SignedBy},
@@ -90,6 +89,7 @@ struct StatementCache<const MAX_EQS: usize> {
     equations: [StatementArgCache; MAX_EQS],
     first_n_equations_valid: [BoolTarget; MAX_EQS],
     op_args: Vec<StatementTarget>,
+    op_arg_hashes: Vec<HashOutTarget>,
 }
 
 impl<const MAX_EQS: usize> StatementCache<MAX_EQS> {
@@ -102,26 +102,34 @@ impl<const MAX_EQS: usize> StatementCache<MAX_EQS> {
         prev_statement_flatteneds: &[Vec<Target>],
         prev_statement_hashes: &[HashOutTarget],
     ) -> Self {
-        let op_args = if prev_statement_flatteneds.is_empty() {
-            (0..max_operation_args)
-                .map(|_| StatementTarget::new_native(builder, params, NativePredicate::None, &[]))
-                .collect_vec()
-        } else {
-            // `op.args` is a vector of arrays of length 1, so `.flatten()` is just
-            // converting a length 1 array into a scalar.
-            op.args
-                .iter()
-                .take(max_operation_args)
-                .map(|i| {
-                    builder.vec_ref_projected(
-                        params,
-                        prev_statement_flatteneds,
-                        prev_statement_hashes,
-                        i,
-                    )
-                })
-                .collect::<Vec<_>>()
-        };
+        let (op_args, op_arg_hashes): (Vec<StatementTarget>, Vec<HashOutTarget>) =
+            if prev_statement_flatteneds.is_empty() {
+                let op_args = (0..max_operation_args)
+                    .map(|_| {
+                        StatementTarget::new_native(builder, params, NativePredicate::None, &[])
+                    })
+                    .collect_vec();
+                let op_arg_hashes = op_args
+                    .iter()
+                    .map(|op_arg| op_arg.hash(builder))
+                    .collect_vec();
+                (op_args, op_arg_hashes)
+            } else {
+                // `op.args` is a vector of arrays of length 1, so `.flatten()` is just
+                // converting a length 1 array into a scalar.
+                op.args
+                    .iter()
+                    .take(max_operation_args)
+                    .map(|i| {
+                        builder.vec_ref_projected::<StatementTarget>(
+                            params,
+                            prev_statement_flatteneds,
+                            prev_statement_hashes,
+                            i,
+                        )
+                    })
+                    .unzip()
+            };
         assert!(Params::max_statement_args() >= MAX_VALUE_ARGS);
         let equations = array::from_fn(|i| {
             let pred_is_none = op_args[i].has_native_type(builder, NativePredicate::None);
@@ -168,6 +176,7 @@ impl<const MAX_EQS: usize> StatementCache<MAX_EQS> {
             equations,
             first_n_equations_valid,
             op_args,
+            op_arg_hashes,
         }
     }
 
@@ -191,22 +200,11 @@ impl<const MAX_EQS: usize> StatementCache<MAX_EQS> {
 /// Statement cache for private statements
 type StatementCachePriv = StatementCache<MAX_VALUE_ARGS>;
 
-enum OperationAuxTableTag {
-    None = 0,
-    MerkleProof = 1,
-    MerkleTransitionProof = 2,
-    OpenInputStatement = 3,
-    CustomPredVerify = 4,
-    PublicKeyOf = 5,
-    SignedBy = 6,
-}
-
-// Domain-separation tag prepended to the hashed query input for each aux kind.
-// This is distinct from `OperationAuxTableTag`: the table tag labels the physical
-// row segment, while this kind separates semantic query shapes that share a row tag,
-// such as `Contains`/`NotContains` or transition `Insert`/`Update`/`Delete`.
-// Custom verification (see `hash_custom_predicate_verify_query`) carries no query kind; its row
-// tag is sufficient because its input shape is structurally unique among aux kinds.
+// Domain-separation prefix folded into every aux query hash. Each kind gets a distinct prefix so
+// a query hash built for one kind can never equal one built for another (e.g. `Contains` vs
+// `NotContains`, or transition `Insert`/`Update`/`Delete`). That is what lets a table lookup
+// return a bare hash: a verify circuit recomputes the hash for its own kind and compares, so
+// pointing at the wrong row simply fails to match. No separate physical row tag is needed.
 #[derive(Copy, Clone)]
 enum OperationAuxQueryKind {
     MerkleContains = 1,
@@ -216,6 +214,7 @@ enum OperationAuxQueryKind {
     OpenInputStatement = 5,
     PublicKeyOf = 6,
     SignedBy = 7,
+    CustomPredVerify = 8,
 }
 
 fn operation_aux_query_hash(
@@ -295,11 +294,11 @@ fn hash_merkle_delete_query(
     )
 }
 
-fn hash_statement_query(builder: &mut CircuitBuilder, st: &StatementTarget) -> HashOutTarget {
+fn hash_statement_query(builder: &mut CircuitBuilder, st_hash: &HashOutTarget) -> HashOutTarget {
     operation_aux_query_hash(
         builder,
         OperationAuxQueryKind::OpenInputStatement,
-        st.flatten(),
+        st_hash.elements.to_vec(),
     )
 }
 
@@ -316,21 +315,27 @@ fn hash_pair_query(
     )
 }
 
-// Custom verification doesn't go through `operation_aux_query_hash`: its row tag is sufficient
-// because its input shape is structurally unique among aux kinds, so no query-kind prefix is
-// needed.
+/// Hash of a custom predicate verification query over its pre-hashed components: the output
+/// statement's hash, the operation type, and one hash per operation argument. Working from
+/// component hashes keeps the hashed input at a fixed `HASH_SIZE + operation_type_size +
+/// N * HASH_SIZE` (4 + 6 + N*4) regardless of statement width.
 fn hash_custom_predicate_verify_query(
     builder: &mut CircuitBuilder,
-    statement: StatementTarget,
-    op_type: OperationTypeTarget,
-    op_args: Vec<StatementTarget>,
+    statement_hash: &HashOutTarget,
+    op_type: &OperationTypeTarget,
+    op_arg_hashes: &[HashOutTarget],
 ) -> HashOutTarget {
-    CustomPredicateVerifyQueryTarget {
-        statement,
-        op_type,
-        op_args,
-    }
-    .hash(builder)
+    operation_aux_query_hash(
+        builder,
+        OperationAuxQueryKind::CustomPredVerify,
+        statement_hash
+            .elements
+            .iter()
+            .chain(op_type.elements.iter())
+            .chain(op_arg_hashes.iter().flat_map(|h| h.elements.iter()))
+            .copied()
+            .collect(),
+    )
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -410,11 +415,7 @@ fn append_container_proofs_operation_aux_table_circuit(
         let entry = MerkleClaimTarget::from_proof_existence(builder, merkle_proof.clone());
         let query_hash = hash_merkle_contains_query(builder, entry.root, entry.key, entry.value);
 
-        table.push(
-            builder,
-            OperationAuxTableTag::MerkleProof as u32,
-            &query_hash,
-        );
+        table.push(query_hash);
     }
     // Medium MerkleProofs: verify container merkle proofs (inclusion/non-inclusion)
     for merkle_proof in &merkle_proofs.medium {
@@ -431,11 +432,7 @@ fn append_container_proofs_operation_aux_table_circuit(
             &not_contains_query_hash,
         );
 
-        table.push(
-            builder,
-            OperationAuxTableTag::MerkleProof as u32,
-            &query_hash,
-        );
+        table.push(query_hash);
     }
 
     // Small Merkle state transition proofs: verify op proof (only update)
@@ -451,11 +448,7 @@ fn append_container_proofs_operation_aux_table_circuit(
             entry.op_value,
         );
 
-        table.push(
-            builder,
-            OperationAuxTableTag::MerkleTransitionProof as u32,
-            &query_hash,
-        );
+        table.push(query_hash);
     }
     // Medium Merkle state transition proofs: verify op proof (insert/update/delete)
     for merkle_transition_proof in &merkle_transition_proofs.medium {
@@ -480,11 +473,7 @@ fn append_container_proofs_operation_aux_table_circuit(
             &transition_query_hash,
         );
 
-        table.push(
-            builder,
-            OperationAuxTableTag::MerkleTransitionProof as u32,
-            &query_hash,
-        );
+        table.push(query_hash);
     }
 }
 
@@ -507,8 +496,7 @@ fn append_open_input_statements_aux_table_circuit(
         let measure = measure_gates_begin!(builder, "OpenInputSt");
         let pod = builder.vec_ref_small(params, input_pod_table, data.input_pod_table_index);
         let key = ValueTarget::from_int_lo(builder, data.st_index);
-        let raw_st_hash =
-            builder.hash_n_to_hash_no_pad::<PoseidonHash>(data.raw_statement.flatten());
+        let raw_st_hash = data.raw_statement.hash(builder);
         let value = ValueTarget {
             elements: raw_st_hash.elements,
         };
@@ -528,12 +516,9 @@ fn append_open_input_statements_aux_table_circuit(
             is_intro,
             &pod.vd_hash,
         );
-        let query_hash = hash_statement_query(builder, &st);
-        table.push(
-            builder,
-            OperationAuxTableTag::OpenInputStatement as u32,
-            &query_hash,
-        );
+        let st_hash = st.hash(builder);
+        let query_hash = hash_statement_query(builder, &st_hash);
+        table.push(query_hash);
         measure_gates_end!(builder, measure);
     }
 }
@@ -559,10 +544,7 @@ fn build_operation_aux_table_circuit(
         params.containers.state_ops.max_medium,
         input.merkle_proofs.medium.len()
     );
-    let mut table = MuxTableTarget::new(params, HashOutTarget::size(params));
-
-    // None
-    table.push_flattened(builder, OperationAuxTableTag::None as u32, &[]);
+    let mut table = MuxTableTarget::new(builder, params);
 
     append_container_proofs_operation_aux_table_circuit(
         params,
@@ -601,17 +583,15 @@ fn build_operation_aux_table_circuit(
         let out_query_hash = entry.custom_predicate.hash(builder);
         builder.connect_array(table_query_hash.elements, out_query_hash.elements);
 
-        let query_hash = hash_custom_predicate_verify_query(
-            builder,
-            statement,             // output
-            op_type,               // output
-            entry.op_args.clone(), // input
-        );
-        table.push(
-            builder,
-            OperationAuxTableTag::CustomPredVerify as u32,
-            &query_hash,
-        );
+        let statement_hash = statement.hash(builder);
+        let op_arg_hashes = entry
+            .op_args
+            .iter()
+            .map(|op_arg| op_arg.hash(builder))
+            .collect_vec();
+        let query_hash =
+            hash_custom_predicate_verify_query(builder, &statement_hash, &op_type, &op_arg_hashes);
+        table.push(query_hash);
         measure_gates_end!(builder, measure);
     }
 
@@ -645,11 +625,7 @@ fn build_operation_aux_table_circuit(
             sk_hash,
         );
 
-        table.push(
-            builder,
-            OperationAuxTableTag::PublicKeyOf as u32,
-            &query_hash,
-        );
+        table.push(query_hash);
         measure_gates_end!(builder, measure);
     }
 
@@ -682,7 +658,7 @@ fn build_operation_aux_table_circuit(
             pk_hash,
         );
 
-        table.push(builder, OperationAuxTableTag::SignedBy as u32, &query_hash);
+        table.push(query_hash);
         measure_gates_end!(builder, measure);
     }
 
@@ -693,17 +669,25 @@ fn build_operation_aux_table_circuit(
     Ok(table)
 }
 
+#[derive(Copy, Clone)]
+struct StatementWithHash<'a> {
+    statement: &'a StatementTarget,
+    hash: HashOutTarget,
+}
+
 #[allow(clippy::too_many_arguments)]
 fn verify_operation_circuit(
     params: &Params,
     builder: &mut CircuitBuilder,
-    st: &StatementTarget,
+    st: StatementWithHash,
     op: &OperationTarget,
     prev_statement_flatteneds: &[Vec<Target>],
     prev_statement_hashes: &[HashOutTarget],
     aux_table: &MuxTableTarget,
 ) -> Result<()> {
     let measure = measure_gates_begin!(builder, "OpVerifyPriv");
+    let st_hash = &st.hash;
+    let st = st.statement;
     let _true = builder._true();
     let _false = builder._false();
 
@@ -726,9 +710,7 @@ fn verify_operation_circuit(
     // entries in a table (e.g.: Merkle proofs ). These entries have already been verified, so we
     // need only look up the claim.
 
-    // The aux table always has a fixed zero entry, so we check if there are more than 1 entries to
-    // trigger the unhashing.
-    let resolved_aux = (aux_table.len() > 1).then(|| aux_table.get(builder, &op.aux_index));
+    let resolved_aux = aux_table.lookup(builder, &op.aux_index);
 
     // Op checks to carry out. Each 'verify_X_circuit' should be thought of as operation check
     // restricted to the op of type X, where the returned target is `false` if the input targets
@@ -758,7 +740,7 @@ fn verify_operation_circuit(
                     builder,
                     st,
                     &op.op_type,
-                    &resolved_aux,
+                    resolved_aux,
                     &cache,
                 ),
                 verify_not_contains_from_entries_circuit(
@@ -766,7 +748,7 @@ fn verify_operation_circuit(
                     builder,
                     st,
                     &op.op_type,
-                    &resolved_aux,
+                    resolved_aux,
                     &cache,
                 ),
             ]);
@@ -777,7 +759,7 @@ fn verify_operation_circuit(
                 builder,
                 st,
                 &op.op_type,
-                &resolved_aux,
+                resolved_aux,
                 &cache,
             ));
         }
@@ -787,7 +769,7 @@ fn verify_operation_circuit(
                 builder,
                 st,
                 &op.op_type,
-                &resolved_aux,
+                resolved_aux,
                 &cache,
             ));
         }
@@ -798,7 +780,7 @@ fn verify_operation_circuit(
                     builder,
                     st,
                     &op.op_type,
-                    &resolved_aux,
+                    resolved_aux,
                     &cache,
                 ),
                 verify_merkle_update_circuit(
@@ -806,7 +788,7 @@ fn verify_operation_circuit(
                     builder,
                     st,
                     &op.op_type,
-                    &resolved_aux,
+                    resolved_aux,
                     &cache,
                 ),
                 verify_merkle_delete_circuit(
@@ -814,7 +796,7 @@ fn verify_operation_circuit(
                     builder,
                     st,
                     &op.op_type,
-                    &resolved_aux,
+                    resolved_aux,
                     &cache,
                 ),
             ]);
@@ -822,18 +804,18 @@ fn verify_operation_circuit(
         if params.max_open_input_statement_ops > 0 {
             op_checks.extend_from_slice(&[verify_open_input_statement_circuit(
                 builder,
-                st,
+                st_hash,
                 &op.op_type,
-                &resolved_aux,
+                resolved_aux,
             )]);
         }
         if params.max_custom_predicate_verification_ops > 0 {
             op_checks.push(verify_custom_circuit(
                 builder,
-                st,
+                st_hash,
                 &op.op_type,
-                &resolved_aux,
-                &cache.op_args,
+                resolved_aux,
+                &cache.op_arg_hashes,
             ));
         }
     }
@@ -854,12 +836,10 @@ fn verify_contains_from_entries_circuit(
     builder: &mut CircuitBuilder,
     st: &StatementTarget,
     op_type: &OperationTypeTarget,
-    aux: &TableEntryTarget,
+    resolved_query_hash: HashOutTarget,
     cache: &StatementCachePriv,
 ) -> BoolTarget {
     let measure = measure_gates_begin!(builder, "OpContainsFromEntries");
-    let (aux_tag_ok, resolved_query_hash) =
-        aux.as_type::<HashOutTarget>(builder, OperationAuxTableTag::MerkleProof as u32);
     let op_code_ok = op_type.has_native(builder, NativeOperation::ContainsFromEntries);
 
     let (arg_types_ok, [merkle_root_value, key_value, value_value]) =
@@ -884,7 +864,7 @@ fn verify_contains_from_entries_circuit(
     );
     let st_ok = builder.is_equal_flattenable(st, &expected_statement);
 
-    let ok = builder.all([op_code_ok, aux_tag_ok, arg_types_ok, merkle_proof_ok, st_ok]);
+    let ok = builder.all([op_code_ok, arg_types_ok, merkle_proof_ok, st_ok]);
     measure_gates_end!(builder, measure);
     ok
 }
@@ -894,12 +874,10 @@ fn verify_not_contains_from_entries_circuit(
     builder: &mut CircuitBuilder,
     st: &StatementTarget,
     op_type: &OperationTypeTarget,
-    aux: &TableEntryTarget,
+    resolved_query_hash: HashOutTarget,
     cache: &StatementCachePriv,
 ) -> BoolTarget {
     let measure = measure_gates_begin!(builder, "OpNotContainsFromEntries");
-    let (aux_tag_ok, resolved_query_hash) =
-        aux.as_type::<HashOutTarget>(builder, OperationAuxTableTag::MerkleProof as u32);
     let op_code_ok = op_type.has_native(builder, NativeOperation::NotContainsFromEntries);
 
     let (arg_types_ok, [merkle_root_value, key_value]) = cache.first_n_args_as_values();
@@ -918,7 +896,7 @@ fn verify_not_contains_from_entries_circuit(
     );
     let st_ok = builder.is_equal_flattenable(st, &expected_statement);
 
-    let ok = builder.all([op_code_ok, aux_tag_ok, arg_types_ok, merkle_proof_ok, st_ok]);
+    let ok = builder.all([op_code_ok, arg_types_ok, merkle_proof_ok, st_ok]);
     measure_gates_end!(builder, measure);
     ok
 }
@@ -928,12 +906,10 @@ fn verify_merkle_insert_circuit(
     builder: &mut CircuitBuilder,
     st: &StatementTarget,
     op_type: &OperationTypeTarget,
-    aux: &TableEntryTarget,
+    resolved_query_hash: HashOutTarget,
     cache: &StatementCachePriv,
 ) -> BoolTarget {
     let measure = measure_gates_begin!(builder, "MerkleInsertOp");
-    let (aux_tag_ok, resolved_query_hash) =
-        aux.as_type::<HashOutTarget>(builder, OperationAuxTableTag::MerkleTransitionProof as u32);
     let op_code_ok = op_type.has_native(builder, NativeOperation::ContainerInsertFromEntries);
 
     let (arg_types_ok, [old_root_value, op_key_value, op_value_value, new_root_value]) =
@@ -963,7 +939,7 @@ fn verify_merkle_insert_circuit(
     );
     let st_ok = builder.is_equal_flattenable(st, &expected_statement);
 
-    let ok = builder.all([op_code_ok, aux_tag_ok, arg_types_ok, merkle_proof_ok, st_ok]);
+    let ok = builder.all([op_code_ok, arg_types_ok, merkle_proof_ok, st_ok]);
     measure_gates_end!(builder, measure);
     ok
 }
@@ -973,12 +949,10 @@ fn verify_merkle_update_circuit(
     builder: &mut CircuitBuilder,
     st: &StatementTarget,
     op_type: &OperationTypeTarget,
-    aux: &TableEntryTarget,
+    resolved_query_hash: HashOutTarget,
     cache: &StatementCachePriv,
 ) -> BoolTarget {
     let measure = measure_gates_begin!(builder, "MerkleUpdateOp");
-    let (aux_tag_ok, resolved_query_hash) =
-        aux.as_type::<HashOutTarget>(builder, OperationAuxTableTag::MerkleTransitionProof as u32);
     let op_code_ok = op_type.has_native(builder, NativeOperation::ContainerUpdateFromEntries);
 
     let (arg_types_ok, [old_root_value, op_key_value, op_value_value, new_root_value]) =
@@ -1008,7 +982,7 @@ fn verify_merkle_update_circuit(
     );
     let st_ok = builder.is_equal_flattenable(st, &expected_statement);
 
-    let ok = builder.all([op_code_ok, aux_tag_ok, arg_types_ok, merkle_proof_ok, st_ok]);
+    let ok = builder.all([op_code_ok, arg_types_ok, merkle_proof_ok, st_ok]);
     measure_gates_end!(builder, measure);
     ok
 }
@@ -1018,12 +992,10 @@ fn verify_merkle_delete_circuit(
     builder: &mut CircuitBuilder,
     st: &StatementTarget,
     op_type: &OperationTypeTarget,
-    aux: &TableEntryTarget,
+    resolved_query_hash: HashOutTarget,
     cache: &StatementCachePriv,
 ) -> BoolTarget {
     let measure = measure_gates_begin!(builder, "MerkleDeleteOp");
-    let (aux_tag_ok, resolved_query_hash) =
-        aux.as_type::<HashOutTarget>(builder, OperationAuxTableTag::MerkleTransitionProof as u32);
     let op_code_ok = op_type.has_native(builder, NativeOperation::ContainerDeleteFromEntries);
 
     let (arg_types_ok, [old_root_value, op_key_value, new_root_value]) =
@@ -1049,48 +1021,38 @@ fn verify_merkle_delete_circuit(
     );
     let st_ok = builder.is_equal_flattenable(st, &expected_statement);
 
-    let ok = builder.all([op_code_ok, aux_tag_ok, arg_types_ok, merkle_proof_ok, st_ok]);
+    let ok = builder.all([op_code_ok, arg_types_ok, merkle_proof_ok, st_ok]);
     measure_gates_end!(builder, measure);
     ok
 }
 
 fn verify_custom_circuit(
     builder: &mut CircuitBuilder,
-    st: &StatementTarget,
+    st_hash: &HashOutTarget,
     op_type: &OperationTypeTarget,
-    aux: &TableEntryTarget,
-    resolved_op_args: &[StatementTarget],
+    resolved_query_hash: HashOutTarget,
+    resolved_op_arg_hashes: &[HashOutTarget],
 ) -> BoolTarget {
     let measure = measure_gates_begin!(builder, "OpCustom");
-    let (aux_tag_ok, resolved_query_hash) =
-        aux.as_type::<HashOutTarget>(builder, OperationAuxTableTag::CustomPredVerify as u32);
-
-    let query_hash = hash_custom_predicate_verify_query(
-        builder,
-        st.clone(),
-        op_type.clone(),
-        resolved_op_args.to_vec(),
-    );
+    let query_hash =
+        hash_custom_predicate_verify_query(builder, st_hash, op_type, resolved_op_arg_hashes);
     let query_ok = builder.is_equal_flattenable(&resolved_query_hash, &query_hash);
-    let ok = builder.all([aux_tag_ok, query_ok]);
     measure_gates_end!(builder, measure);
-    ok
+    query_ok
 }
 
 fn verify_open_input_statement_circuit(
     builder: &mut CircuitBuilder,
-    st: &StatementTarget,
+    st_hash: &HashOutTarget,
     op_type: &OperationTypeTarget,
-    aux: &TableEntryTarget,
+    resolved_query_hash: HashOutTarget,
 ) -> BoolTarget {
     let measure = measure_gates_begin!(builder, "OpOpenInputSt");
-    let (aux_tag_ok, resolved_query_hash) =
-        aux.as_type::<HashOutTarget>(builder, OperationAuxTableTag::OpenInputStatement as u32);
     let op_code_ok = op_type.has_native(builder, NativeOperation::OpenInputStatement);
-    let expected_query_hash = hash_statement_query(builder, st);
+    let expected_query_hash = hash_statement_query(builder, st_hash);
     let query_ok = builder.is_equal_flattenable(&resolved_query_hash, &expected_query_hash);
 
-    let ok = builder.all([op_code_ok, aux_tag_ok, query_ok]);
+    let ok = builder.all([op_code_ok, query_ok]);
     measure_gates_end!(builder, measure);
     ok
 }
@@ -1250,12 +1212,10 @@ fn verify_public_key_from_entries_circuit(
     builder: &mut CircuitBuilder,
     st: &StatementTarget,
     op_type: &OperationTypeTarget,
-    aux: &TableEntryTarget,
+    resolved_query_hash: HashOutTarget,
     cache: &StatementCachePriv,
 ) -> BoolTarget {
     let measure = measure_gates_begin!(builder, "OpPublicKey");
-    let (aux_tag_ok, resolved_query_hash) =
-        aux.as_type::<HashOutTarget>(builder, OperationAuxTableTag::PublicKeyOf as u32);
 
     let op_code_ok = op_type.has_native(builder, NativeOperation::PublicKeyFromEntries);
     let (arg_types_ok, [arg1_value, arg2_value]) = cache.first_n_args_as_values();
@@ -1280,7 +1240,7 @@ fn verify_public_key_from_entries_circuit(
     );
     let st_ok = builder.is_equal_flattenable(st, &expected_statement);
 
-    let ok = builder.all([op_code_ok, aux_tag_ok, arg_types_ok, query_ok, st_ok]);
+    let ok = builder.all([op_code_ok, arg_types_ok, query_ok, st_ok]);
     measure_gates_end!(builder, measure);
     ok
 }
@@ -1290,12 +1250,10 @@ fn verify_signed_by_circuit(
     builder: &mut CircuitBuilder,
     st: &StatementTarget,
     op_type: &OperationTypeTarget,
-    aux: &TableEntryTarget,
+    resolved_query_hash: HashOutTarget,
     cache: &StatementCachePriv,
 ) -> BoolTarget {
     let measure = measure_gates_begin!(builder, "OpSignedBy");
-    let (aux_tag_ok, resolved_query_hash) =
-        aux.as_type::<HashOutTarget>(builder, OperationAuxTableTag::SignedBy as u32);
 
     let op_code_ok = op_type.has_native(builder, NativeOperation::SignedByFromEntries);
     let (arg_types_ok, [arg1_value, arg2_value]) = cache.first_n_args_as_values();
@@ -1321,7 +1279,7 @@ fn verify_signed_by_circuit(
     );
     let st_ok = builder.is_equal_flattenable(st, &expected_statement);
 
-    let ok = builder.all([op_code_ok, aux_tag_ok, arg_types_ok, query_ok, st_ok]);
+    let ok = builder.all([op_code_ok, arg_types_ok, query_ok, st_ok]);
     measure_gates_end!(builder, measure);
     ok
 }
@@ -1999,12 +1957,17 @@ fn verify_main_pod_circuit(
         .iter()
         .map(|flat| builder.hash_n_to_hash_no_pad::<PoseidonHash>(flat.clone()))
         .collect_vec();
+    // Pair each statement with its hash here, where the two are known to correspond, so nothing
+    // downstream has to keep a statement and a loose hash aligned by hand.
+    let statements_with_hashes = statements
+        .zip(&statement_hashes)
+        .map(|(statement, &hash)| StatementWithHash { statement, hash })
+        .collect_vec();
 
     // 5. Verify statements
-    for (j, (is_pub, pub_insert_idx, st, op)) in izip!(
+    for (j, (is_pub, pub_insert_idx, op)) in izip!(
         &main_pod.statements_is_pub,
         &main_pod.pub_insert_idx,
-        &main_pod.statements,
         &main_pod.operations
     )
     .enumerate()
@@ -2012,6 +1975,7 @@ fn verify_main_pod_circuit(
         let i = j + 1; // Previous statement have a hardcoded None at index 0
         let prev_statement_flatteneds = &statement_flatteneds[..i];
         let prev_statement_hashes = &statement_hashes[..i];
+        let st = statements_with_hashes[i];
         verify_operation_circuit(
             params,
             builder,
@@ -2022,7 +1986,6 @@ fn verify_main_pod_circuit(
             &aux_tables,
         )?;
         let measure = measure_gates_begin!(builder, "PubSt");
-        let st_hash = statement_hashes[i];
         let sts_roots_entry = builder.vec_ref_small(params, &sts_roots_table, *pub_insert_idx);
         builder.conditional_assert_eq_flattenable(
             is_pub.target,
@@ -2032,7 +1995,7 @@ fn verify_main_pod_circuit(
         builder.conditional_assert_eq_flattenable(
             is_pub.target,
             &sts_roots_entry.st_hash,
-            &ValueTarget::from(st_hash),
+            &ValueTarget::from(st.hash),
         );
         let new_sts_root =
             builder.select_flattenable(params, *is_pub, &sts_roots_entry.new_root, &sts_root);

--- a/src/backends/plonky2/circuits/mainpod/tests.rs
+++ b/src/backends/plonky2/circuits/mainpod/tests.rs
@@ -162,10 +162,14 @@ fn operation_verify(
     let aux_tables =
         build_operation_aux_table_circuit(&params, &mut builder, &[], &[], &aux_table_inputs)?;
 
+    let st_hash_target = st_target.hash(&mut builder);
     verify_operation_circuit(
         &params,
         &mut builder,
-        &st_target,
+        StatementWithHash {
+            statement: &st_target,
+            hash: st_hash_target,
+        },
         &op_target,
         &prev_statement_flatteneds_target,
         &prev_statement_hashes_target,
@@ -1638,30 +1642,20 @@ fn custom_pred_verify_hash_table_lookup(index: usize, expected_hash: HashOut) ->
     let config = CircuitConfig::standard_recursion_config();
     let mut builder = CircuitBuilder::new(config);
 
-    let mut custom_pred_verify_hashes = MuxTableTarget::new(&params, HashOutTarget::size(&params));
+    // `new` seeds the sentinel at index 0, so the two real rows land at indices 1 and 2.
+    let mut custom_pred_verify_hashes = MuxTableTarget::new(&mut builder, &params);
     let hash0 = builder.constant_hash(HashOut {
         elements: [F(11), F(12), F(13), F(14)],
     });
     let hash1 = builder.constant_hash(HashOut {
         elements: [F(21), F(22), F(23), F(24)],
     });
-    custom_pred_verify_hashes.push_flattened(
-        &mut builder,
-        OperationAuxTableTag::CustomPredVerify as u32,
-        &hash0.elements,
-    );
-    custom_pred_verify_hashes.push_flattened(
-        &mut builder,
-        OperationAuxTableTag::CustomPredVerify as u32,
-        &hash1.elements,
-    );
+    custom_pred_verify_hashes.push(hash0);
+    custom_pred_verify_hashes.push(hash1);
 
-    let index_target = IndexTarget::new_virtual(2, &mut builder);
-    let resolved_hash_entry = custom_pred_verify_hashes.get(&mut builder, &index_target);
-    let (aux_tag_ok, resolved_query_hash) = resolved_hash_entry
-        .as_type::<HashOutTarget>(&mut builder, OperationAuxTableTag::CustomPredVerify as u32);
+    let index_target = IndexTarget::new_virtual(3, &mut builder);
+    let resolved_query_hash = custom_pred_verify_hashes.get(&mut builder, &index_target);
     let expected_hash_target = builder.constant_hash(expected_hash);
-    builder.assert_one(aux_tag_ok.target);
     builder.connect_hashes(resolved_query_hash, expected_hash_target);
 
     let mut pw = PartialWitness::<F>::new();
@@ -1677,21 +1671,49 @@ fn test_custom_pred_verify_hash_table_index_selection() {
     let hash0 = HashOut {
         elements: [F(11), F(12), F(13), F(14)],
     };
-    custom_pred_verify_hash_table_lookup(0, hash0).unwrap();
-    assert!(custom_pred_verify_hash_table_lookup(1, hash0).is_err());
+    // hash0 sits at index 1 (index 0 is the sentinel); index 2 holds the other row.
+    custom_pred_verify_hash_table_lookup(1, hash0).unwrap();
+    assert!(custom_pred_verify_hash_table_lookup(2, hash0).is_err());
 }
 
-fn prove_connected_aux_query_hashes(
-    hash_pair: impl FnOnce(
-        &mut crate::backends::plonky2::basetypes::CircuitBuilder,
-    ) -> (HashOutTarget, HashOutTarget),
+/// Build a custom-verify query hash over fresh virtual targets for the given components and record
+/// their witness values, returning the query-hash target.
+fn build_custom_query_side(
+    builder: &mut crate::backends::plonky2::basetypes::CircuitBuilder,
+    pw: &mut PartialWitness<F>,
+    st: HashOut,
+    op: &OperationType,
+    op_args: &[HashOut],
+) -> Result<HashOutTarget> {
+    let st_target = builder.add_virtual_hash();
+    let op_target = builder.add_virtual_operation_type();
+    let arg_targets: Vec<_> = op_args.iter().map(|_| builder.add_virtual_hash()).collect();
+    let query_hash =
+        hash_custom_predicate_verify_query(builder, &st_target, &op_target, &arg_targets);
+
+    pw.set_hash_target(st_target, st)?;
+    op_target.set_targets(pw, op)?;
+    for (target, hash) in arg_targets.iter().zip(op_args) {
+        pw.set_hash_target(*target, *hash)?;
+    }
+    Ok(query_hash)
+}
+
+/// Build two custom-verify query hashes from full components and require them to be equal, so a
+/// mismatch surfaces as a prove failure. A test varies one component (statement hash, op type, or
+/// op args) across the two sides to check that component is bound into the query hash.
+fn custom_query_hashes_match(
+    lhs: (HashOut, &OperationType, &[HashOut]),
+    rhs: (HashOut, &OperationType, &[HashOut]),
 ) -> Result<()> {
     let config = CircuitConfig::standard_recursion_config();
-    let mut builder = crate::backends::plonky2::basetypes::CircuitBuilder::new(config);
-    let (left, right) = hash_pair(&mut builder);
-    builder.connect_hashes(left, right);
+    let mut builder = CircuitBuilder::new(config);
+    let mut pw = PartialWitness::<F>::new();
 
-    let pw = PartialWitness::<F>::new();
+    let lhs_query_hash = build_custom_query_side(&mut builder, &mut pw, lhs.0, lhs.1, lhs.2)?;
+    let rhs_query_hash = build_custom_query_side(&mut builder, &mut pw, rhs.0, rhs.1, rhs.2)?;
+    builder.connect_hashes(lhs_query_hash, rhs_query_hash);
+
     let data = builder.build::<C>();
     let proof = data.prove(pw)?;
     data.verify(proof)?;
@@ -1699,38 +1721,113 @@ fn prove_connected_aux_query_hashes(
 }
 
 #[test]
-fn test_aux_query_hash_distinguishes_contains_from_not_contains() {
-    assert!(prove_connected_aux_query_hashes(|builder| {
-        let root = builder.constant_hash(HashOut {
-            elements: [F(1), F(2), F(3), F(4)],
-        });
-        let key = builder.constant_value(RawValue::from(42));
-        let value = builder.constant_value(RawValue::from(0));
-        let contains_hash = hash_merkle_contains_query(builder, root, key, value);
-        let not_contains_hash = hash_merkle_not_contains_query(builder, root, key);
-        (contains_hash, not_contains_hash)
-    })
-    .is_err());
+fn test_custom_query_hash_is_sensitive_to_op_arg_order_and_content() {
+    let st = HashOut {
+        elements: [F(101), F(102), F(103), F(104)],
+    };
+    let op = OperationType::Native(NativeOperation::None);
+    let hash_a = HashOut {
+        elements: [F(1), F(2), F(3), F(4)],
+    };
+    let hash_b = HashOut {
+        elements: [F(5), F(6), F(7), F(8)],
+    };
+    let hash_c = HashOut {
+        elements: [F(9), F(10), F(11), F(12)],
+    };
+
+    custom_query_hashes_match((st, &op, &[hash_a, hash_b]), (st, &op, &[hash_a, hash_b])).unwrap();
+    assert!(
+        custom_query_hashes_match((st, &op, &[hash_a, hash_b]), (st, &op, &[hash_b, hash_a]))
+            .is_err()
+    );
+    assert!(
+        custom_query_hashes_match((st, &op, &[hash_a, hash_b]), (st, &op, &[hash_a, hash_c]))
+            .is_err()
+    );
 }
 
 #[test]
-fn test_aux_query_hash_distinguishes_transition_delete_from_delete_shape() {
-    assert!(prove_connected_aux_query_hashes(|builder| {
-        let old_root = builder.constant_hash(HashOut {
-            elements: [F(11), F(12), F(13), F(14)],
-        });
-        let new_root = builder.constant_hash(HashOut {
-            elements: [F(21), F(22), F(23), F(24)],
-        });
-        let key = builder.constant_value(RawValue::from(7));
-        let value = builder.constant_value(RawValue::from(0));
-        let delete_op = builder.constant(F::from_canonical_u8(MerkleTreeOp::Delete as u8));
-        let transition_hash =
-            hash_merkle_transition_query(builder, delete_op, old_root, new_root, key, value);
-        let delete_hash = hash_merkle_delete_query(builder, old_root, new_root, key);
-        (transition_hash, delete_hash)
-    })
-    .is_err());
+fn test_custom_query_hash_is_sensitive_to_statement_and_op_type() {
+    let st_a = HashOut {
+        elements: [F(1), F(2), F(3), F(4)],
+    };
+    let st_b = HashOut {
+        elements: [F(5), F(6), F(7), F(8)],
+    };
+    let op_arg = HashOut {
+        elements: [F(9), F(10), F(11), F(12)],
+    };
+    let op_a = OperationType::Native(NativeOperation::None);
+    let op_b = OperationType::Native(NativeOperation::ContainsFromEntries);
+
+    // Identical components agree.
+    custom_query_hashes_match((st_a, &op_a, &[op_arg]), (st_a, &op_a, &[op_arg])).unwrap();
+    // The statement hash is bound into the query.
+    assert!(custom_query_hashes_match((st_a, &op_a, &[op_arg]), (st_b, &op_a, &[op_arg])).is_err());
+    // The op type is bound into the query.
+    assert!(custom_query_hashes_match((st_a, &op_a, &[op_arg]), (st_a, &op_b, &[op_arg])).is_err());
+}
+
+/// Build one query of every aux kind over deliberately-overlapping field values, so only the kind
+/// (and field shape) separates them, and require all the resulting hashes to be pairwise distinct.
+/// Soundness rests on each kind folding a distinct prefix into its hash; this is the one place that
+/// exercises every kind at once, so a duplicate `OperationAuxQueryKind` value or a dropped prefix
+/// that let one kind's row satisfy another's verify circuit shows up as a collision here.
+#[test]
+fn test_aux_query_kinds_are_pairwise_distinct() -> Result<()> {
+    let config = CircuitConfig::standard_recursion_config();
+    let mut builder = CircuitBuilder::new(config);
+
+    // Reuse the same data across kinds so the kind, not the data, is what separates the hashes.
+    let h_a = builder.constant_hash(HashOut {
+        elements: [F(1), F(2), F(3), F(4)],
+    });
+    let h_b = builder.constant_hash(HashOut {
+        elements: [F(5), F(6), F(7), F(8)],
+    });
+    let v_a = builder.constant_value(RawValue::from(1));
+    let v_b = builder.constant_value(RawValue::from(2));
+    // Give the transition query the delete op: that is the worst case for a collision with the
+    // delete query (both describe a delete), so distinctness here means only the kind separates them.
+    let op = builder.constant(F::from_canonical_u8(MerkleTreeOp::Delete as u8));
+    let op_type = builder.add_virtual_operation_type();
+    let op_arg_hashes = vec![h_a, h_b];
+
+    let hashes = [
+        hash_merkle_contains_query(&mut builder, h_a, v_a, v_b),
+        hash_merkle_not_contains_query(&mut builder, h_a, v_a),
+        hash_merkle_transition_query(&mut builder, op, h_a, h_b, v_a, v_b),
+        hash_merkle_delete_query(&mut builder, h_a, h_b, v_a),
+        hash_statement_query(&mut builder, &h_a),
+        hash_pair_query(&mut builder, OperationAuxQueryKind::PublicKeyOf, h_a, h_b),
+        hash_pair_query(&mut builder, OperationAuxQueryKind::SignedBy, h_a, h_b),
+        hash_custom_predicate_verify_query(&mut builder, &h_a, &op_type, &op_arg_hashes),
+    ];
+    for hash in &hashes {
+        builder.register_public_inputs(&hash.elements);
+    }
+
+    let mut pw = PartialWitness::<F>::new();
+    op_type.set_targets(&mut pw, &OperationType::Native(NativeOperation::None))?;
+    let data = builder.build::<C>();
+    let proof = data.prove(pw)?;
+    let out: Vec<HashOut> = proof
+        .public_inputs
+        .chunks(4)
+        .map(|c| HashOut {
+            elements: [c[0], c[1], c[2], c[3]],
+        })
+        .collect();
+    data.verify(proof)?;
+
+    assert_eq!(out.len(), hashes.len());
+    for i in 0..out.len() {
+        for j in (i + 1)..out.len() {
+            assert_ne!(out[i], out[j], "aux query kinds {i} and {j} collide");
+        }
+    }
+    Ok(())
 }
 
 /// Drives `verify_custom_circuit` against an aux table whose only real entry stores
@@ -1767,35 +1864,40 @@ fn helper_verify_custom_mutation(
     let stored_op_args_target: Vec<_> = (0..BASE_PARAMS.max_operation_args)
         .map(|_| builder.add_virtual_statement(false))
         .collect();
-    let stored_hash = CustomPredicateVerifyQueryTarget {
-        statement: stored_st_target.clone(),
-        op_type: stored_op_type_target.clone(),
-        op_args: stored_op_args_target.clone(),
-    }
-    .hash(&mut builder);
-
-    let mut tbl = MuxTableTarget::new(&params, HashOutTarget::size(&params));
-    tbl.push_flattened(&mut builder, OperationAuxTableTag::None as u32, &[]);
-    tbl.push(
+    let stored_st_hash = stored_st_target.hash(&mut builder);
+    let stored_op_arg_hashes: Vec<_> = stored_op_args_target
+        .iter()
+        .map(|op_arg| op_arg.hash(&mut builder))
+        .collect();
+    let stored_hash = hash_custom_predicate_verify_query(
         &mut builder,
-        OperationAuxTableTag::CustomPredVerify as u32,
-        &stored_hash,
+        &stored_st_hash,
+        &stored_op_type_target,
+        &stored_op_arg_hashes,
     );
+
+    let mut tbl = MuxTableTarget::new(&mut builder, &params);
+    tbl.push(stored_hash);
 
     let verify_st_target = builder.add_virtual_statement(false);
     let verify_op_type_target = builder.add_virtual_operation_type();
     let verify_op_args_target: Vec<_> = (0..BASE_PARAMS.max_operation_args)
         .map(|_| builder.add_virtual_statement(false))
         .collect();
+    let verify_st_hash = verify_st_target.hash(&mut builder);
+    let verify_op_arg_hashes: Vec<_> = verify_op_args_target
+        .iter()
+        .map(|op_arg| op_arg.hash(&mut builder))
+        .collect();
     let aux_index = IndexTarget::new_virtual(2, &mut builder);
     let resolved_aux = tbl.get(&mut builder, &aux_index);
 
     let ok = verify_custom_circuit(
         &mut builder,
-        &verify_st_target,
+        &verify_st_hash,
         &verify_op_type_target,
-        &resolved_aux,
-        &verify_op_args_target,
+        resolved_aux,
+        &verify_op_arg_hashes,
     );
     builder.assert_one(ok.target);
 
@@ -1855,7 +1957,7 @@ fn test_verify_custom_circuit_hash_binding() -> frontend::Result<()> {
     // Positive: identical inputs at the real row.
     helper_verify_custom_mutation(&st, &op_type, &op_args, &st, &op_type, &op_args, 1).unwrap();
 
-    // aux_index points at the None row -> aux_tag_ok must fail.
+    // aux_index points at the sentinel row, whose zero hash can't match the query hash.
     assert!(
         helper_verify_custom_mutation(&st, &op_type, &op_args, &st, &op_type, &op_args, 0).is_err()
     );
@@ -1966,10 +2068,14 @@ fn helper_verify_operation_through_aux_table(
         &aux_table_input,
     )?;
 
+    let st_hash_target = st_target.hash(&mut builder);
     verify_operation_circuit(
         params,
         &mut builder,
-        &st_target,
+        StatementWithHash {
+            statement: &st_target,
+            hash: st_hash_target,
+        },
         &op_target,
         &prev_statement_flatteneds_target,
         &prev_statement_hashes_target,
@@ -2092,8 +2198,8 @@ fn test_verify_operation_custom_aux_index_binding() -> frontend::Result<()> {
     )
     .unwrap();
 
-    // Mutation: aux points at the leading None row (non-custom slot).
-    // The aux entry there has the None tag, so aux_tag_ok fails.
+    // Mutation: aux points at the leading sentinel row (non-custom slot), whose zero hash can't
+    // match the recomputed query hash.
     assert!(helper_verify_operation_through_aux_table(
         &params,
         &custom_predicates,
@@ -2106,8 +2212,8 @@ fn test_verify_operation_custom_aux_index_binding() -> frontend::Result<()> {
     )
     .is_err());
 
-    // Mutation: aux points at the other custom row, whose stored hash binds different op_args.
-    // aux_tag_ok passes, query_ok fails.
+    // Mutation: aux points at the other custom row, whose stored hash binds different op_args, so
+    // the recomputed query hash does not match.
     assert!(helper_verify_operation_through_aux_table(
         &params,
         &custom_predicates,

--- a/src/backends/plonky2/circuits/mainpod/tests.rs
+++ b/src/backends/plonky2/circuits/mainpod/tests.rs
@@ -1799,7 +1799,7 @@ fn test_aux_query_kinds_are_pairwise_distinct() -> Result<()> {
         hash_merkle_not_contains_query(&mut builder, h_a, v_a),
         hash_merkle_transition_query(&mut builder, op, h_a, h_b, v_a, v_b),
         hash_merkle_delete_query(&mut builder, h_a, h_b, v_a),
-        hash_statement_query(&mut builder, &h_a),
+        hash_open_input_statement_query(&mut builder, &h_a),
         hash_pair_query(&mut builder, OperationAuxQueryKind::PublicKeyOf, h_a, h_b),
         hash_pair_query(&mut builder, OperationAuxQueryKind::SignedBy, h_a, h_b),
         hash_custom_predicate_verify_query(&mut builder, &h_a, &op_type, &op_arg_hashes),

--- a/src/backends/plonky2/circuits/mux_table.rs
+++ b/src/backends/plonky2/circuits/mux_table.rs
@@ -1,15 +1,11 @@
 use std::iter;
 
-use itertools::Itertools;
 use plonky2::{
-    field::{extension::Extendable, types::Field},
-    hash::{
-        hash_types::{HashOutTarget, RichField},
-        poseidon::{PoseidonHash, PoseidonPermutation},
-    },
+    field::extension::Extendable,
+    hash::hash_types::{HashOut, HashOutTarget, RichField},
     iop::{
         generator::{GeneratedValues, SimpleGenerator},
-        target::{BoolTarget, Target},
+        target::Target,
         witness::{PartitionWitness, Witness, WitnessWrite},
     },
     plonk::circuit_data::CommonCircuitData,
@@ -19,104 +15,54 @@ use plonky2::{
 use crate::{
     backends::plonky2::{
         basetypes::CircuitBuilder,
-        circuits::{
-            common::{CircuitBuilderPod, Flattenable, IndexTarget},
-            hash::{hash_from_state_circuit, precompute_hash_state},
-        },
+        circuits::common::{CircuitBuilderPod, IndexTarget},
     },
     measure_gates_begin, measure_gates_end,
-    middleware::{Params, F},
+    middleware::Params,
 };
 
-// This structure allows multiplexing multiple tables into one by using tags.  The table entries
-// are computed by hashing the concatenation of the tag with the flattened target, with zero
-// padding to normalize the size of all flattened entries.  We use zero-padding on then reverse the
-// array so that smaller entries can skip the initial hashes by using the precomputed hash state of
-// the prefixed zeroes.
-// The table offers an indexing API that returns a flattened entry that includes the "unhashing",
-// this allows doing a single lookup for different possible tagged entries at the same time.
+// A table of aux query hashes addressed by index. Each operation hashes its query inputs into a
+// single `HashOutTarget` (with a domain-separation kind folded in, so hashes from different op
+// kinds can't be confused) and pushes it here; a verify circuit looks up a row by index and
+// compares it against the hash it recomputes from the operation's inputs.
 pub struct MuxTableTarget {
     params: Params,
-    max_flattened_entry_len: usize,
-    hashed_tagged_entries: Vec<HashOutTarget>,
-    tagged_entries: Vec<Vec<Target>>,
+    entries: Vec<HashOutTarget>,
 }
 
 impl MuxTableTarget {
-    pub fn new(params: &Params, max_flattened_entry_len: usize) -> Self {
+    /// Create a table seeded with the sentinel row at index 0. The sentinel hashes to zero, which
+    /// no real query hash can equal, so an operation with no aux data points at index 0 and never
+    /// matches a verify circuit. Real rows are pushed after it, starting at index 1.
+    pub fn new(builder: &mut CircuitBuilder, params: &Params) -> Self {
         Self {
             params: params.clone(),
-            max_flattened_entry_len,
-            hashed_tagged_entries: Vec::new(),
-            tagged_entries: Vec::new(),
+            entries: vec![builder.constant_hash(HashOut::ZERO)],
         }
     }
 
     #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
-        self.hashed_tagged_entries.len()
+        self.entries.len()
     }
 
-    pub fn push<T: Flattenable>(&mut self, builder: &mut CircuitBuilder, tag: u32, entry: &T) {
-        let flattened_entry = entry.flatten();
-        self.push_flattened(builder, tag, &flattened_entry);
+    pub fn push(&mut self, query_hash: HashOutTarget) {
+        self.entries.push(query_hash);
     }
 
-    pub fn push_flattened(
-        &mut self,
+    pub fn get(&self, builder: &mut CircuitBuilder, index: &IndexTarget) -> HashOutTarget {
+        let measure = measure_gates_begin!(builder, "GetAuxTblEntry");
+        let entry = builder.vec_ref(&self.params, &self.entries, index);
+        measure_gates_end!(builder, measure);
+        entry
+    }
+
+    pub fn lookup(
+        &self,
         builder: &mut CircuitBuilder,
-        tag: u32,
-        flattened_entry: &[Target],
-    ) {
-        let measure = measure_gates_begin!(builder, "HashTaggedTblEntry");
-        assert!(flattened_entry.len() <= self.max_flattened_entry_len);
-        let flattened = [&[builder.constant(F(tag as u64))], flattened_entry].concat();
-        self.tagged_entries.push(flattened.clone());
-
-        let tagged_entry_max_len = 1 + self.max_flattened_entry_len;
-        let front_pad_elts = iter::repeat(F::ZERO)
-            .take(tagged_entry_max_len - flattened.len())
-            .collect_vec();
-
-        let (perm, front_pad_elts_rem) =
-            precompute_hash_state::<F, PoseidonPermutation<F>>(&front_pad_elts);
-
-        let rev_flattened = flattened.iter().rev().copied();
-        // Precompute the Poseidon state for the initial padding chunks
-        let inputs = front_pad_elts_rem
-            .iter()
-            .map(|v| builder.constant(*v))
-            .chain(rev_flattened)
-            .collect_vec();
-        let hash =
-            hash_from_state_circuit::<PoseidonHash, PoseidonPermutation<F>>(builder, perm, &inputs);
-
-        measure_gates_end!(builder, measure);
-        self.hashed_tagged_entries.push(hash);
-    }
-
-    pub fn get(&self, builder: &mut CircuitBuilder, index: &IndexTarget) -> TableEntryTarget {
-        let measure = measure_gates_begin!(builder, "GetTaggedTblEntry");
-        let entry_hash = builder.vec_ref(&self.params, &self.hashed_tagged_entries, index);
-
-        let mut rev_resolved_tagged_flattened =
-            builder.add_virtual_targets(1 + self.max_flattened_entry_len);
-        let query_hash =
-            builder.hash_n_to_hash_no_pad::<PoseidonHash>(rev_resolved_tagged_flattened.clone());
-        builder.connect_flattenable(&entry_hash, &query_hash);
-        rev_resolved_tagged_flattened.reverse();
-        let resolved_tagged_flattened = rev_resolved_tagged_flattened;
-
-        builder.add_simple_generator(TableGetGenerator::new(
-            index.clone(),
-            self.tagged_entries.clone(),
-            resolved_tagged_flattened.clone(),
-        ));
-        measure_gates_end!(builder, measure);
-        TableEntryTarget {
-            params: self.params.clone(),
-            tagged_flattened_entry: resolved_tagged_flattened,
-        }
+        index: &IndexTarget,
+    ) -> Option<HashOutTarget> {
+        (self.len() > 1).then(|| self.get(builder, index))
     }
 }
 
@@ -202,25 +148,5 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for Tab
             entries,
             revealed_entry,
         })
-    }
-}
-
-pub struct TableEntryTarget {
-    params: Params,
-    tagged_flattened_entry: Vec<Target>,
-}
-
-impl TableEntryTarget {
-    pub fn as_type<T: Flattenable>(
-        &self,
-        builder: &mut CircuitBuilder,
-        tag: u32,
-    ) -> (BoolTarget, T) {
-        let tag_target = self.tagged_flattened_entry[0];
-        let flattened_entry = &self.tagged_flattened_entry[1..];
-        let entry = T::from_flattened(&self.params, &flattened_entry[..T::size(&self.params)]);
-        let tag_expect = builder.constant(F(tag as u64));
-        let tag_ok = builder.is_equal(tag_expect, tag_target);
-        (tag_ok, entry)
     }
 }


### PR DESCRIPTION
Closes #527 

Two related changes to the operation aux-table machinery, building on #504:

1. Cheaper query hashes. The custom-predicate and open-input-statement aux queries now hash over *already-materialized component hashes* instead of re-flattening wide statement structures. The custom query went from hashing a ~314-element flattening of `(statement, op_type, op_args)` to hashing `statement_hash (4) + op_type (6) + op_arg_hashes (N*4)`, where those component hashes are reused from work the circuit already does (`vec_ref_projected` now returns the hash it computes; `statement_hashes[i]` is already available).

2. Collapse the aux-table indirection. With every entry now a 4-element query hash, the table no longer needs the generic hash-and-unhash layer it inherited. `MuxTableTarget` stores query hashes directly, `get` returns a bare `HashOutTarget`, and `TableEntryTarget` is removed. This addresses issue #527.

Collapsing the indirection drops the per-row `OperationAuxTableTag` and the per-verify tag check. That is sound because domain separation now lives entirely in the query hash: every `hash_*_query` helper routes through `operation_aux_query_hash`, which prepends a unique `OperationAuxQueryKind`.

Removing this indirection reduces gate count by 2200 or so.